### PR TITLE
Use rustls instead of openssl

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["olap", "analytics-store"]
 
 [dependencies]
 actix-web-httpauth = "0.6"
-actix-web = { version = "4.1", features = ["openssl"] }
+actix-web = { version = "4.1", features = ["rustls"] }
 actix-cors = "0.6"
 actix-files = "0.6.1"
 anyhow = { version = "1.0.43", features = ["backtrace"] }
@@ -30,10 +30,11 @@ http = "0.2.4"
 lazy_static = "1.4.0"
 log = "0.4.14"
 num_cpus = "1.0.0"
-openssl = { version = "0.10" }
 os_info = "3.0.7"
 hostname = "0.3"
 rand = "0.8.4"
+rustls = "0.20.6"
+rustls-pemfile = "1.0.1"
 rust-flatten-json = "0.2.0"
 semver = "1.0.14"
 serde = "^1.0.8"


### PR DESCRIPTION
Fixes #121

### Description 
Use rustls instead of openssl. This involves switching out openssl feature for rustls in actix web. This commit introduces no addtional breaking changes in how keys are registered with actix_web, so they should work as before.

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
