### PR TITLE
Config datafusion query with schema

### DIFF
--- a/server/src/query.rs
+++ b/server/src/query.rs
@@ -17,6 +17,7 @@
  */
 
 use chrono::{DateTime, Utc};
+use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::listing::ListingOptions;
@@ -44,6 +45,7 @@ fn get_value<'a>(value: &'a Value, key: &'static str) -> Result<&'a str, Error> 
 pub struct Query {
     pub query: String,
     pub stream_name: String,
+    pub schema: Arc<Schema>,
     pub start: DateTime<Utc>,
     pub end: DateTime<Utc>,
 }

--- a/server/src/validator.rs
+++ b/server/src/validator.rs
@@ -16,10 +16,13 @@
  *
  */
 
+use std::sync::Arc;
+
 use chrono::{DateTime, Utc};
 use serde_json::json;
 
 use crate::alerts::Alerts;
+use crate::metadata::STREAM_INFO;
 use crate::query::Query;
 use crate::Error;
 
@@ -133,10 +136,18 @@ pub fn query(query: &str, start_time: &str, end_time: &str) -> Result<Query, Err
         return Err(Error::StartTimeAfterEndTime());
     }
 
+    let stream_name = tokens[stream_name_index].to_string();
+
+    let schema = match STREAM_INFO.schema(&stream_name)? {
+        Some(schema) => Arc::new(schema),
+        None => return Err(Error::MissingRecord),
+    };
+
     Ok(Query {
         stream_name: tokens[stream_name_index].to_string(),
         start,
         end,
         query: query.to_string(),
+        schema,
     })
 }


### PR DESCRIPTION
### Description
Instead of pre listing all the valid prefixes before query execution and letting datafusion infer the schema, it is better to pass the schema we already have for a given stream and let datafusion do all the heavy lifting. In case stream info does not have a schema for a given stream then we return early with Error suggesting they need to post events to this logstream first.

### Goal 
Avoid unnecessary network calls as Datafusion underneath does that and ignores if file is not present.
Add more consistency to codebase which also helps in #36 

## Solution
Check for schema in metadata and add it to query itself which then can be used for query

<hr>

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
