### PR TITLE
Use / for listing

### DIFF
--- a/server/src/s3.rs
+++ b/server/src/s3.rs
@@ -297,7 +297,7 @@ impl S3 {
             .client
             .list_objects_v2()
             .bucket(&S3_CONFIG.s3_bucket_name)
-            .delimiter("/.schema")
+            .delimiter('/')
             .send()
             .await?;
 
@@ -307,7 +307,7 @@ impl S3 {
         let logstreams: Vec<_> = common_prefixes
             .iter()
             .filter_map(CommonPrefix::prefix)
-            .filter_map(|name| name.strip_suffix("/.schema"))
+            .filter_map(|name| name.strip_suffix('/'))
             .map(String::from)
             .map(|name| LogStream { name })
             .collect();


### PR DESCRIPTION
### Description

There are different behaviour from different s3 instances on use of delimiter `/.schema`. Just using `/` will list all root level prefixes, This can be used for listing streams for now .

Note: any extra directory at root level will also get listed. So it it advised to not store anything manually on the bucket specified for parseable

In future we need to make listing more consistent across every platform.  
