### PR TITLE
Lock metadata on first event.

### DIFF
--- a/server/src/handlers/event.rs
+++ b/server/src/handlers/event.rs
@@ -64,20 +64,18 @@ pub async fn post_event(
         collect_labelled_headers(&req, PREFIX_META, SEPARATOR)?,
     )]);
 
-    let s3 = S3::new();
-
     if let Some(array) = body.as_array() {
         for body in array {
             let body = merge(body.clone(), metadata.clone());
             let body = merge(body, tags.clone());
             let body = flatten_json_body(web::Json(body)).unwrap();
 
-            let e = event::Event {
+            let event = event::Event {
                 body,
                 stream_name: stream_name.clone(),
             };
 
-            e.process(&s3).await?;
+            event.process().await?;
         }
     } else {
         let body = merge(body.clone(), metadata);
@@ -88,7 +86,7 @@ pub async fn post_event(
             stream_name,
         };
 
-        event.process(&s3).await?;
+        event.process().await?;
     }
 
     Ok(HttpResponse::Ok().finish())

--- a/server/src/handlers/logstream.rs
+++ b/server/src/handlers/logstream.rs
@@ -168,8 +168,6 @@ pub async fn put(req: HttpRequest) -> HttpResponse {
     if s3.get_schema(&stream_name).await.is_err() {
         // Fail if unable to create log stream on object store backend
         if let Err(e) = s3.create_stream(&stream_name).await {
-            // delete the stream from metadata because we couldn't create it on object store backend
-            metadata::STREAM_INFO.delete_stream(&stream_name);
             return response::ServerResponse {
                 msg: format!(
                     "failed to create log stream {} due to err: {}",

--- a/server/src/metadata.rs
+++ b/server/src/metadata.rs
@@ -90,6 +90,7 @@ impl STREAM_INFO {
         Ok(())
     }
 
+    #[allow(dead_code)]
     pub fn set_schema(&self, stream_name: &str, schema: Schema) -> Result<(), MetadataError> {
         let mut map = self.write().expect(LOCK_EXPECT);
         map.get_mut(stream_name)

--- a/server/src/s3.rs
+++ b/server/src/s3.rs
@@ -365,6 +365,10 @@ impl S3 {
 
 #[async_trait]
 impl ObjectStorage for S3 {
+    fn new() -> Self {
+        Self::new()
+    }
+
     async fn check(&self) -> Result<(), ObjectStorageError> {
         self.client
             .head_bucket()

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -52,6 +52,7 @@ pub const OBJECT_STORE_DATA_GRANULARITY: u32 = (LOCAL_SYNC_INTERVAL as u32) / 60
 
 #[async_trait]
 pub trait ObjectStorage: Sync + 'static {
+    fn new() -> Self;
     async fn check(&self) -> Result<(), ObjectStorageError>;
     async fn put_schema(
         &self,


### PR DESCRIPTION
### Description

When multiple requests reaches event processing too quickly then many threads race to register first event. This is problematic as it means server may drop many request after panicking on local writer.

This PR fixes this issue by locking metadata with write lock beforehand in case of first event. This prevents other thread from reading metadata and thus blocks other requests until first event has processed.

### Todo
- This can be seperate issue but as metadata expects that all it's method are panic free there should not be any panic inside s3 client when processing for first event

<hr>

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
