### PR TITLE
Set zip version with only deflate feature enabled

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -60,7 +60,7 @@ cargo_toml = "0.12.4"
 ureq = "2.5.0"
 sha1_smol = { version = "1.0.0", features = ["std"] }
 vergen = { version = "7.4.2", features = ["build", "git"] }
-zip = { git = "https://github.com/zip-rs/zip" }
+zip = { version = "0.6.3", default_features = false, features = ["deflate"] }
 
 [dev-dependencies]
 maplit = "1.0.2"


### PR DESCRIPTION
### Description

Set `zip` crate back to stable crates.io version with minimal features enabled. This gets rid of bzip2 as indirect dependency and transitively on bzip2-sys crate. Console releases on GitHub use `deflate` method for zip, so Parseable build step should only requires this feature. 
