### PR TITLE
Add StringRule for alerts

### DIFF
--- a/server/src/validator.rs
+++ b/server/src/validator.rs
@@ -51,6 +51,11 @@ pub fn alert(alerts: &Alerts) -> Result<(), AlertValidationError> {
                     return Err(AlertValidationError::InvalidRuleRepeat);
                 }
             }
+            Rule::String(ref rule) => {
+                if rule.column.is_empty() {
+                    return Err(AlertValidationError::EmptyRuleField);
+                }
+            }
         }
     }
     Ok(())


### PR DESCRIPTION
### Description

Add a rule for string matching which supports following matching stratergies. Note that all of these work for both case sensitive and insensitive case ( ascii lowercasing ) , this behavior is set through `ignoreCase` while setting up alert rule.
- Exact 
- Not Exact  ( opposite of exact, not be be confused with contains )
- Contains
- Not Contains

Other variants that could be added but were not in this PR.
- Regex
- Starts With
- Ends With

Ref to #184 