### PR TITLE
Add rstest for testing 

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -56,6 +56,10 @@ ureq = "2.5.0"
 sha1_smol = { version = "1.0.0", features=["std"] }
 zip = { git = "https://github.com/zip-rs/zip" }
 
+[dev-dependencies]
+maplit = "1.0.2"
+rstest = "0.15.0"
+
 [package.metadata.parseable_ui]
 assets-url = "https://github.com/parseablehq/frontend/releases/download/v0.0.1/build.zip"
 assets-sha1 = "d9243bde7a98bdd8a19ed47cca2f12f9a5ce40ba"

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -281,6 +281,7 @@ impl TimePeriod {
 #[cfg(test)]
 mod tests {
     use chrono::DateTime;
+    use rstest::*;
 
     use super::TimePeriod;
 
@@ -292,125 +293,70 @@ mod tests {
         )
     }
 
-    #[test]
-    fn prefix_generation_same_minute() {
-        let time_period =
-            time_period_from_str("2022-06-11T16:30:00+00:00", "2022-06-11T16:30:59+00:00");
-
-        assert_eq!(
-            time_period.generate_prefixes("stream_name"),
-            vec!["stream_name/date=2022-06-11/hour=16/minute=30/".to_string()]
-        );
-    }
-
-    #[test]
-    fn prefix_generation_same_hour_different_minute() {
-        let time_period =
-            time_period_from_str("2022-06-11T16:57:00+00:00", "2022-06-11T16:59:00+00:00");
-
-        assert_eq!(
-            time_period.generate_prefixes("stream_name"),
-            vec![
-                "stream_name/date=2022-06-11/hour=16/minute=57/".to_string(),
-                "stream_name/date=2022-06-11/hour=16/minute=58/".to_string(),
-            ]
-        );
-    }
-
-    #[test]
-    fn prefix_generation_same_hour_with_00_to_59_minute_block() {
-        let time_period =
-            time_period_from_str("2022-06-11T16:00:00+00:00", "2022-06-11T16:59:59+00:00");
-
-        assert_eq!(
-            time_period.generate_prefixes("stream_name"),
-            vec!["stream_name/date=2022-06-11/hour=16/".to_string(),]
-        );
-    }
-
-    #[test]
-    fn prefix_generation_same_date_different_hours_coherent_minute() {
-        let time_period =
-            time_period_from_str("2022-06-11T15:00:00+00:00", "2022-06-11T17:00:00+00:00");
-
-        assert_eq!(
-            time_period.generate_prefixes("stream_name"),
-            vec![
-                "stream_name/date=2022-06-11/hour=15/".to_string(),
-                "stream_name/date=2022-06-11/hour=16/".to_string(),
-            ]
-        );
-    }
-
-    #[test]
-    fn prefix_generation_same_date_different_hours_incoherent_minutes() {
-        let time_period =
-            time_period_from_str("2022-06-11T15:59:00+00:00", "2022-06-11T16:01:00+00:00");
-
-        assert_eq!(
-            time_period.generate_prefixes("stream_name"),
-            vec![
-                "stream_name/date=2022-06-11/hour=15/minute=59/".to_string(),
-                "stream_name/date=2022-06-11/hour=16/minute=00/".to_string(),
-            ]
-        );
-    }
-
-    #[test]
-    fn prefix_generation_same_date_different_hours_whole_hours_between_incoherent_minutes() {
-        let time_period =
-            time_period_from_str("2022-06-11T15:59:00+00:00", "2022-06-11T17:01:00+00:00");
-
-        assert_eq!(
-            time_period.generate_prefixes("stream_name"),
-            vec![
-                "stream_name/date=2022-06-11/hour=15/minute=59/".to_string(),
-                "stream_name/date=2022-06-11/hour=16/".to_string(),
-                "stream_name/date=2022-06-11/hour=17/minute=00/".to_string(),
-            ]
-        );
-    }
-
-    #[test]
-    fn prefix_generation_different_date_coherent_hours_and_minutes() {
-        let time_period =
-            time_period_from_str("2022-06-11T00:00:00+00:00", "2022-06-13T00:00:00+00:00");
-
-        assert_eq!(
-            time_period.generate_prefixes("stream_name"),
-            vec![
-                "stream_name/date=2022-06-11/".to_string(),
-                "stream_name/date=2022-06-12/".to_string(),
-            ]
-        );
-    }
-
-    #[test]
-    fn prefix_generation_different_date_incoherent_hours_coherent_minutes() {
-        let time_period =
-            time_period_from_str("2022-06-11T23:00:01+00:00", "2022-06-12T01:59:59+00:00");
-
-        assert_eq!(
-            time_period.generate_prefixes("stream_name"),
-            vec![
-                "stream_name/date=2022-06-11/hour=23/".to_string(),
-                "stream_name/date=2022-06-12/hour=00/".to_string(),
-                "stream_name/date=2022-06-12/hour=01/".to_string(),
-            ]
-        );
-    }
-
-    #[test]
-    fn prefix_generation_different_date_incoherent_hours_incoherent_minutes() {
-        let time_period =
-            time_period_from_str("2022-06-11T23:59:59+00:00", "2022-06-12T00:01:00+00:00");
-
-        assert_eq!(
-            time_period.generate_prefixes("stream_name"),
-            vec![
-                "stream_name/date=2022-06-11/hour=23/minute=59/".to_string(),
-                "stream_name/date=2022-06-12/hour=00/minute=00/".to_string(),
-            ]
-        );
+    #[rstest]
+    #[case::same_minute(
+        "2022-06-11T16:30:00+00:00", "2022-06-11T16:30:59+00:00",
+        &["stream_name/date=2022-06-11/hour=16/minute=30/"]
+    )]
+    #[case::same_hour_different_minute(
+        "2022-06-11T16:57:00+00:00", "2022-06-11T16:59:00+00:00",
+        &[
+            "stream_name/date=2022-06-11/hour=16/minute=57/",
+            "stream_name/date=2022-06-11/hour=16/minute=58/"
+        ]
+    )]
+    #[case::same_hour_with_00_to_59_minute_block(
+        "2022-06-11T16:00:00+00:00", "2022-06-11T16:59:59+00:00",   
+        &["stream_name/date=2022-06-11/hour=16/"]
+    )]
+    #[case::same_date_different_hours_coherent_minute(
+        "2022-06-11T15:00:00+00:00", "2022-06-11T17:00:00+00:00",
+       &[
+            "stream_name/date=2022-06-11/hour=15/",
+            "stream_name/date=2022-06-11/hour=16/"
+        ]
+    )]
+    #[case::same_date_different_hours_incoherent_minutes(
+        "2022-06-11T15:59:00+00:00", "2022-06-11T16:01:00+00:00", 
+        &[
+            "stream_name/date=2022-06-11/hour=15/minute=59/",
+            "stream_name/date=2022-06-11/hour=16/minute=00/"
+        ]
+    )]
+    #[case::same_date_different_hours_whole_hours_between_incoherent_minutes(
+        "2022-06-11T15:59:00+00:00", "2022-06-11T17:01:00+00:00", 
+        &[
+            "stream_name/date=2022-06-11/hour=15/minute=59/",
+            "stream_name/date=2022-06-11/hour=16/",
+            "stream_name/date=2022-06-11/hour=17/minute=00/"
+        ]
+    )]
+    #[case::different_date_coherent_hours_and_minutes(
+        "2022-06-11T00:00:00+00:00", "2022-06-13T00:00:00+00:00", 
+        &[
+            "stream_name/date=2022-06-11/",
+            "stream_name/date=2022-06-12/"
+        ]
+    )]
+    #[case::different_date_incoherent_hours_coherent_minutes(
+        "2022-06-11T23:00:01+00:00", "2022-06-12T01:59:59+00:00", 
+        &[
+            "stream_name/date=2022-06-11/hour=23/",
+            "stream_name/date=2022-06-12/hour=00/",
+            "stream_name/date=2022-06-12/hour=01/"
+        ]
+    )]
+    #[case::different_date_incoherent_hours_incoherent_minutes(
+        "2022-06-11T23:59:59+00:00", "2022-06-12T00:01:00+00:00", 
+        &[
+            "stream_name/date=2022-06-11/hour=23/minute=59/",
+            "stream_name/date=2022-06-12/hour=00/minute=00/"
+        ]
+    )]
+    fn prefix_generation(#[case] start: &str, #[case] end: &str, #[case] right: &[&str]) {
+        let time_period = time_period_from_str(start, end);
+        let prefixes = time_period.generate_prefixes("stream_name");
+        let left = prefixes.iter().map(String::as_str).collect::<Vec<&str>>();
+        assert_eq!(left.as_slice(), right);
     }
 }


### PR DESCRIPTION
### Description

This PR introduces [rstest](https://lib.rs/crates/rstest) as main unit testing framework. It's added as a development dependency to the project. [maplit](https://docs.rs/maplit/latest/maplit/) is added for its hashmap macro.
 
#### Core advantages of using rstest
- can save on some boilerplate code
- easier to add new test cases
- #[once] Fixture to make an object initialise once and be shared between all tests

#### Disadvatages of using rstest
- Complex struct initialisation might not be possible in a test case. This can still be a no-issue because we can always write normal rust tests for anything that can't be done using rstest.

#### What is changed 
- tests added to metadata.rs
- tests converted in query.rs
- tests converted in utils.rs
 
<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviours.
