### PR TITLE
Introduce Stats API

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -67,7 +67,6 @@ zip = { version = "0.6.3", default_features = false, features = ["deflate"] }
 [dev-dependencies]
 maplit = "1.0.2"
 rstest = "0.15.0"
-serde_test = "1.0"
 serial_test = { version = "0.9.0", default-features = false }
 
 [package.metadata.parseable_ui]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -67,6 +67,7 @@ zip = { version = "0.6.3", default_features = false, features = ["deflate"] }
 [dev-dependencies]
 maplit = "1.0.2"
 rstest = "0.15.0"
+serde_test = "1.0"
 serial_test = { version = "0.9.0", default-features = false }
 
 [package.metadata.parseable_ui]

--- a/server/src/handlers/logstream.rs
+++ b/server/src/handlers/logstream.rs
@@ -302,6 +302,27 @@ pub async fn put_alert(req: HttpRequest, body: web::Json<serde_json::Value>) -> 
     .to_http()
 }
 
+pub async fn get_stats(req: HttpRequest) -> HttpResponse {
+    let stream_name: String = req.match_info().get("logstream").unwrap().parse().unwrap();
+
+    let stats = metadata::STREAM_INFO
+        .get_stats(&stream_name)
+        .map(|ref stats| serde_json::to_string(stats).expect("stats can serialize to json"));
+
+    match stats {
+        Ok(stats) => response::ServerResponse {
+            msg: stats,
+            code: StatusCode::OK,
+        }
+        .to_http(),
+        Err(e) => response::ServerResponse {
+            msg: format!("Could not return stats due to error: {}", e),
+            code: StatusCode::BAD_REQUEST,
+        }
+        .to_http(),
+    }
+}
+
 fn remove_id_from_alerts(value: &mut Value) {
     if let Some(Value::Array(alerts)) = value.get_mut("alerts") {
         alerts

--- a/server/src/handlers/logstream.rs
+++ b/server/src/handlers/logstream.rs
@@ -20,6 +20,7 @@ use std::fs;
 
 use actix_web::http::StatusCode;
 use actix_web::{web, HttpRequest, HttpResponse, Responder};
+use chrono::Utc;
 use serde_json::Value;
 
 use crate::alerts::Alerts;
@@ -305,22 +306,37 @@ pub async fn put_alert(req: HttpRequest, body: web::Json<serde_json::Value>) -> 
 pub async fn get_stats(req: HttpRequest) -> HttpResponse {
     let stream_name: String = req.match_info().get("logstream").unwrap().parse().unwrap();
 
-    let stats = metadata::STREAM_INFO
-        .get_stats(&stream_name)
-        .map(|ref stats| serde_json::to_string(stats).expect("stats can serialize to json"));
+    let stats = match metadata::STREAM_INFO.get_stats(&stream_name) {
+        Ok(stats) => stats,
+        Err(e) => {
+            return response::ServerResponse {
+                msg: format!("Could not return stats due to error: {}", e),
+                code: StatusCode::BAD_REQUEST,
+            }
+            .to_http()
+        }
+    };
 
-    match stats {
-        Ok(stats) => response::ServerResponse {
-            msg: stats,
-            code: StatusCode::OK,
+    let time = Utc::now();
+
+    let stats = serde_json::json!({
+        "stream": stream_name,
+        "time": time,
+        "ingestion": {
+            "size": format!("{} {}", stats.ingestion, "Bytes"),
+            "format": "json"
+        },
+        "storage": {
+            "size": format!("{} {}", stats.storage, "Bytes"),
+            "format": "parquet"
         }
-        .to_http(),
-        Err(e) => response::ServerResponse {
-            msg: format!("Could not return stats due to error: {}", e),
-            code: StatusCode::BAD_REQUEST,
-        }
-        .to_http(),
+    });
+
+    response::ServerResponse {
+        msg: stats.to_string(),
+        code: StatusCode::OK,
     }
+    .to_http()
 }
 
 fn remove_id_from_alerts(value: &mut Value) {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -50,6 +50,7 @@ mod option;
 mod query;
 mod response;
 mod s3;
+mod stats;
 mod storage;
 mod utils;
 mod validator;
@@ -342,6 +343,11 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
                 web::resource(schema_path("{logstream}"))
                     .route(web::get().to(handlers::logstream::schema)),
             )
+            .service(
+                // GET "/logstream/{logstream}/stats" ==> Get stats for given log stream
+                web::resource(stats_path("{logstream}"))
+                    .route(web::get().to(handlers::logstream::get_stats)),
+            )
             // GET "/liveness" ==> Livenss check as per https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command
             .service(web::resource(liveness_path()).route(web::get().to(handlers::liveness)))
             // GET "/readiness" ==> Readiness check as per https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes
@@ -398,4 +404,8 @@ fn alert_path(stream_name: &str) -> String {
 
 fn schema_path(stream_name: &str) -> String {
     format!("{}/schema", logstream_path(stream_name))
+}
+
+fn stats_path(stream_name: &str) -> String {
+    format!("{}/stats", logstream_path(stream_name))
 }

--- a/server/src/stats.rs
+++ b/server/src/stats.rs
@@ -1,0 +1,72 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug)]
+pub struct StatsCounter {
+    ingestion_size: AtomicU64,
+    storage_size: AtomicU64,
+}
+
+impl Default for StatsCounter {
+    fn default() -> Self {
+        Self {
+            ingestion_size: AtomicU64::new(0),
+            storage_size: AtomicU64::new(0),
+        }
+    }
+}
+
+impl PartialEq for StatsCounter {
+    fn eq(&self, other: &Self) -> bool {
+        self.ingestion_size() == other.ingestion_size()
+            && self.storage_size() == other.storage_size()
+    }
+}
+
+impl StatsCounter {
+    pub fn new(ingestion_size: u64, storage_size: u64) -> Self {
+        Self {
+            ingestion_size: AtomicU64::new(ingestion_size),
+            storage_size: AtomicU64::new(storage_size),
+        }
+    }
+
+    pub fn ingestion_size(&self) -> u64 {
+        self.ingestion_size.load(Ordering::Relaxed)
+    }
+
+    pub fn storage_size(&self) -> u64 {
+        self.storage_size.load(Ordering::Relaxed)
+    }
+
+    pub fn add_ingestion_size(&self, size: u64) {
+        self.ingestion_size.fetch_add(size, Ordering::AcqRel);
+    }
+
+    pub fn add_storage_size(&self, size: u64) {
+        self.storage_size.fetch_add(size, Ordering::AcqRel);
+    }
+}
+
+/// Helper struct type created by copying stats values from metadata
+#[derive(Debug, Default, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub struct Stats {
+    ingestion: u64,
+    storage: u64,
+}
+
+impl From<&StatsCounter> for Stats {
+    fn from(stats: &StatsCounter) -> Self {
+        Self {
+            ingestion: stats.ingestion_size(),
+            storage: stats.storage_size(),
+        }
+    }
+}
+
+impl From<Stats> for StatsCounter {
+    fn from(stats: Stats) -> Self {
+        StatsCounter::new(stats.ingestion, stats.storage)
+    }
+}

--- a/server/src/stats.rs
+++ b/server/src/stats.rs
@@ -52,8 +52,8 @@ impl StatsCounter {
 /// Helper struct type created by copying stats values from metadata
 #[derive(Debug, Default, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 pub struct Stats {
-    ingestion: u64,
-    storage: u64,
+    pub ingestion: u64,
+    pub storage: u64,
 }
 
 impl From<&StatsCounter> for Stats {

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -243,7 +243,7 @@ impl TimePeriod {
     pub fn generate_prefixes(&self, prefix: &str) -> Vec<String> {
         let prefix = format!("{}/", prefix);
 
-        let end_minute = self.end.minute() + if self.end.second() > 0 { 1 } else { 0 };
+        let end_minute = self.end.minute() + u32::from(self.end.second() > 0);
 
         self.generate_date_prefixes(
             &prefix,


### PR DESCRIPTION
### Description

Adds stats implementation based on atomic u64 counters. On each event ingestion counter is updated and on every sync parquet file size is added to compressed counter. On call to metadata api for stats it produces a json serializable `Stats` instance which is copy of metadata stats counter. Stats are synced on every s3 sync cycle and is stored inside parseable.json file.

Changes: 
- Stats module with StatsCounter and Stats type
- Define stats handler for Actix
- Update events and metadata method for stats
- Add put_stats requirement for storage trait and provide s3 implementation

<hr>

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
