### PR TITLE
Delay s3sync polling using tokio sleep

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -185,6 +185,7 @@ fn s3_sync() -> (JoinHandle<()>, oneshot::Receiver<()>, oneshot::Sender<()>) {
                     });
 
                 loop {
+                    tokio::time::sleep(Duration::from_secs(1)).await;
                     scheduler.run_pending().await;
                     match AssertUnwindSafe(|| inbox_rx.try_recv())() {
                         Ok(_) => break,


### PR DESCRIPTION
Fixes #90.

Use tokio::time::sleep to avoid continuous polling.
