### PR TITLE
Automatically add p_datetime if there are no suitable time columns

### DIFF
--- a/server/src/event.rs
+++ b/server/src/event.rs
@@ -47,7 +47,7 @@ type LocalWriter = Mutex<Option<StreamWriter<std::fs::File>>>;
 type LocalWriterGuard<'a> = MutexGuard<'a, Option<StreamWriter<std::fs::File>>>;
 
 const DEFAULT_TIMESTAMP_KEY: &str = "p_timestamp";
-const TIME_KEYS: &[&str] = &["time", "datetime", "timestamp"];
+const TIME_KEYS: &[&str] = &["time", "date", "datetime", "timestamp"];
 
 lazy_static! {
     #[derive(Default)]

--- a/server/src/metadata.rs
+++ b/server/src/metadata.rs
@@ -61,10 +61,8 @@ impl STREAM_INFO {
                 event.stream_name.to_owned(),
             ))?;
 
-        let event_json: serde_json::Value = serde_json::from_str(&event.body)?;
-
         for alert in &meta.alerts.alerts {
-            alert.check_alert(event.stream_name.clone(), &event_json)
+            alert.check_alert(event.stream_name.clone(), &event.body)
         }
 
         Ok(())


### PR DESCRIPTION
###  Description

This PR adds ability for a stream to define altered schema with a dedicated timestamp column if there is none provided in the first request. This column is called `p_datetime`


This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
