### PR TITLE
Fix query validation to ensure we use actual query value

### DIFF
--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -62,8 +62,8 @@ pub enum Error {
     MultipleStreams(String),
     #[error("start time can not be later than end time")]
     StartTimeAfterEndTime(),
-    #[error("query is incomplete")]
-    IncompleteQuery(),
+    #[error("query '{0}' is incomplete")]
+    IncompleteQuery(String),
     #[error("query cannot be empty")]
     EmptyQuery,
     #[error("start time cannot be empty in query")]

--- a/server/src/query.rs
+++ b/server/src/query.rs
@@ -52,12 +52,11 @@ impl Query {
     // this query is supposed to be executed
     pub fn parse(query_json: Value) -> Result<Query, Error> {
         // retrieve query, start and end time information from payload.
-        // Convert query to lowercase.
-        let query = get_value(&query_json, "query")?.to_lowercase();
+        let query = get_value(&query_json, "query")?;
         let start_time = get_value(&query_json, "startTime")?;
         let end_time = get_value(&query_json, "endTime")?;
 
-        validator::query(&query, start_time, end_time)
+        validator::query(query, start_time, end_time)
     }
 
     /// Return prefixes, each per day/hour/minutes as necessary

--- a/server/src/validator.rs
+++ b/server/src/validator.rs
@@ -132,12 +132,17 @@ pub fn query(query: &str, start_time: &str, end_time: &str) -> Result<Query, Err
         return Err(Error::EmptyQuery);
     }
 
-    let tokens = query.split(' ').collect::<Vec<&str>>();
+    // convert query to lower case for validation only
+    // if validation succeeds, we use the original query
+    // since table names/fields are case sensitive
+    let query_lower = query.to_lowercase();
+
+    let tokens = query_lower.split(' ').collect::<Vec<&str>>();
     if tokens.contains(&"join") {
         return Err(Error::Join(query.to_string()));
     }
     if tokens.len() < 4 {
-        return Err(Error::IncompleteQuery());
+        return Err(Error::IncompleteQuery(query.to_string()));
     }
     if start_time.is_empty() {
         return Err(Error::EmptyStartTime);
@@ -151,7 +156,7 @@ pub fn query(query: &str, start_time: &str, end_time: &str) -> Result<Query, Err
     // we currently don't support queries like "select name, address from stream1 and stream2"
     // so if there is an `and` after the first log stream name, we return an error.
     if tokens.len() > stream_name_index + 1 && tokens[stream_name_index + 1] == "and" {
-        return Err(Error::MultipleStreams(query.to_owned()));
+        return Err(Error::MultipleStreams(query.to_string()));
     }
 
     let start: DateTime<Utc> = DateTime::parse_from_rfc3339(start_time)?.into();


### PR DESCRIPTION
This PR fixes the situation where original query sent
by the user was converted to lower case. We now lower case
the query for validation only. Then pass on the
actual query to datafusion.

Fixes #47
