### PR TITLE
Add demo flag documentation in error message

### DIFF
--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -53,9 +53,14 @@ where
     S: Clone + clap::Args + StorageOpt,
 {
     fn new() -> Self {
-        Config {
-            parseable: Opt::<S>::parse(),
-        }
+        let parseable = match Opt::<S>::try_parse() {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("You can also use the --demo flag to run Parseable with default object storage. For testing purposes only");
+                e.exit();
+            }
+        };
+        Config { parseable }
     }
 
     pub fn storage(&self) -> &S {


### PR DESCRIPTION
This changes add information about `--demo` flag on clap parse error if the required argument is not supplied.


Fixes #160.

### Description

Add information about demo mode to user, if they try to run the executable and not yet configured the required environment variables or flags.

<hr>

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.
