### PR TITLE
Improve LocalStreamWriter along with error types

### DIFF
--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -199,7 +199,7 @@ impl StorageDir {
         let record_tmp_file_path = self.temp_dir.join(filename.clone() + ".tmp");
         fs::rename(self.data_path.join("data.records"), &record_tmp_file_path)
             .map_err(|_| MoveDataError::Rename)?;
-        event::STREAM_WRITERS::unset_entry(&self.stream_name);
+        event::STREAM_WRITERS::unset_entry(&self.stream_name).unwrap();
         let file = File::open(&record_tmp_file_path).map_err(|_| MoveDataError::Open)?;
         let reader = StreamReader::try_new(file, None)?;
         let schema = reader.schema();


### PR DESCRIPTION
### Description

This PR disallows taking stream_writer as mutable if any inner mutex is held . File creation logic is improved and is now atomic, no two threads can call set_entry at the same time. File creation was not guarded well so there could have arrived a situation where two threads tried to create the file then in that case one of thread would have failed and errored.

Changes
- set_entry takes writer which ensures no other thread can call set_entry at the same time. File creation is atomic.
- Addded error type StreamWriterError

<hr>

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
