### PR TITLE
Add ingest API

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -259,6 +259,8 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
         web::scope(&base_path())
             // POST "/query" ==> Get results of the SQL query passed in request body
             .service(web::resource(query_path()).route(web::post().to(handlers::event::query)))
+            // POST "/ingest" ==> Post logs to given log stream based on header
+            .service(web::resource(ingest_path()).route(web::post().to(handlers::event::ingest)))
             .service(
                 // logstream API
                 web::resource(logstream_path("{logstream}"))
@@ -339,6 +341,10 @@ fn liveness_path() -> String {
 
 fn query_path() -> String {
     "/query".to_string()
+}
+
+fn ingest_path() -> String {
+    "/ingest".to_string()
 }
 
 fn alert_path(stream_name: &str) -> String {

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -103,6 +103,8 @@ pub mod header_parsing {
         SeperatorInKey(char),
         #[error("A value passed in header contains reserved char {0}")]
         SeperatorInValue(char),
+        #[error("Stream name not found in header")]
+        MissingStreamName,
     }
 
     impl ResponseError for ParseHeaderError {


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->
This API will push logs to stream based on header.

<!-- Describe the possible solutions and chosen one with the rationale. -->
Separated out pushing log logic into `push_logs()` - avoid code redundancy

<!-- Describe key changes made in the patch. -->
Expose `/ingest` API which push logs to a stream name based on header.
The header key is `X-P-STREAM-NAME`

<hr>

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
