### PR TITLE
Redefine CLI subcommands

### DIFF
--- a/server/src/banner.rs
+++ b/server/src/banner.rs
@@ -36,6 +36,7 @@ pub fn system_info() {
     )
 }
 
+#[allow(dead_code)]
 pub fn warning_line() {
     eprint!(
         "

--- a/server/src/event.rs
+++ b/server/src/event.rs
@@ -36,7 +36,7 @@ use std::sync::RwLock;
 use crate::metadata;
 use crate::metadata::LOCK_EXPECT;
 use crate::option::CONFIG;
-use crate::storage::{ObjectStorageProvider, StorageDir};
+use crate::storage::StorageDir;
 
 use self::error::{EventError, StreamWriterError};
 

--- a/server/src/handlers/event.rs
+++ b/server/src/handlers/event.rs
@@ -25,7 +25,6 @@ use crate::event;
 use crate::option::CONFIG;
 use crate::query::Query;
 use crate::response::QueryResponse;
-use crate::storage::ObjectStorageProvider;
 use crate::utils::header_parsing::{collect_labelled_headers, ParseHeaderError};
 use crate::utils::{self, flatten_json_body, merge};
 

--- a/server/src/handlers/logstream.rs
+++ b/server/src/handlers/logstream.rs
@@ -25,7 +25,7 @@ use serde_json::Value;
 
 use crate::alerts::Alerts;
 use crate::option::CONFIG;
-use crate::storage::{ObjectStorageProvider, StorageDir};
+use crate::storage::StorageDir;
 use crate::{event, response};
 use crate::{metadata, validator};
 

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -22,7 +22,7 @@ pub mod logstream;
 use actix_web::http::StatusCode;
 use actix_web::HttpResponse;
 
-use crate::{option::CONFIG, storage::ObjectStorageProvider};
+use crate::option::CONFIG;
 
 pub async fn liveness() -> HttpResponse {
     HttpResponse::new(StatusCode::OK)

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -54,8 +54,6 @@ mod validator;
 
 use option::CONFIG;
 
-use crate::storage::ObjectStorageProvider;
-
 // Global configurations
 const MAX_EVENT_PAYLOAD_SIZE: usize = 1024000;
 const API_BASE_PATH: &str = "/api";

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -35,8 +35,6 @@ lazy_static::lazy_static! {
 
 pub const USERNAME_ENV: &str = "P_USERNAME";
 pub const PASSWORD_ENV: &str = "P_PASSWORD";
-pub const DEFAULT_USERNAME: &str = "parseable";
-pub const DEFAULT_PASSWORD: &str = "parseable";
 
 pub struct Config {
     pub parseable: Server,
@@ -231,7 +229,6 @@ pub struct Server {
         long,
         env = USERNAME_ENV,
         value_name = "username",
-        default_value_if("demo", ArgPredicate::IsPresent, DEFAULT_USERNAME)
     )]
     pub username: String,
 
@@ -240,13 +237,8 @@ pub struct Server {
         long,
         env = PASSWORD_ENV,
         value_name = "password",
-        default_value_if("demo", ArgPredicate::IsPresent, DEFAULT_PASSWORD)
     )]
     pub password: String,
-
-    /// Run Parseable in demo mode with default credentials and open object store
-    #[arg(short, long, exclusive = true)]
-    pub demo: bool,
 }
 
 impl Server {

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -189,7 +189,7 @@ pub struct Server {
     /// from object storage backend
     #[arg(
         long,
-        env = "P_LOCAL_STAGE_PATH",
+        env = "P_STAGING_DIR",
         default_value = "./data",
         value_name = "path"
     )]

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -210,7 +210,7 @@ pub struct Server {
     /// from object storage backend
     #[arg(
         long,
-        env = "P_LOCAL_STORAGE",
+        env = "P_LOCAL_STAGE_PATH",
         default_value = "./data",
         value_name = "path"
     )]

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -16,7 +16,6 @@
  *
  */
 
-use clap::builder::ArgPredicate;
 use clap::{Parser, Subcommand};
 use crossterm::style::Stylize;
 use std::path::PathBuf;
@@ -60,7 +59,6 @@ impl Config {
         let scheme = CONFIG.parseable.get_scheme();
         self.status_info(&scheme);
         banner::version::print();
-        self.demo();
         self.storage_info();
         banner::system_info();
         println!();
@@ -113,23 +111,6 @@ impl Config {
             self.parseable.local_disk_path.to_string_lossy(),
             self.storage().get_endpoint(),
         )
-    }
-
-    fn demo(&self) {
-        if self.is_demo() {
-            banner::warning_line();
-            eprintln!(
-                "
-        {}",
-                "Parseable is in demo mode with default credentials and open object store. Please use this for demo purposes only."
-                    .to_string()
-                    .red(),
-                )
-        }
-    }
-
-    fn is_demo(&self) -> bool {
-        self.parseable.demo
     }
 
     pub fn storage(&self) -> Arc<dyn ObjectStorageProvider + Send + Sync> {

--- a/server/src/query.rs
+++ b/server/src/query.rs
@@ -30,10 +30,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::option::CONFIG;
-use crate::storage::ObjectStorage;
 use crate::storage::ObjectStorageError;
 use crate::storage::StorageDir;
-use crate::storage::{self, ObjectStorageProvider};
+use crate::storage::{ObjectStorage, OBJECT_STORE_DATA_GRANULARITY};
 use crate::utils::TimePeriod;
 use crate::validator;
 
@@ -68,7 +67,7 @@ impl Query {
 
     /// Return prefixes, each per day/hour/minutes as necessary
     pub fn get_prefixes(&self) -> Vec<String> {
-        TimePeriod::new(self.start, self.end, storage::OBJECT_STORE_DATA_GRANULARITY)
+        TimePeriod::new(self.start, self.end, OBJECT_STORE_DATA_GRANULARITY)
             .generate_prefixes(&self.stream_name)
     }
 

--- a/server/src/storage/localfs.rs
+++ b/server/src/storage/localfs.rs
@@ -46,7 +46,7 @@ use super::{LogStream, ObjectStorage, ObjectStorageError, ObjectStorageProvider}
     about = "configuration for using local filesystem for storage"
 )]
 pub struct FSConfig {
-    #[arg(long, env = "P_FS_PATH", value_name = "path")]
+    #[arg(env = "P_FS_PATH", value_name = "filesystem path")]
     root: PathBuf,
 }
 

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -145,7 +145,7 @@ pub trait ObjectStorage: Sync + 'static {
     }
 
     async fn sync(&self) -> Result<(), MoveDataError> {
-        if !Path::new(&CONFIG.parseable.local_disk_path).exists() {
+        if !Path::new(&CONFIG.staging_dir()).exists() {
             return Ok(());
         }
 

--- a/server/src/storage/s3.rs
+++ b/server/src/storage/s3.rs
@@ -26,7 +26,6 @@ use aws_sdk_s3::{Client, Credentials, Endpoint, Region};
 use aws_smithy_async::rt::sleep::default_async_sleep;
 use base64::encode;
 use bytes::Bytes;
-use clap::builder::ArgPredicate;
 
 use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::listing::{

--- a/server/src/storage/s3.rs
+++ b/server/src/storage/s3.rs
@@ -51,61 +51,27 @@ use crate::storage::{LogStream, ObjectStorage, ObjectStorageError};
 
 use super::ObjectStorageProvider;
 
-// Default object storage currently is DO Spaces bucket
-// Any user who starts the Parseable server with default configuration
-// will point to this bucket and will see any data present on this bucket
-const DEFAULT_S3_URL: &str = "https://minio.parseable.io:9000";
-const DEFAULT_S3_REGION: &str = "us-east-1";
-const DEFAULT_S3_BUCKET: &str = "parseable";
-const DEFAULT_S3_ACCESS_KEY: &str = "minioadmin";
-const DEFAULT_S3_SECRET_KEY: &str = "minioadmin";
-
 #[derive(Debug, Clone, clap::Args)]
 #[command(name = "S3 config", about = "configuration for AWS S3 SDK")]
 pub struct S3Config {
     /// The endpoint to AWS S3 or compatible object storage platform
-    #[arg(
-        long,
-        env = "P_S3_URL",
-        value_name = "url",
-        default_value_if("demo", ArgPredicate::IsPresent, DEFAULT_S3_URL)
-    )]
+    #[arg(long, env = "P_S3_URL", value_name = "url")]
     pub s3_endpoint_url: String,
 
     /// The access key for AWS S3 or compatible object storage platform
-    #[arg(
-        long,
-        env = "P_S3_ACCESS_KEY",
-        value_name = "access-key",
-        default_value_if("demo", ArgPredicate::IsPresent, DEFAULT_S3_ACCESS_KEY)
-    )]
+    #[arg(long, env = "P_S3_ACCESS_KEY", value_name = "access-key")]
     pub s3_access_key_id: String,
 
     /// The secret key for AWS S3 or compatible object storage platform
-    #[arg(
-        long,
-        env = "P_S3_SECRET_KEY",
-        value_name = "secret-key",
-        default_value_if("demo", ArgPredicate::IsPresent, DEFAULT_S3_SECRET_KEY)
-    )]
+    #[arg(long, env = "P_S3_SECRET_KEY", value_name = "secret-key")]
     pub s3_secret_key: String,
 
     /// The region for AWS S3 or compatible object storage platform
-    #[arg(
-        long,
-        env = "P_S3_REGION",
-        value_name = "region",
-        default_value_if("demo", ArgPredicate::IsPresent, DEFAULT_S3_REGION)
-    )]
+    #[arg(long, env = "P_S3_REGION", value_name = "region")]
     pub s3_region: String,
 
     /// The AWS S3 or compatible object storage bucket to be used for storage
-    #[arg(
-        long,
-        env = "P_S3_BUCKET",
-        value_name = "bucket-name",
-        default_value_if("demo", ArgPredicate::IsPresent, DEFAULT_S3_BUCKET)
-    )]
+    #[arg(long, env = "P_S3_BUCKET", value_name = "bucket-name")]
     pub s3_bucket_name: String,
 
     /// Set client to send content_md5 header on every put request


### PR DESCRIPTION
### Description

Sub-commands are moved to top level of CLI and can be specified with `--s3` and `--drive`.
Removed demo mode

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
