### PR TITLE
Create a Dockerfile that outputs a static binary during build

### DIFF
--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -1,0 +1,34 @@
+# Copyright (C) 2022 Parseable, Inc.
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# 
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Compile
+FROM    rust:1.63-alpine AS compiler
+
+WORKDIR /parseable
+
+RUN     apk add --no-cache musl-dev
+
+COPY . .
+
+RUN     set -eux; \
+        apkArch="$(apk --print-arch)"; \
+        if [ "$apkArch" = "aarch64" ]; then \
+        export JEMALLOC_SYS_WITH_LG_PAGE=16; \
+        fi && \
+        cargo build --release --target x86_64-unknown-linux-musl
+
+FROM scratch AS export-stage
+
+COPY     --from=compiler parseable/target/x86_64-unknown-linux-musl/release/parseable parseable


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description
Can be built using:
```
docker build -f Dockerfile.static -o static-build .
```

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
