### PR TITLE
Bump aws_sdk_s3 version and provide sleep and retry impl for S3 client

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -15,7 +15,8 @@ actix-cors = "0.6"
 actix-files = "0.6.1"
 anyhow = { version = "1.0.43", features = ["backtrace"] }
 async-trait = "0.1"
-aws-sdk-s3 = "0.17"
+aws-sdk-s3 = "0.19"
+aws-smithy-async = { version = "0.49.0", features = ["rt-tokio"] }
 bytes = "1"
 chrono = "0.4.19"
 chrono-humanize = "0.2.2"

--- a/server/src/s3.rs
+++ b/server/src/s3.rs
@@ -3,7 +3,9 @@ use aws_sdk_s3::error::{HeadBucketError, HeadBucketErrorKind};
 use aws_sdk_s3::model::{CommonPrefix, Delete, ObjectIdentifier};
 use aws_sdk_s3::types::{ByteStream, SdkError};
 use aws_sdk_s3::Error as AwsSdkError;
+use aws_sdk_s3::RetryConfig;
 use aws_sdk_s3::{Client, Credentials, Endpoint, Region};
+use aws_smithy_async::rt::sleep::default_async_sleep;
 use bytes::Bytes;
 use crossterm::style::Stylize;
 use datafusion::arrow::datatypes::Schema;
@@ -171,6 +173,8 @@ impl S3 {
             .region(options.region)
             .endpoint_resolver(options.endpoint)
             .credentials_provider(options.creds)
+            .retry_config(RetryConfig::standard().with_max_attempts(1))
+            .sleep_impl(default_async_sleep().expect("sleep impl is provided for tokio rt"))
             .build();
 
         let client = Client::from_conf(config);

--- a/server/src/s3.rs
+++ b/server/src/s3.rs
@@ -173,7 +173,7 @@ impl S3 {
             .region(options.region)
             .endpoint_resolver(options.endpoint)
             .credentials_provider(options.creds)
-            .retry_config(RetryConfig::standard().with_max_attempts(1))
+            .retry_config(RetryConfig::standard().with_max_attempts(5))
             .sleep_impl(default_async_sleep().expect("sleep impl is provided for tokio rt"))
             .build();
 


### PR DESCRIPTION
Fixes #63 

### Description
Client is given a generic retry and sleep implementation which gets rid of warning generated by aws_sdk_s3 crate
