### PR TITLE
Fix build process for unified binary

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -54,7 +54,6 @@ static-files = "0.2.1"
 cargo_toml = "0.11.5"
 ureq = "2.5.0"
 sha1_smol = {version = "1.0.0", features=["std"]}
-hex = "0.4.3"
 zip = { git = "https://github.com/zip-rs/zip" }
 
 [package.metadata.parseable_ui]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -57,8 +57,8 @@ sha1_smol = {version = "1.0.0", features=["std"]}
 zip = { git = "https://github.com/zip-rs/zip" }
 
 [package.metadata.parseable_ui]
-assets-url = "http://localhost:5555/ui/build.zip"
-assets-sha1 = "541f1887087ff80149b1d19bce802b4e359cb2e3"
+assets-url = "https://github.com/parseablehq/frontend/releases/download/v0.0.1/build.zip"
+assets-sha1 = "d9243bde7a98bdd8a19ed47cca2f12f9a5ce40ba"
 # specifies where to find local assests
 # default behaviour is to use assets from url above
 # USE_LOCAL_ASSESTS=true to prefer local build over build linked above

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -51,3 +51,16 @@ walkdir = "2"
 
 [build-dependencies]
 static-files = "0.2.1"
+cargo_toml = "0.11.5"
+ureq = "2.5.0"
+sha1_smol = {version = "1.0.0", features=["std"]}
+hex = "0.4.3"
+zip = { git = "https://github.com/zip-rs/zip" }
+
+[package.metadata.parseable_ui]
+assets-url = "http://localhost:5555/ui/build.zip"
+assets-sha1 = "541f1887087ff80149b1d19bce802b4e359cb2e3"
+# specifies where to find local assests
+# default behaviour is to use assets from url above
+# USE_LOCAL_ASSESTS=true to prefer local build over build linked above
+local-assets = "../ui/build"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -53,7 +53,7 @@ walkdir = "2"
 static-files = "0.2.1"
 cargo_toml = "0.11.5"
 ureq = "2.5.0"
-sha1_smol = {version = "1.0.0", features=["std"]}
+sha1_smol = { version = "1.0.0", features=["std"] }
 zip = { git = "https://github.com/zip-rs/zip" }
 
 [package.metadata.parseable_ui]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -59,7 +59,3 @@ zip = { git = "https://github.com/zip-rs/zip" }
 [package.metadata.parseable_ui]
 assets-url = "https://github.com/parseablehq/frontend/releases/download/v0.0.1/build.zip"
 assets-sha1 = "d9243bde7a98bdd8a19ed47cca2f12f9a5ce40ba"
-# specifies where to find local assests
-# default behaviour is to use assets from url above
-# USE_LOCAL_ASSESTS=true to prefer local build over build linked above
-local-assets = "../ui/build"

--- a/server/build.rs
+++ b/server/build.rs
@@ -16,8 +16,117 @@
  *
  */
 
-use static_files::resource_dir;
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=Cargo.toml");
+    // println!("cargo:rerun-if-changed=Cargo.lock");
+    println!("cargo:rerun-if-env-changed=USE_LOCAL_ASSETS");
+    println!("Build File running");
+    ui::setup().unwrap()
+}
 
-fn main() -> std::io::Result<()> {
-    resource_dir("../ui/build").build()
+mod ui {
+
+    use std::env;
+    use std::io::{self, Cursor, Read, Write};
+    use std::path::{PathBuf, Path};
+    use std::fs::{self, create_dir_all, OpenOptions};
+    use std::str::FromStr;
+
+    use static_files::resource_dir;
+    use ureq::get as get_from_url;
+    use cargo_toml::Manifest;
+    use sha1_smol::Sha1;
+
+    fn build_resource_from(local_path: impl AsRef<Path>) -> io::Result<()> {
+        let local_path = local_path.as_ref();
+        if local_path.exists() {
+            resource_dir(local_path).build()
+        }
+        else {
+            Err(io::Error::new(io::ErrorKind::NotFound, "Local UI directory not found!"))
+        }
+    }
+
+    pub fn setup() -> io::Result<()> {
+
+        let cargo_manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+        let cargo_toml = cargo_manifest_dir.join("Cargo.toml");
+        let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+        let parseable_ui_path = out_dir.join("ui");
+        let checksum_path = out_dir.join("parseable_ui.sha1");
+        
+        let _use_local_assets = env::var("USE_LOCAL_ASSETS").unwrap_or("false".to_string());
+        // Maybe throw a warning here
+        let use_local_assets = bool::from_str(&_use_local_assets).unwrap_or(false);
+
+        let manifest = Manifest::from_path(cargo_toml).unwrap();
+
+        let manifest = manifest
+            .package
+            .expect("package not specified in Cargo.toml")
+            .metadata
+            .expect("no metadata specified in Cargo.toml");
+            
+        let metadata = manifest
+            .get("parseable_ui")
+            .ok_or(io::Error::new(io::ErrorKind::Other, "Parseable UI Metadata not defined correctly"))
+            .unwrap();
+        
+        // If local build of ui is to be used 
+        if use_local_assets {
+            if let Some(local_path) = metadata.get("local-assets") {
+                println!("cargo:rerun-if-changed={}", local_path.as_str().unwrap());
+                build_resource_from(local_path.as_str().unwrap()).unwrap();
+                return Ok(())
+            }
+        }
+
+        // If UI is already downloaded in the target directory then verify and return 
+        if checksum_path.exists() && parseable_ui_path.exists() {
+            let checksum = fs::read_to_string(&checksum_path)?;
+            if checksum == metadata["assets-sha1"].as_str().unwrap() {
+                // Nothing to do.
+                return Ok(());
+            }
+        }
+
+        // If there is no UI in the target directory or checksum check failed
+        // then we downlaod the UI from given url in cargo.toml metadata
+        let url = metadata["assets-url"].as_str().unwrap();
+
+        // See https://docs.rs/ureq/2.5.0/ureq/struct.Response.html#method.into_reader
+        let parseable_ui_bytes = match get_from_url(url).call() {
+            Ok(data) => {
+                let mut buf: Vec<u8> = Vec::new();
+                data.into_reader().read_to_end(&mut buf).unwrap();
+                buf
+            },
+            Err(_) => return Err(io::Error::new(io::ErrorKind::Other, format!("Failed to download from {url}"))),
+        };
+
+        let checksum = Sha1::from(&parseable_ui_bytes).hexdigest();
+
+        assert_eq!(
+            metadata["assets-sha1"].as_str().unwrap(),
+            checksum,
+            "Downloaded parseable UI shasum differs from the one specified in the Cargo.toml"
+        );
+
+        create_dir_all(&parseable_ui_path)?;
+        let mut zip = zip::read::ZipArchive::new(Cursor::new(&parseable_ui_bytes))?;
+        zip.extract(&parseable_ui_path)?;
+        resource_dir(&parseable_ui_path).build()?;
+
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(checksum_path)?;
+
+        file.write_all(checksum.as_bytes())?;
+        file.flush()?;
+
+        Ok(())
+    }
 }

--- a/server/build.rs
+++ b/server/build.rs
@@ -96,19 +96,14 @@ mod ui {
         let url = metadata["assets-url"].as_str().unwrap();
 
         // See https://docs.rs/ureq/2.5.0/ureq/struct.Response.html#method.into_reader
-        let parseable_ui_bytes = match get_from_url(url).call() {
-            Ok(data) => {
+        let parseable_ui_bytes = get_from_url(url)
+            .call()
+            .map(|data| {
                 let mut buf: Vec<u8> = Vec::new();
                 data.into_reader().read_to_end(&mut buf).unwrap();
                 buf
-            }
-            Err(_) => {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("Failed to download from {url}"),
-                ))
-            }
-        };
+            })
+            .expect("Failed to get resource from {url}");
 
         let checksum = Sha1::from(&parseable_ui_bytes).hexdigest();
 

--- a/server/build.rs
+++ b/server/build.rs
@@ -56,9 +56,10 @@ mod ui {
         let parseable_ui_path = out_dir.join("ui");
         let checksum_path = out_dir.join("parseable_ui.sha1");
 
-        let _use_local_assets = env::var("USE_LOCAL_ASSETS").unwrap_or("false".to_string());
+        let _use_local_assets =
+            env::var("USE_LOCAL_ASSETS").unwrap_or_else(|_| String::from("false"));
         // Maybe throw a warning here
-        let use_local_assets = bool::from_str(&_use_local_assets).unwrap_or(false);
+        let use_local_assets = bool::from_str(&_use_local_assets).unwrap_or_default();
 
         let manifest = Manifest::from_path(cargo_toml).unwrap();
 
@@ -70,10 +71,12 @@ mod ui {
 
         let metadata = manifest
             .get("parseable_ui")
-            .ok_or(io::Error::new(
-                io::ErrorKind::Other,
-                "Parseable UI Metadata not defined correctly",
-            ))
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    "Parseable UI Metadata not defined correctly",
+                )
+            })
             .unwrap();
 
         // If local build of ui is to be used

--- a/server/build.rs
+++ b/server/build.rs
@@ -19,7 +19,6 @@
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=Cargo.toml");
-    // println!("cargo:rerun-if-changed=Cargo.lock");
     println!("cargo:rerun-if-env-changed=USE_LOCAL_ASSETS");
     println!("Build File running");
     ui::setup().unwrap()


### PR DESCRIPTION
Fixes #18.

### Description

This PR allows for UI to be decoupled from the parseable repo and yet be able to merge server and frontend into unified binary. In production environment build script will look for `assets-url` and `assets-sha1` in package metadata specified in  Cargo.toml, this asset will then be downloaded and linked as resource when binary is being built.

An environment variable called `LOCAL_ASSETS_PATH` is provided for development purposes. if this is set to a valid path ( i.e build folder of the frontend ) before running cargo then it will include UI artefacts directly from build folder specified.
