### PR TITLE
Use correct path for frontend resource.

### DIFF
--- a/server/build.rs
+++ b/server/build.rs
@@ -116,7 +116,7 @@ mod ui {
         create_dir_all(&parseable_ui_path)?;
         let mut zip = zip::read::ZipArchive::new(Cursor::new(&parseable_ui_bytes))?;
         zip.extract(&parseable_ui_path)?;
-        resource_dir(&parseable_ui_path).build()?;
+        resource_dir(parseable_ui_path.join("build")).build()?;
 
         let mut file = OpenOptions::new()
             .write(true)


### PR DESCRIPTION
### Description
In the release build zip for the frontend, the resource is within a sub directory called `build`. This PR just fixes the path so that resource directory points to right path.

<hr>