### PR TITLE
Refactor alerts

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -53,6 +53,7 @@ actix-web-static-files = "4.0"
 static-files = "0.2.1"
 walkdir = "2"
 ureq = { version = "2.5.0", features = ["json"] }
+uuid = { version = "1.2.1", features = ["v4", "fast-rng", "serde"] }
 
 [build-dependencies]
 static-files = "0.2.1"

--- a/server/src/alerts.rs
+++ b/server/src/alerts.rs
@@ -113,9 +113,15 @@ impl NumericRule {
 
         let comparison = match self.operator {
             NumericOperator::EqualTo => number == &self.value,
-            // TODO: currently this is a hack, ensure checks are performed in the right way
+            NumericOperator::NotEqualTo => number != &self.value,
             NumericOperator::GreaterThan => number.as_f64().unwrap() > self.value.as_f64().unwrap(),
+            NumericOperator::GreaterThanEquals => {
+                number.as_f64().unwrap() >= self.value.as_f64().unwrap()
+            }
             NumericOperator::LessThan => number.as_f64().unwrap() < self.value.as_f64().unwrap(),
+            NumericOperator::LessThanEquals => {
+                number.as_f64().unwrap() <= self.value.as_f64().unwrap()
+            }
         };
 
         // If truthy, increment count of repeated
@@ -143,9 +149,18 @@ impl NumericRule {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum NumericOperator {
+    #[serde(alias = "=")]
     EqualTo,
+    #[serde(alias = "!=")]
+    NotEqualTo,
+    #[serde(alias = ">")]
     GreaterThan,
+    #[serde(alias = ">=")]
+    GreaterThanEquals,
+    #[serde(alias = "<")]
     LessThan,
+    #[serde(alias = "<=")]
+    LessThanEquals,
 }
 
 impl Default for NumericOperator {

--- a/server/src/alerts.rs
+++ b/server/src/alerts.rs
@@ -70,20 +70,20 @@ impl Rule {
     pub fn valid_for_schema(&self, schema: &arrow_schema::Schema) -> bool {
         match self {
             Rule::Numeric(NumericRule { field, .. }) => match schema.column_with_name(field) {
-                Some((_, field)) => match field.data_type() {
+                Some((_, field)) => matches!(
+                    field.data_type(),
                     arrow_schema::DataType::Int8
-                    | arrow_schema::DataType::Int16
-                    | arrow_schema::DataType::Int32
-                    | arrow_schema::DataType::Int64
-                    | arrow_schema::DataType::UInt8
-                    | arrow_schema::DataType::UInt16
-                    | arrow_schema::DataType::UInt32
-                    | arrow_schema::DataType::UInt64
-                    | arrow_schema::DataType::Float16
-                    | arrow_schema::DataType::Float32
-                    | arrow_schema::DataType::Float64 => true,
-                    _ => false,
-                },
+                        | arrow_schema::DataType::Int16
+                        | arrow_schema::DataType::Int32
+                        | arrow_schema::DataType::Int64
+                        | arrow_schema::DataType::UInt8
+                        | arrow_schema::DataType::UInt16
+                        | arrow_schema::DataType::UInt32
+                        | arrow_schema::DataType::UInt64
+                        | arrow_schema::DataType::Float16
+                        | arrow_schema::DataType::Float32
+                        | arrow_schema::DataType::Float64
+                ),
                 None => false,
             },
         }

--- a/server/src/alerts.rs
+++ b/server/src/alerts.rs
@@ -66,6 +66,28 @@ impl Rule {
             Rule::Numeric(rule) => rule.resolves(event),
         }
     }
+
+    pub fn valid_for_schema(&self, schema: &arrow_schema::Schema) -> bool {
+        match self {
+            Rule::Numeric(NumericRule { field, .. }) => match schema.column_with_name(field) {
+                Some((_, field)) => match field.data_type() {
+                    arrow_schema::DataType::Int8
+                    | arrow_schema::DataType::Int16
+                    | arrow_schema::DataType::Int32
+                    | arrow_schema::DataType::Int64
+                    | arrow_schema::DataType::UInt8
+                    | arrow_schema::DataType::UInt16
+                    | arrow_schema::DataType::UInt32
+                    | arrow_schema::DataType::UInt64
+                    | arrow_schema::DataType::Float16
+                    | arrow_schema::DataType::Float32
+                    | arrow_schema::DataType::Float64 => true,
+                    _ => false,
+                },
+                None => false,
+            },
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/server/src/alerts.rs
+++ b/server/src/alerts.rs
@@ -57,13 +57,13 @@ impl Alert {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Rule {
-    NumericRule(NumericRule),
+    Numeric(NumericRule),
 }
 
 impl Rule {
     fn resolves(&self, event: &serde_json::Value) -> bool {
         match self {
-            Rule::NumericRule(rule) => rule.resolves(event),
+            Rule::Numeric(rule) => rule.resolves(event),
         }
     }
 }

--- a/server/src/alerts.rs
+++ b/server/src/alerts.rs
@@ -69,9 +69,9 @@ impl Rule {
 
     pub fn valid_for_schema(&self, schema: &arrow_schema::Schema) -> bool {
         match self {
-            Rule::Numeric(NumericRule { field, .. }) => match schema.column_with_name(field) {
-                Some((_, field)) => matches!(
-                    field.data_type(),
+            Rule::Numeric(NumericRule { column, .. }) => match schema.column_with_name(column) {
+                Some((_, column)) => matches!(
+                    column.data_type(),
                     arrow_schema::DataType::Int8
                         | arrow_schema::DataType::Int16
                         | arrow_schema::DataType::Int32
@@ -93,7 +93,7 @@ impl Rule {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NumericRule {
-    pub field: String,
+    pub column: String,
     /// Field that determines what comparison operator is to be used
     #[serde(default)]
     pub operator: NumericOperator,
@@ -106,7 +106,7 @@ pub struct NumericRule {
 impl NumericRule {
     // TODO: utilise `within` to set a range for validity of rule to trigger alert
     fn resolves(&self, event: &serde_json::Value) -> bool {
-        let number = match event.get(&self.field).expect("field exists") {
+        let number = match event.get(&self.column).expect("column exists") {
             serde_json::Value::Number(number) => number,
             _ => unreachable!("right rule is set for right column type"),
         };

--- a/server/src/alerts.rs
+++ b/server/src/alerts.rs
@@ -21,6 +21,8 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::event::Event;
+
 #[derive(Default, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Alerts {
@@ -41,13 +43,20 @@ pub struct Alert {
 impl Alert {
     // TODO: spawn async tasks to call webhooks if alert rules are met
     // This is done to ensure that threads aren't blocked by calls to the webhook
-    pub async fn check_alert(&self, event: &serde_json::Value) -> Result<(), ()> {
-        if self.rule.resolves(event) {
-            log::info!("Alert triggered; name: {}", self.name);
+    pub async fn check_alert(&self, event: &Event) -> Result<(), ()> {
+        let event_json: serde_json::Value = serde_json::from_str(&event.body).map_err(|_| ())?;
+
+        if self.rule.resolves(&event_json) {
+            log::info!("Alert triggered for stream {}", self.name);
             for target in self.targets.clone() {
-                let msg = self.message.clone();
+                let context = Context::new(
+                    event.stream_name.clone(),
+                    self.name.clone(),
+                    self.message.clone(),
+                    self.rule.trigger_reason(),
+                );
                 actix_web::rt::spawn(async move {
-                    target.call(&msg);
+                    target.call(&context);
                 });
             }
         }
@@ -90,6 +99,43 @@ impl Rule {
             },
         }
     }
+
+    pub fn trigger_reason(&self) -> String {
+        match self {
+            Rule::Numeric(NumericRule {
+                column,
+                operator,
+                value,
+                repeats,
+                ..
+            }) => match operator {
+                NumericOperator::EqualTo => format!(
+                    "{} column was equal to {}, {} times",
+                    column, value, repeats
+                ),
+                NumericOperator::NotEqualTo => format!(
+                    "{} column was not equal to {}, {} times",
+                    column, value, repeats
+                ),
+                NumericOperator::GreaterThan => format!(
+                    "{} column was greater than {}, {} times",
+                    column, value, repeats
+                ),
+                NumericOperator::GreaterThanEquals => format!(
+                    "{} column was greater than or equal to {}, {} times",
+                    column, value, repeats
+                ),
+                NumericOperator::LessThan => format!(
+                    "{} column was less than {}, {} times",
+                    column, value, repeats
+                ),
+                NumericOperator::LessThanEquals => format!(
+                    "{} column was less than or equal to {}, {} times",
+                    column, value, repeats
+                ),
+            },
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -106,7 +152,6 @@ pub struct NumericRule {
 }
 
 impl NumericRule {
-    // TODO: utilise `within` to set a range for validity of rule to trigger alert
     fn resolves(&self, event: &serde_json::Value) -> bool {
         let number = match event.get(&self.column).expect("column exists") {
             serde_json::Value::Number(number) => number,
@@ -181,24 +226,23 @@ pub enum Target {
 }
 
 impl Target {
-    pub fn call(&self, msg: &str) {
+    pub fn call(&self, payload: &Context) {
         match self {
-            Target::Slack(target) => target.call(msg),
-            Target::Other(target) => target.call(msg),
+            Target::Slack(target) => target.call(payload),
+            Target::Other(target) => target.call(payload),
         }
     }
 }
 
-pub trait CallableTarget<T> {
-    fn call(&self, payload: T);
+pub trait CallableTarget {
+    fn call(&self, payload: &Context);
 }
 
 pub mod targets {
     pub mod slack {
         use serde::{Deserialize, Serialize};
-        use serde_json::Value;
 
-        use crate::alerts::CallableTarget;
+        use crate::alerts::{CallableTarget, Context};
 
         #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
         pub struct SlackWebHook {
@@ -206,22 +250,11 @@ pub mod targets {
             server_url: String,
         }
 
-        impl CallableTarget<&Value> for SlackWebHook {
-            fn call(&self, payload: &Value) {
+        impl CallableTarget for SlackWebHook {
+            fn call(&self, payload: &Context) {
                 if let Err(e) = ureq::post(&self.server_url)
                     .set("Content-Type", "application/json")
-                    .send_json(payload)
-                {
-                    log::error!("Couldn't make call to webhook, error: {}", e)
-                }
-            }
-        }
-
-        impl CallableTarget<&str> for SlackWebHook {
-            fn call(&self, payload: &str) {
-                if let Err(e) = ureq::post(&self.server_url)
-                    .set("Content-Type", "application/json")
-                    .send_json(ureq::json!({ "text": payload }))
+                    .send_json(ureq::json!({ "text": payload.default_alert_string() }))
                 {
                     log::error!("Couldn't make call to webhook, error: {}", e)
                 }
@@ -232,7 +265,7 @@ pub mod targets {
     pub mod other {
         use serde::{Deserialize, Serialize};
 
-        use crate::alerts::CallableTarget;
+        use crate::alerts::{CallableTarget, Context};
 
         #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
         #[serde(untagged)]
@@ -249,19 +282,19 @@ pub mod targets {
             },
         }
 
-        impl CallableTarget<&str> for OtherWebHook {
-            fn call(&self, payload: &str) {
+        impl CallableTarget for OtherWebHook {
+            fn call(&self, payload: &Context) {
                 let res = match self {
                     OtherWebHook::Simple { server_url } => ureq::post(server_url)
-                        .set("Content-Type", "application/json")
-                        .send_string(payload),
+                        .set("Content-Type", "text/plain; charset=iso-8859-1")
+                        .send_string(&payload.default_alert_string()),
                     OtherWebHook::ApiKey {
                         server_url,
                         api_key,
                     } => ureq::post(server_url)
-                        .set("Content-Type", "application/json")
+                        .set("Content-Type", "text/plain; charset=iso-8859-1")
                         .set("X-API-Key", api_key)
-                        .send_json(ureq::json!({ "text": payload })),
+                        .send_string(&payload.default_alert_string()),
                 };
 
                 if let Err(e) = res {
@@ -269,5 +302,33 @@ pub mod targets {
                 }
             }
         }
+    }
+}
+
+pub struct Context {
+    stream: String,
+    alert_name: String,
+    message: String,
+    reason: String,
+}
+
+impl Context {
+    pub fn new(stream: String, alert_name: String, message: String, reason: String) -> Self {
+        Self {
+            stream,
+            alert_name,
+            message,
+            reason,
+        }
+    }
+
+    // <Alert_Name> Triggered on <Log_stream>
+    // Message: Ting
+    // Failing Condition: Status column was equal to 500, 5 times
+    fn default_alert_string(&self) -> String {
+        format!(
+            "{} triggered on {}\nMessage: {}\nFailing Condition: {}",
+            self.alert_name, self.stream, self.message, self.reason
+        )
     }
 }

--- a/server/src/alerts.rs
+++ b/server/src/alerts.rs
@@ -237,15 +237,15 @@ pub mod targets {
         #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
         #[serde(untagged)]
         pub enum OtherWebHook {
-            Simple {
-                #[serde(rename = "server_url")]
-                server_url: String,
-            },
             ApiKey {
                 #[serde(rename = "server_url")]
                 server_url: String,
                 #[serde(rename = "api_key")]
                 api_key: String,
+            },
+            Simple {
+                #[serde(rename = "server_url")]
+                server_url: String,
             },
         }
 

--- a/server/src/alerts.rs
+++ b/server/src/alerts.rs
@@ -16,10 +16,7 @@
  *
  */
 
-use std::{
-    fmt::Debug,
-    sync::atomic::{AtomicU32, Ordering},
-};
+use std::sync::atomic::{AtomicU32, Ordering};
 
 use log::{error, info};
 use serde::{Deserialize, Serialize};

--- a/server/src/alerts.rs
+++ b/server/src/alerts.rs
@@ -20,6 +20,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 use log::{error, info};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 #[derive(Default, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -30,6 +31,8 @@ pub struct Alerts {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Alert {
+    #[serde(default = "crate::utils::uuid::gen")]
+    pub id: Uuid,
     pub name: String,
     pub message: String,
     pub rule: Rule,

--- a/server/src/handlers/logstream.rs
+++ b/server/src/handlers/logstream.rs
@@ -94,9 +94,7 @@ pub async fn schema(req: HttpRequest) -> HttpResponse {
     match metadata::STREAM_INFO.schema(&stream_name) {
         Ok(schema) => response::ServerResponse {
             msg: schema
-                .map(|ref schema| {
-                    serde_json::to_string(schema).expect("schema can be converted to json")
-                })
+                .and_then(|ref schema| serde_json::to_string(schema).ok())
                 .unwrap_or_default(),
             code: StatusCode::OK,
         }

--- a/server/src/metadata.rs
+++ b/server/src/metadata.rs
@@ -72,8 +72,6 @@ pub const LOCK_EXPECT: &str = "no method in metadata should panic while holding 
 #[allow(clippy::all)]
 impl STREAM_INFO {
     pub async fn check_alerts(&self, event: &Event) -> Result<(), CheckAlertError> {
-        let event_json: serde_json::Value = serde_json::from_str(&event.body)?;
-
         let mut map = self.write().expect(LOCK_EXPECT);
         let meta = map
             .get_mut(&event.stream_name)
@@ -82,7 +80,7 @@ impl STREAM_INFO {
             ))?;
 
         for alert in meta.alerts.alerts.iter_mut() {
-            if alert.check_alert(&event_json).await.is_err() {
+            if alert.check_alert(event).await.is_err() {
                 log::error!("Error while parsing event against alerts");
             }
         }

--- a/server/src/s3.rs
+++ b/server/src/s3.rs
@@ -407,9 +407,9 @@ impl ObjectStorage for S3 {
     async fn put_alerts(
         &self,
         stream_name: &str,
-        alerts: Alerts,
+        alerts: &Alerts,
     ) -> Result<(), ObjectStorageError> {
-        let body = serde_json::to_vec(&alerts)?;
+        let body = serde_json::to_vec(alerts)?;
         self._put_alerts(stream_name, body).await?;
 
         Ok(())

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -62,8 +62,11 @@ pub trait ObjectStorage: Sync + 'static {
     async fn create_stream(&self, stream_name: &str) -> Result<(), ObjectStorageError>;
     async fn delete_stream(&self, stream_name: &str) -> Result<(), ObjectStorageError>;
 
-    async fn put_alerts(&self, stream_name: &str, alerts: Alerts)
-        -> Result<(), ObjectStorageError>;
+    async fn put_alerts(
+        &self,
+        stream_name: &str,
+        alerts: &Alerts,
+    ) -> Result<(), ObjectStorageError>;
     async fn get_schema(&self, stream_name: &str) -> Result<Option<Schema>, ObjectStorageError>;
     async fn get_alerts(&self, stream_name: &str) -> Result<Alerts, ObjectStorageError>;
     async fn get_stats(&self, stream_name: &str) -> Result<Stats, ObjectStorageError>;

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -127,6 +127,14 @@ pub fn hostname_unchecked() -> String {
     hostname::get().unwrap().into_string().unwrap()
 }
 
+pub mod uuid {
+    use uuid::Uuid;
+
+    pub fn gen() -> Uuid {
+        Uuid::new_v4()
+    }
+}
+
 pub mod update {
     use crate::banner::version::current;
     use std::path::Path;

--- a/server/src/validator.rs
+++ b/server/src/validator.rs
@@ -43,7 +43,7 @@ pub fn alert(alerts: &Alerts) -> Result<(), AlertValidationError> {
         }
 
         match alert.rule {
-            Rule::NumericRule(ref rule) => {
+            Rule::Numeric(ref rule) => {
                 if rule.field.is_empty() {
                     return Err(AlertValidationError::EmptyRuleField);
                 }

--- a/server/src/validator.rs
+++ b/server/src/validator.rs
@@ -44,7 +44,7 @@ pub fn alert(alerts: &Alerts) -> Result<(), AlertValidationError> {
 
         match alert.rule {
             Rule::Numeric(ref rule) => {
-                if rule.field.is_empty() {
+                if rule.column.is_empty() {
                     return Err(AlertValidationError::EmptyRuleField);
                 }
                 if rule.repeats == 0 {
@@ -172,7 +172,7 @@ pub mod error {
         EmptyName,
         #[error("Alert message cannot be empty")]
         EmptyMessage,
-        #[error("Alert's rule.field cannot be empty")]
+        #[error("Alert's rule.column cannot be empty")]
         EmptyRuleField,
         #[error("Alert's rule.repeats can't be set to 0")]
         InvalidRuleRepeat,

--- a/server/src/validator.rs
+++ b/server/src/validator.rs
@@ -18,12 +18,10 @@
 
 use std::sync::Arc;
 
-use chrono::{DateTime, Utc};
-use serde_json::json;
-
-use crate::alerts::Alerts;
+use crate::alerts::{Alerts, Rule};
 use crate::metadata::STREAM_INFO;
 use crate::query::Query;
+use chrono::{DateTime, Utc};
 
 use self::error::{AlertValidationError, QueryValidationError, StreamNameValidationError};
 
@@ -40,20 +38,19 @@ pub fn alert(alerts: &Alerts) -> Result<(), AlertValidationError> {
         if alert.message.is_empty() {
             return Err(AlertValidationError::EmptyMessage);
         }
-        if alert.rule.value == json!(null) {
-            return Err(AlertValidationError::EmptyRuleValue);
-        }
-        if alert.rule.field.is_empty() {
-            return Err(AlertValidationError::EmptyRuleField);
-        }
-        if alert.rule.within.is_empty() {
-            return Err(AlertValidationError::EmptyRuleWithin);
-        }
-        if alert.rule.repeats == 0 {
-            return Err(AlertValidationError::InvalidRuleRepeat);
-        }
         if alert.targets.is_empty() {
             return Err(AlertValidationError::NoTarget);
+        }
+
+        match alert.rule {
+            Rule::NumericRule(ref rule) => {
+                if rule.field.is_empty() {
+                    return Err(AlertValidationError::EmptyRuleField);
+                }
+                if rule.repeats == 0 {
+                    return Err(AlertValidationError::InvalidRuleRepeat);
+                }
+            }
         }
     }
     Ok(())
@@ -175,12 +172,8 @@ pub mod error {
         EmptyName,
         #[error("Alert message cannot be empty")]
         EmptyMessage,
-        #[error("Alert's rule.value cannot be empty")]
-        EmptyRuleValue,
         #[error("Alert's rule.field cannot be empty")]
         EmptyRuleField,
-        #[error("Alert's rule.within cannot be empty")]
-        EmptyRuleWithin,
         #[error("Alert's rule.repeats can't be set to 0")]
         InvalidRuleRepeat,
         #[error("Alert must have at least one target")]


### PR DESCRIPTION
### Description

Alerts are stored on metadata map which is behind and rwlock. This is fine but having to hold writer lock for alert check is not ideal. This PR refactors code around alerts implementation. Each alerts rule should be self contained with its own interior mutable state if it requires any. Interior mutablity pattern allows for alert to be resolved with shared reference. An alert can now contain different variant of rules which can be state or stateless.
<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
