### PR TITLE
Add support for automatic stream creation

### DIFF
--- a/server/src/event.rs
+++ b/server/src/event.rs
@@ -172,7 +172,6 @@ impl Event {
         let inferred_schema = self.infer_schema()?;
 
         let event = self.get_reader(inferred_schema.clone());
-
         let stream_schema = metadata::STREAM_INFO.schema(&self.stream_name)?;
 
         if let Some(existing_schema) = stream_schema {
@@ -211,7 +210,7 @@ impl Event {
         // note for functions _schema_with_map and _set_schema_with_map,
         // these are to be called while holding a write lock specifically.
         // this guarantees two things
-        // - no other metadata operation can happen inbetween
+        // - no other metadata operation can happen in between
         // - map always have an entry for this stream
 
         let stream_name = &self.stream_name;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -265,7 +265,7 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
                 // logstream API
                 web::resource(logstream_path("{logstream}"))
                     // PUT "/logstream/{logstream}" ==> Create log stream
-                    .route(web::put().to(handlers::logstream::put))
+                    .route(web::put().to(handlers::logstream::put_stream))
                     // POST "/logstream/{logstream}" ==> Post logs to given log stream
                     .route(web::post().to(handlers::event::post_event))
                     // DELETE "/logstream/{logstream}" ==> Delete log stream

--- a/server/src/metadata.rs
+++ b/server/src/metadata.rs
@@ -80,6 +80,11 @@ impl STREAM_INFO {
             })
     }
 
+    pub fn stream_exists(&self, stream_name: &str) -> bool {
+        let map = self.read().expect(LOCK_EXPECT);
+        map.contains_key(stream_name)
+    }
+
     pub fn schema(&self, stream_name: &str) -> Result<Option<Schema>, MetadataError> {
         let map = self.read().expect(LOCK_EXPECT);
         map.get(stream_name)
@@ -112,7 +117,7 @@ impl STREAM_INFO {
     }
 
     pub async fn load(&self, storage: &impl ObjectStorage) -> Result<(), LoadError> {
-        // When loading streams this funtion will assume list_streams only returns valid streams.
+        // When loading streams this function will assume list_streams only returns valid streams.
         // a valid stream would have a .schema file.
         // .schema file could be empty in that case it will be treated as an uninitialized stream.
         // return error in case of an error from object storage itself.

--- a/server/src/stats.rs
+++ b/server/src/stats.rs
@@ -1,3 +1,21 @@
+/*
+ * Parseable Server (C) 2022 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use serde::{Deserialize, Serialize};

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -103,7 +103,7 @@ pub mod header_parsing {
         SeperatorInKey(char),
         #[error("A value passed in header contains reserved char {0}")]
         SeperatorInValue(char),
-        #[error("Stream name not found in header")]
+        #[error("Stream name not found in header [x-p-stream]")]
         MissingStreamName,
     }
 

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -35,7 +35,7 @@ pub fn merge(value: Value, fields: HashMap<String, String>) -> Value {
             for (k, v) in fields {
                 match m.get_mut(&k) {
                     Some(val) => {
-                        let mut final_val = String::new();
+                        let mut final_val = String::default();
                         final_val.push_str(val.as_str().unwrap());
                         final_val.push(',');
                         final_val.push_str(&v);


### PR DESCRIPTION
In case the user specifies x-p-stream in the header and the stream doesn't exist, server failed with stream doesn't exist error.

But in highly automated environments like kubernetes, it is important to dynamically create the stream so that Parseable is able to ingest the log data quickly without too much user involvement.

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviours.
