### PR TITLE
Switch from structopt to clap

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "parseable"
 version = "0.0.3"
 authors = [
-    "NitishTiwari <nitish@parseable.io>", 
+    "NitishTiwari <nitish@parseable.io>",
     "AdheipSingh <adheip@parseable.io>",
 ]
 edition = "2021"
@@ -20,6 +20,7 @@ aws-smithy-async = { version = "0.49.0", features = ["rt-tokio"] }
 bytes = "1"
 chrono = "0.4.19"
 chrono-humanize = "0.2.2"
+clap = { version = "4.0.8", features = ["derive", "env"] }
 crossterm = "0.23.2"
 datafusion = "11.0"
 object_store = { version = "0.4", features=["aws"] }
@@ -41,7 +42,6 @@ semver = "1.0.14"
 serde = "^1.0.8"
 serde_derive = "^1.0.8"
 serde_json = "^1.0.8"
-structopt = { version = "0.3.25" }
 sysinfo = "0.20.5"
 thiserror = "1"
 thread-priority = "0.9.2"

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -16,10 +16,10 @@
  *
  */
 
+use clap::Parser;
 use crossterm::style::Stylize;
 use std::path::PathBuf;
 use std::sync::Arc;
-use structopt::StructOpt;
 
 use crate::banner;
 use crate::s3::S3Config;
@@ -28,7 +28,7 @@ use crate::storage::{ObjectStorage, ObjectStorageError, LOCAL_SYNC_INTERVAL};
 lazy_static::lazy_static! {
     #[derive(Debug)]
     pub static ref CONFIG: Arc<Config> = {
-        let storage = Box::new(S3Config::from_args());
+        let storage = Box::new(S3Config::parse());
         Arc::new(Config::new(storage))
     };
 }
@@ -53,7 +53,7 @@ pub struct Config {
 impl Config {
     fn new(storage: Box<dyn StorageOpt>) -> Config {
         Config {
-            parseable: Opt::from_args(),
+            parseable: Opt::parse(),
             storage,
         }
     }
@@ -91,7 +91,7 @@ impl Config {
                 "Failed to authenticate. Please ensure credentials are valid\n Caused by: {cause}",
                 cause = inner
             ),
-            Err(error) => { panic!("{error}") } 
+            Err(error) => { panic!("{error}") }
         }
     }
 
@@ -164,41 +164,41 @@ impl Config {
     }
 }
 
-#[derive(Debug, Clone, StructOpt)]
-#[structopt(
+#[derive(Debug, Clone, Parser)]
+#[command(
     name = "Parseable config",
     about = "configuration for Parseable server"
 )]
 pub struct Opt {
     /// The location of TLS Cert file
-    #[structopt(long, env = "P_TLS_CERT_PATH")]
+    #[arg(long, env = "P_TLS_CERT_PATH")]
     pub tls_cert_path: Option<PathBuf>,
 
     /// The location of TLS Private Key file
-    #[structopt(long, env = "P_TLS_KEY_PATH")]
+    #[arg(long, env = "P_TLS_KEY_PATH")]
     pub tls_key_path: Option<PathBuf>,
 
     /// The address on which the http server will listen.
-    #[structopt(long, env = "P_ADDR", default_value = "0.0.0.0:8000")]
+    #[arg(long, env = "P_ADDR", default_value = "0.0.0.0:8000")]
     pub address: String,
 
     /// The local storage path is used as temporary landing point
     /// for incoming events and local cache while querying data pulled
     /// from object storage backend
-    #[structopt(long, env = "P_LOCAL_STORAGE", default_value = "./data")]
+    #[arg(long, env = "P_LOCAL_STORAGE", default_value = "./data")]
     pub local_disk_path: PathBuf,
 
     /// Optional interval after which server would upload uncommited data to
     /// remote object storage platform. Defaults to 1min.
-    #[structopt(long, env = "P_STORAGE_UPLOAD_INTERVAL", default_value = "60")]
+    #[arg(long, env = "P_STORAGE_UPLOAD_INTERVAL", default_value = "60")]
     pub upload_interval: u64,
 
     /// Optional username to enable basic auth on the server
-    #[structopt(long, env = USERNAME_ENV, default_value = DEFAULT_USERNAME)]
+    #[arg(long, env = USERNAME_ENV, default_value = DEFAULT_USERNAME)]
     pub username: String,
 
     /// Optional password to enable basic auth on the server
-    #[structopt(long, env = PASSOWRD_ENV, default_value = DEFAULT_PASSWORD)]
+    #[arg(long, env = PASSOWRD_ENV, default_value = DEFAULT_PASSWORD)]
     pub password: String,
 }
 

--- a/server/src/s3.rs
+++ b/server/src/s3.rs
@@ -7,6 +7,7 @@ use aws_sdk_s3::RetryConfig;
 use aws_sdk_s3::{Client, Credentials, Endpoint, Region};
 use aws_smithy_async::rt::sleep::default_async_sleep;
 use bytes::Bytes;
+use clap::Parser;
 use crossterm::style::Stylize;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::record_batch::RecordBatch;
@@ -24,7 +25,6 @@ use object_store::limit::LimitStore;
 use std::fs;
 use std::iter::Iterator;
 use std::sync::Arc;
-use structopt::StructOpt;
 
 use crate::alerts::Alerts;
 use crate::metadata::Stats;
@@ -48,7 +48,7 @@ const MAX_OBJECT_STORE_REQUESTS: usize = 1000;
 
 lazy_static::lazy_static! {
     #[derive(Debug)]
-    pub static ref S3_CONFIG: Arc<S3Config> = Arc::new(S3Config::from_args());
+    pub static ref S3_CONFIG: Arc<S3Config> = Arc::new(S3Config::parse());
 
     // runtime to be used in query session
     pub static ref STORAGE_RUNTIME: Arc<RuntimeEnv> = {
@@ -79,27 +79,27 @@ lazy_static::lazy_static! {
     };
 }
 
-#[derive(Debug, Clone, StructOpt)]
-#[structopt(name = "S3 config", about = "configuration for AWS S3 SDK")]
+#[derive(Debug, Clone, Parser)]
+#[command(name = "S3 config", about = "configuration for AWS S3 SDK")]
 pub struct S3Config {
     /// The endpoint to AWS S3 or compatible object storage platform
-    #[structopt(long, env = S3_URL_ENV_VAR, default_value = DEFAULT_S3_URL )]
+    #[arg(long, env = S3_URL_ENV_VAR, default_value = DEFAULT_S3_URL )]
     pub s3_endpoint_url: String,
 
     /// The access key for AWS S3 or compatible object storage platform
-    #[structopt(long, env = "P_S3_ACCESS_KEY", default_value = DEFAULT_S3_ACCESS_KEY)]
+    #[arg(long, env = "P_S3_ACCESS_KEY", default_value = DEFAULT_S3_ACCESS_KEY)]
     pub s3_access_key_id: String,
 
     /// The secret key for AWS S3 or compatible object storage platform
-    #[structopt(long, env = "P_S3_SECRET_KEY", default_value = DEFAULT_S3_SECRET_KEY)]
+    #[arg(long, env = "P_S3_SECRET_KEY", default_value = DEFAULT_S3_SECRET_KEY)]
     pub s3_secret_key: String,
 
     /// The region for AWS S3 or compatible object storage platform
-    #[structopt(long, env = "P_S3_REGION", default_value = DEFAULT_S3_REGION)]
+    #[arg(long, env = "P_S3_REGION", default_value = DEFAULT_S3_REGION)]
     pub s3_default_region: String,
 
     /// The AWS S3 or compatible object storage bucket to be used for storage
-    #[structopt(long, env = "P_S3_BUCKET", default_value = DEFAULT_S3_BUCKET)]
+    #[arg(long, env = "P_S3_BUCKET", default_value = DEFAULT_S3_BUCKET)]
     pub s3_bucket_name: String,
 }
 


### PR DESCRIPTION
Fixes #140.

### Description

Replaces `structopt` with `clap`.

Without any additional formatting changes, this is how the help output is now written:

```plain
configuration for AWS S3 SDK

Usage: parseable [OPTIONS]

Options:
      --s3-endpoint-url <S3_ENDPOINT_URL>
          The endpoint to AWS S3 or compatible object storage platform [env: P_S3_URL=] [default: https://minio.parseable.io:9000]
      --s3-access-key-id <S3_ACCESS_KEY_ID>
          The access key for AWS S3 or compatible object storage platform [env: P_S3_ACCESS_KEY=] [default: minioadmin]
      --s3-secret-key <S3_SECRET_KEY>
          The secret key for AWS S3 or compatible object storage platform [env: P_S3_SECRET_KEY=] [default: minioadmin]
      --s3-default-region <S3_DEFAULT_REGION>
          The region for AWS S3 or compatible object storage platform [env: P_S3_REGION=] [default: us-east-1]
      --s3-bucket-name <S3_BUCKET_NAME>
          The AWS S3 or compatible object storage bucket to be used for storage [env: P_S3_BUCKET=] [default: parseable]
  -h, --help
          Print help information
```

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
