### PR TITLE
Use Arrow Schema instead of custom schema type.

### DIFF
--- a/server/src/query.rs
+++ b/server/src/query.rs
@@ -17,7 +17,6 @@
  */
 
 use chrono::{DateTime, Utc};
-use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::listing::ListingOptions;
@@ -94,13 +93,12 @@ impl Query {
             target_partitions: 1,
         };
 
-        let schema = &STREAM_INFO.schema(&self.stream_name)?;
+        let schema = STREAM_INFO.schema(&self.stream_name)?;
 
-        if schema.is_empty() {
-            return Ok(());
-        }
-
-        let schema: Arc<Schema> = Arc::new(serde_json::from_str(schema)?);
+        let schema = match schema {
+            Some(schema) => Arc::new(schema),
+            None => return Ok(()),
+        };
 
         ctx.register_listing_table(
             &self.stream_name,

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -23,8 +23,8 @@ use crate::query::Query;
 use crate::utils;
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use chrono::{Duration, Timelike, Utc};
+use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::record_batch::RecordBatch;
 use serde::Serialize;
 
@@ -48,14 +48,17 @@ pub const OBJECT_STORE_DATA_GRANULARITY: u32 = (LOCAL_SYNC_INTERVAL as u32) / 60
 #[async_trait]
 pub trait ObjectStorage: Sync + 'static {
     async fn check(&self) -> Result<(), ObjectStorageError>;
-    async fn put_schema(&self, stream_name: String, body: String)
-        -> Result<(), ObjectStorageError>;
+    async fn put_schema(
+        &self,
+        stream_name: String,
+        schema: &Schema,
+    ) -> Result<(), ObjectStorageError>;
     async fn create_stream(&self, stream_name: &str) -> Result<(), ObjectStorageError>;
     async fn delete_stream(&self, stream_name: &str) -> Result<(), ObjectStorageError>;
 
     async fn put_alerts(&self, stream_name: &str, alerts: Alerts)
         -> Result<(), ObjectStorageError>;
-    async fn get_schema(&self, stream_name: &str) -> Result<Bytes, ObjectStorageError>;
+    async fn get_schema(&self, stream_name: &str) -> Result<Option<Schema>, ObjectStorageError>;
     async fn get_alerts(&self, stream_name: &str) -> Result<Alerts, ObjectStorageError>;
     async fn get_stats(&self, stream_name: &str) -> Result<Stats, ObjectStorageError>;
     async fn list_streams(&self) -> Result<Vec<LogStream>, ObjectStorageError>;


### PR DESCRIPTION
### Description
Replace custom schema type with arrow schema wrapped in Option. If metadata was able to load a schema then it will be of Some variant, in case there is no schema ( new stream ) then the None variant will be used. This reduced number of times serialization to schema happens and this schema will be directly passed on to future event processing and queries.

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
