### PR TITLE
Exact match when deleting stream

### DIFF
--- a/server/src/s3.rs
+++ b/server/src/s3.rs
@@ -175,7 +175,7 @@ impl S3 {
             .client
             .list_objects_v2()
             .bucket(&S3_CONFIG.s3_bucket_name)
-            .prefix(stream_name)
+            .prefix(format!("{}/", stream_name))
             .into_paginator()
             .send();
 


### PR DESCRIPTION
### Description
When deleting a logstream from s3 avoid deleting other prefixes which starts with same stream_name for which delete request was made.

For example, when deleting stream named `test`, such streams are also deleted because they share same prefix `test`
`test`stream
`test`longrun
`test`application 

Fix: 
Use delimiter at the end of stream name so that only those prefix are matched where stream name is exactly first component of path on s3. i.e `test/` instead of `test`. This will match only logstreams named test.

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
