### PR TITLE
Change local cache directory structure

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -25,7 +25,6 @@ object_store = { version = "0.5.1", features = ["aws"] }
 derive_more = "0.99.17"
 env_logger = "0.9.0"
 futures = "0.3"
-filetime = "0.2.17"
 http = "0.2.4"
 humantime-serde = "1.1.1"
 lazy_static = "1.4.0"
@@ -52,7 +51,6 @@ tokio = { version = "1.13.1", default-features = false, features = [
 clokwerk = "0.4.0-rc1"
 actix-web-static-files = "4.0"
 static-files = "0.2.1"
-walkdir = "2"
 ureq = { version = "2.5.0", features = ["json"] }
 uuid = { version = "1.2.1", features = ["v4", "fast-rng", "serde"] }
 

--- a/server/src/event.rs
+++ b/server/src/event.rs
@@ -147,10 +147,7 @@ fn init_new_stream_writer_file(
 
     std::fs::create_dir_all(dir.data_path)?;
 
-    let file = OpenOptions::new()
-        .create_new(true)
-        .append(true)
-        .open(path)?;
+    let file = OpenOptions::new().create(true).append(true).open(path)?;
 
     let mut stream_writer = StreamWriter::try_new(file, &record.schema())
         .expect("File and RecordBatch both are checked");

--- a/server/src/handlers/logstream.rs
+++ b/server/src/handlers/logstream.rs
@@ -70,7 +70,7 @@ pub async fn delete(req: HttpRequest) -> HttpResponse {
         )
     }
 
-    let stream_dir = StorageDir::new(stream_name.clone());
+    let stream_dir = StorageDir::new(&stream_name);
     if fs::remove_dir_all(&stream_dir.data_path).is_err() {
         log::warn!(
             "failed to delete local data for stream {}. Clean {} manually",

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -97,7 +97,7 @@ pub trait ObjectStorage: Sync + 'static {
                 let records = reader.filter_map(|record| match record {
                     Ok(record) => Some(record),
                     Err(e) => {
-                        log::warn!("error when reading from arrow stream {:?}", e);
+                        log::warn!("warning from arrow stream {:?}", e);
                         None
                     }
                 });


### PR DESCRIPTION
### Description

This PR introduces changes to local directory and removes tmp directory. All conversion is still carried out in s3 sync cycle. StorageDir is used as primary class for determining what is the data path for a logstream.

Recordbatch file is signified by extention .arrows.

This PR removes startup sync step as it is not required.

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<hr>

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
