### PR TITLE
Ignore empty alerts

### DIFF
--- a/server/src/metadata.rs
+++ b/server/src/metadata.rs
@@ -148,16 +148,18 @@ impl STREAM_INFO {
             let alerts = storage
                 .get_alerts(&stream.name)
                 .await
-                .map_err(|_| Error::AlertNotInStore(stream.name.to_owned()))?;
+                .map_err(|_| Error::AlertNotInStore(stream.name.to_owned()));
+
             let schema = storage
                 .get_schema(&stream.name)
                 .await
                 .map_err(|e| e.into())
                 .and_then(parse_string)
                 .map_err(|_| Error::SchemaNotInStore(stream.name.to_owned()))?;
+
             let metadata = LogStreamMetadata {
                 schema,
-                alerts,
+                alerts: alerts.unwrap_or_default(),
                 ..Default::default()
             };
 


### PR DESCRIPTION
### Description
Ignore unset alerts on stream when loading from s3. This PR fixes this by using unwrap_or_default on result instead of early return   

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
