### PR TITLE
Add serial-test 

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -59,6 +59,7 @@ zip = { git = "https://github.com/zip-rs/zip" }
 [dev-dependencies]
 maplit = "1.0.2"
 rstest = "0.15.0"
+serial_test = { version = "0.9.0", default-features = false }
 
 [package.metadata.parseable_ui]
 assets-url = "https://github.com/parseablehq/frontend/releases/download/v0.0.1/build.zip"

--- a/server/src/metadata.rs
+++ b/server/src/metadata.rs
@@ -181,6 +181,7 @@ mod tests {
     use super::*;
     use maplit::hashmap;
     use rstest::*;
+    use serial_test::serial;
 
     #[rstest]
     #[case::zero(0, 0, 0)]
@@ -226,6 +227,7 @@ mod tests {
     #[rstest]
     #[case::stream_schema_alert("teststream", "schema", "alert_config")]
     #[case::stream_only("teststream", "", "")]
+    #[serial]
     fn test_add_stream(
         #[case] stream_name: String,
         #[case] schema: String,
@@ -249,6 +251,7 @@ mod tests {
 
     #[rstest]
     #[case::stream_only("teststream")]
+    #[serial]
     fn test_delete_stream(#[case] stream_name: String) {
         clear_map();
         STREAM_INFO


### PR DESCRIPTION
### Description

Cargo runs tests in parallel by default, this causes inconsistent state of STREAM_INFO when two tests mutate it concurrently. Multiple tests with the [serial](https://docs.rs/serial_test/latest/serial_test/attr.serial.html) attribute are guaranteed to be executed such that they won't overlap in execution.
