### PR TITLE
Fix dockerfile to include glibc for runtime dependency

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -39,6 +39,24 @@ RUN    \
     wget https://github.com/parseablehq/parseable/releases/latest/download/parseable_linux_x86_64 -O /bin/parseable && \
     chmod +x /bin/parseable
 
+
+RUN apk --no-cache add  \
+        wget            \
+        ca-certificates \
+        libstdc++
+# Get and install glibc for alpine
+ARG APK_GLIBC_VERSION=2.34-r0
+ARG APK_GLIBC_FILE="glibc-${APK_GLIBC_VERSION}.apk"
+ARG APK_GLIBC_BIN_FILE="glibc-bin-${APK_GLIBC_VERSION}.apk"
+ARG APK_GLIBC_BASE_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${APK_GLIBC_VERSION}"
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
+    && wget "${APK_GLIBC_BASE_URL}/${APK_GLIBC_FILE}"       \
+    && apk --no-cache add "${APK_GLIBC_FILE}"               \
+    && wget "${APK_GLIBC_BASE_URL}/${APK_GLIBC_BIN_FILE}"   \
+    && apk --no-cache add "${APK_GLIBC_BIN_FILE}"           \
+    && rm glibc-*
+
+RUN     chown -R parseable /parseable/
 USER    parseable:parseable
 
 EXPOSE  8000/tcp


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->
For compatibility with glibc, some options that were attempted, but didn't work out were:
```
# apk add gcompat
# apk add libc6-compat
```
They both resulted in errors similar to the one shown below with alpine-glibc-v2.35-r0

### This patch installs [glibc for alpine](https://github.com/sgerrand/alpine-pkg-glibc) to include the C Runtime Dependencies.
The version chosen is [2.34-r0](https://github.com/sgerrand/alpine-pkg-glibc/releases/tag/2.34-r0) instead of [2.35-r0](https://github.com/sgerrand/alpine-pkg-glibc/releases/tag/2.35-r0) (Latest Release).
This is because the latest release is producing errors at runtime as follows:
```
Error relocating /lib/ld-linux-x86-64.so.2: unsupported relocation type 37
Error relocating /bin/parseable: __memcpy_chk: symbol not found
Error relocating /bin/parseable: __register_atfork: symbol not found
Error relocating /bin/parseable: gnu_get_libc_version: symbol not found
Error relocating /bin/parseable: __res_init: symbol not found
```
<!-- Describe key changes made in the patch. -->
- Added Glibc package
- Added a chown (missing folder permission for parseable user
<hr>

### This cannot be merged yet as the server panics with the following error upon starting
```
$ docker run parseable-glibc parseable server --demo
thread 'local-sync' panicked at 'unable to parse localtime info: Io(Os { code: 2, kind: NotFound, message: "No such file or directory" })', /root/.cargo/registry/src/github.com-1ecc6299db9ec823/chrono-0.4.20/src/offset/local/unix.rs:95:37
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread '<unnamed>' panicked at 'unable to parse localtime info: Io(Os { code: 2, kind: NotFound, message: "No such file or directory" })', /root/.cargo/registry/src/github.com-1ecc6299db9ec823/chrono-0.4.20/src/offset/local/unix.rs:95:37
Error: Failed to sync local data to disc. This can happen due to critical error in disc or environment. Please restart the Parseable server.

Join us on Parseable Slack if the issue persists after restart : https://launchpass.com/parseable
```
### The image size is `80.4MB`
This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.
