### PR TITLE
Metadata checks

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -36,7 +36,7 @@ md-5 = "0.10.5"
 os_info = "3.0.7"
 hostname = "0.3"
 rand = "0.8.4"
-relative-path = "1.7.2"
+relative-path = { version = "1.7.2", features = ["serde"] }
 rustls = "0.20.6"
 rustls-pemfile = "1.0.1"
 rust-flatten-json = "0.2.0"

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -54,6 +54,8 @@ mod validator;
 
 use option::CONFIG;
 
+use crate::storage::resolve_parseable_metadata;
+
 // Global configurations
 const MAX_EVENT_PAYLOAD_SIZE: usize = 1024000;
 const API_BASE_PATH: &str = "/api";
@@ -69,6 +71,7 @@ async fn main() -> anyhow::Result<()> {
     if let Err(e) = metadata::STREAM_INFO.load(&*storage).await {
         warn!("could not populate local metadata. {:?}", e);
     }
+    resolve_parseable_metadata().await?;
     // track all parquet files already in the data directory
     storage::CACHED_FILES.track_parquet();
 

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -199,8 +199,7 @@ pub struct Server {
         long,
         env = "P_STAGING_DIR",
         default_value = "./data",
-        value_name = "path",
-        value_parser = validation::absolute_path
+        value_name = "path"
     )]
     pub local_staging_path: PathBuf,
 
@@ -245,7 +244,7 @@ impl Server {
     }
 }
 
-pub(self) mod validation {
+pub mod validation {
     use std::path::PathBuf;
 
     pub fn file_path(s: &str) -> Result<PathBuf, String> {
@@ -260,12 +259,5 @@ pub(self) mod validation {
         }
 
         Ok(path)
-    }
-
-    pub fn absolute_path(s: &str) -> Result<PathBuf, String> {
-        std::fs::canonicalize(s).map_err(|_| {
-            "Could not construct absolute path from given path value for staging directory"
-                .to_string()
-        })
     }
 }

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -160,7 +160,7 @@ pub trait ObjectStorage: Sync + 'static {
                     Some(serde_json::from_slice(&bytes).expect("parseable config is valid json"))
                 }
                 Err(err) => {
-                    if let ObjectStorageError::NoSuchKey(_) = err {
+                    if matches!(err, ObjectStorageError::NoSuchKey(_)) {
                         None
                     } else {
                         return Err(err);

--- a/server/src/storage/store_metadata.rs
+++ b/server/src/storage/store_metadata.rs
@@ -1,0 +1,104 @@
+use std::{
+    fs::{self, OpenOptions},
+    path::PathBuf,
+};
+
+use serde::{Deserialize, Serialize};
+use std::io;
+
+use crate::{option::CONFIG, utils::hostname_unchecked};
+
+use super::{object_storage::PARSEABLE_METADATA_FILE_NAME, ObjectStorageError};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StorageMetadata {
+    pub version: String,
+    pub mode: String,
+    pub staging: PathBuf,
+    pub storage: String,
+    pub deployment_id: String,
+    pub user: Vec<User>,
+    pub stream: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct User {
+    username: String,
+    password: String,
+    role: String,
+}
+
+impl StorageMetadata {
+    pub fn new() -> Self {
+        Self {
+            version: "v1".to_string(),
+            mode: CONFIG.storage_name.to_owned(),
+            staging: CONFIG.staging_dir().canonicalize().unwrap(),
+            storage: CONFIG.storage().get_endpoint(),
+            deployment_id: hostname_unchecked(),
+            user: Vec::new(),
+            stream: Vec::new(),
+        }
+    }
+}
+
+pub async fn startup_check() -> Result<EnvChange, ObjectStorageError> {
+    let staging_metadata = get_staging_metadata()?;
+    let storage = CONFIG.storage().get_object_store();
+    let remote_metadata = storage.get_metadata().await?;
+
+    Ok(check_metadata_conflict(staging_metadata, remote_metadata))
+}
+
+fn check_metadata_conflict(
+    staging_metadata: Option<StorageMetadata>,
+    remote_metadata: Option<StorageMetadata>,
+) -> EnvChange {
+    match (staging_metadata, remote_metadata) {
+        (Some(staging), Some(remote)) if staging.mode == remote.mode => {
+            if staging.storage != remote.storage {
+                EnvChange::StorageMismatch
+            } else if staging.staging != remote.staging {
+                EnvChange::StagingMismatch
+            } else {
+                EnvChange::None
+            }
+        }
+        (Some(staging), Some(remote)) if staging.mode != remote.mode => EnvChange::StorageMismatch,
+        (None, None) => EnvChange::CreateBoth,
+        (None, Some(_)) => EnvChange::NewStaging,
+        (Some(_), None) => EnvChange::NewRemote,
+        _ => unreachable!(),
+    }
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnvChange {
+    None,
+    StagingMismatch,
+    StorageMismatch,
+    NewRemote,
+    NewStaging,
+    CreateBoth,
+}
+
+fn get_staging_metadata() -> io::Result<Option<StorageMetadata>> {
+    let path = CONFIG.staging_dir().join(PARSEABLE_METADATA_FILE_NAME);
+    let bytes = match fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(err) => match err.kind() {
+            io::ErrorKind::NotFound => return Ok(None),
+            _ => return Err(err),
+        },
+    };
+
+    let meta: StorageMetadata = serde_json::from_slice(&bytes).unwrap();
+
+    Ok(Some(meta))
+}
+
+pub fn put_staging_metadata(meta: &StorageMetadata) -> io::Result<()> {
+    let path = CONFIG.staging_dir().join(PARSEABLE_METADATA_FILE_NAME);
+    let mut file = OpenOptions::new().create_new(true).write(true).open(path)?;
+    serde_json::to_writer(&mut file, meta)?;
+    Ok(())
+}


### PR DESCRIPTION
### Description

Parseable will check main metadata file (.parseable.json) on both storage and staging directory. If any critical differences are to be found it will cause a graceful exit. The issue can be resolved by mending the different metadata versions.