### PR TITLE
Set max thread priority for local-sync

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -40,6 +40,7 @@ serde_json = "^1.0.8"
 structopt = { version = "0.3.25" }
 sysinfo = "0.20.5"
 thiserror = "1"
+thread-priority = "0.9.2"
 tokio-stream = "0.1.8"
 tokio = { version = "1.13.1", default-features = false, features=["sync", "macros"] }
 clokwerk = "0.4.0-rc1"


### PR DESCRIPTION
Fixes #103.

### Description
localsync thread is important and should run at exact intervals. To ensure this its priority is set to max. Priority setting if fails is ignored for now which means if thread_priority can't set it to max then all can be done is log it. Scheduling behaviour is dependant on the underlying OS. It is user's responsiblity to make sure that program can set thread/process priority. For example on linux you'd have to allow `cpu cpuset` cgroup for current user.

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
