### PR TITLE
Fix system memory calculation and formatting

### DIFF
--- a/server/src/banner.rs
+++ b/server/src/banner.rs
@@ -27,12 +27,12 @@ pub fn system_info() {
     {}
         OS: {}
         Processor: {} logical, {} physical
-        Memory: {} GiB total",
+        Memory: {:.2} GiB total",
         "System:".to_string().blue().bold(),
         os_info::get(),
         num_cpus::get(),
         num_cpus::get_physical(),
-        system.total_memory() / (1024 * 1024)
+        system.total_memory() as f32 / (1024 * 1024 * 1024) as f32
     )
 }
 


### PR DESCRIPTION
### Description
`System::total_memory` method returns memory in bytes. This PR fixes banner's system memory calculation accordingly and now shows memory available with precision up to 2 decimal points.  
