### PR TITLE
Move leftover data.parquet to tmp with valid prefix on server startup

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -28,6 +28,7 @@ object_store = { version = "0.4", features=["aws"] }
 derive_more = "0.99.17"
 env_logger = "0.9.0"
 futures = "0.3"
+filetime = "0.2.17"
 http = "0.2.4"
 lazy_static = "1.4.0"
 log = "0.4.14"

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -164,18 +164,18 @@ impl StorageDir {
         }
     }
 
-    fn create_temp_dir(&self) -> io::Result<()> {
+    pub fn create_temp_dir(&self) -> io::Result<()> {
         fs::create_dir_all(&self.temp_dir)
     }
 
-    fn move_parquet_to_temp(&self, filename: String) -> io::Result<()> {
+    pub fn move_parquet_to_temp(&self, filename: String) -> io::Result<()> {
         fs::rename(
             self.data_path.join("data.parquet"),
             self.temp_dir.join(filename),
         )
     }
 
-    fn parquet_path_exists(&self) -> bool {
+    pub fn parquet_path_exists(&self) -> bool {
         self.data_path.join("data.parquet").exists()
     }
 }


### PR DESCRIPTION
Fixes #53 .

### Description

When server is restarted it should try to sync data on the local directory that is not yet synced to s3. Otherwise the data will get lost when new event arrives.

Make use of last modified system time to generate a prefix and move `data.parquet` to tmp directory, It will be synced to s3 on next `s3_sync` run. 
 
<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
