### PR TITLE
ObjectStorage: add AuthenticationError type

### DIFF
--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -86,6 +86,10 @@ impl Config {
                 url = self.storage.endpoint_url(),
                 cause = inner
             ),
+            Err(ObjectStorageError::AuthenticationError(inner)) => panic!(
+                "Failed to authenticate. Please ensure credentials are valid\n Caused by: {cause}",
+                cause = inner
+            ),
             Err(error) => { panic!("{error}") } 
         }
     }

--- a/server/src/s3.rs
+++ b/server/src/s3.rs
@@ -494,6 +494,14 @@ impl From<SdkError<HeadBucketError>> for ObjectStorageError {
                     },
                 ..
             } => ObjectStorageError::NoSuchBucket(S3_CONFIG.bucket_name().to_string()),
+            SdkError::ServiceError {
+                err:
+                    HeadBucketError {
+                        kind: HeadBucketErrorKind::Unhandled(err),
+                        ..
+                    },
+                ..
+            } => ObjectStorageError::AuthenticationError(err),
             SdkError::DispatchFailure(err) => ObjectStorageError::ConnectionError(Box::new(err)),
             SdkError::TimeoutError(err) => ObjectStorageError::ConnectionError(err),
             err => ObjectStorageError::UnhandledError(Box::new(err)),

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -216,6 +216,8 @@ pub enum ObjectStorageError {
     DataFusionError(#[from] datafusion::error::DataFusionError),
     #[error("Unhandled Error: {0}")]
     UnhandledError(Box<dyn std::error::Error + Send + 'static>),
+    #[error("Authentication Error: {0}")]
+    AuthenticationError(Box<dyn std::error::Error + Send + 'static>),
 }
 
 impl From<ObjectStorageError> for crate::error::Error {


### PR DESCRIPTION
Fixes #52 .

### Description

<!-- Describe the goal of this PR -->
Add `ObjectStorage::AuthenticationError` type to better signal error cause.
<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
