### PR TITLE
Bump crates to current latest release

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,18 +1,17 @@
 [package]
 name = "parseable"
 version = "0.0.5"
-authors = [
-    "Parseable Team <hi@parseable.io>",
-]
+authors = ["Parseable Team <hi@parseable.io>"]
 edition = "2021"
 categories = ["olap", "logging", "analytics-store"]
 
 [dependencies]
-actix-web-httpauth = "0.6"
+actix-web-httpauth = "0.8"
 actix-web = { version = "4.1", features = ["rustls"] }
 actix-cors = "0.6"
 actix-files = "0.6.1"
 anyhow = { version = "1.0.43", features = ["backtrace"] }
+arrow-schema = { version = "24.0.0", features = ["serde"] }
 async-trait = "0.1"
 aws-sdk-s3 = "0.19"
 aws-smithy-async = { version = "0.49.0", features = ["rt-tokio"] }
@@ -20,9 +19,9 @@ bytes = "1"
 chrono = "0.4.19"
 chrono-humanize = "0.2.2"
 clap = { version = "4.0.8", features = ["derive", "env"] }
-crossterm = "0.23.2"
-datafusion = "11.0"
-object_store = { version = "0.4", features=["aws"] }
+crossterm = "0.25"
+datafusion = "13.0"
+object_store = { version = "0.5.1", features = ["aws"] }
 derive_more = "0.99.17"
 env_logger = "0.9.0"
 futures = "0.3"
@@ -41,11 +40,14 @@ semver = "1.0.14"
 serde = "^1.0.8"
 serde_derive = "^1.0.8"
 serde_json = "^1.0.8"
-sysinfo = "0.20.5"
+sysinfo = "0.26.4"
 thiserror = "1"
 thread-priority = "0.9.2"
 tokio-stream = "0.1.8"
-tokio = { version = "1.13.1", default-features = false, features=["sync", "macros"] }
+tokio = { version = "1.13.1", default-features = false, features = [
+    "sync",
+    "macros",
+] }
 clokwerk = "0.4.0-rc1"
 actix-web-static-files = "4.0"
 static-files = "0.2.1"
@@ -54,9 +56,9 @@ ureq = { version = "2.5.0", features = ["json"] }
 
 [build-dependencies]
 static-files = "0.2.1"
-cargo_toml = "0.11.5"
+cargo_toml = "0.12.4"
 ureq = "2.5.0"
-sha1_smol = { version = "1.0.0", features=["std"] }
+sha1_smol = { version = "1.0.0", features = ["std"] }
 vergen = { version = "7.4.2", features = ["build", "git"] }
 zip = { git = "https://github.com/zip-rs/zip" }
 

--- a/server/src/handlers/logstream.rs
+++ b/server/src/handlers/logstream.rs
@@ -94,7 +94,9 @@ pub async fn schema(req: HttpRequest) -> HttpResponse {
     match metadata::STREAM_INFO.schema(&stream_name) {
         Ok(schema) => response::ServerResponse {
             msg: schema
-                .map(|schema| schema.to_json().to_string())
+                .map(|ref schema| {
+                    serde_json::to_string(schema).expect("schema can be converted to json")
+                })
                 .unwrap_or_default(),
             code: StatusCode::OK,
         }
@@ -106,8 +108,8 @@ pub async fn schema(req: HttpRequest) -> HttpResponse {
                 code: StatusCode::BAD_REQUEST,
             }
             .to_http(),
-            Ok(Some(schema)) => response::ServerResponse {
-                msg: serde_json::from_value(schema.to_json()).unwrap(),
+            Ok(Some(ref schema)) => response::ServerResponse {
+                msg: serde_json::to_string(schema).unwrap(),
                 code: StatusCode::OK,
             }
             .to_http(),

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -248,14 +248,14 @@ fn run_local_sync() -> (JoinHandle<()>, oneshot::Receiver<()>, oneshot::Sender<(
 async fn validator(
     req: ServiceRequest,
     credentials: BasicAuth,
-) -> Result<ServiceRequest, actix_web::Error> {
+) -> Result<ServiceRequest, (actix_web::Error, ServiceRequest)> {
     if credentials.user_id().trim() == CONFIG.parseable.username
         && credentials.password().unwrap().trim() == CONFIG.parseable.password
     {
         return Ok(req);
     }
 
-    Err(actix_web::error::ErrorUnauthorized("Unauthorized"))
+    Err((actix_web::error::ErrorUnauthorized("Unauthorized"), req))
 }
 
 async fn run_http() -> anyhow::Result<()> {


### PR DESCRIPTION
### Description
This PR bumps few crate version to possible latest while also fixing few error generated from the change.

Arrow Schema now derives `serde` and removes explicit `to_json` method. This broke code at few places which are fixed by directly depending on `arrow_schema` crate with `serde` feature enabled, calls `to_json` is replaced by `to_string` method from serde_json according to usage.

`actix_web_httpauth` crate requires a different function signature for validator which is fixed as well.

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
