### PR TITLE
Add events ingested counter in stats

### DIFF
--- a/server/src/handlers/logstream.rs
+++ b/server/src/handlers/logstream.rs
@@ -213,6 +213,7 @@ pub async fn get_stats(req: HttpRequest) -> Result<impl Responder, StreamError> 
         "stream": stream_name,
         "time": time,
         "ingestion": {
+            "count": stats.events,
             "size": format!("{} {}", stats.ingestion, "Bytes"),
             "format": "json"
         },

--- a/server/src/metadata.rs
+++ b/server/src/metadata.rs
@@ -154,6 +154,7 @@ impl STREAM_INFO {
             .ok_or(MetadataError::StreamMetaNotFound(stream_name.to_owned()))?;
 
         stream.stats.add_ingestion_size(size);
+        stream.stats.increase_event_by_one();
 
         Ok(())
     }


### PR DESCRIPTION
### Description
Add an atomic counter to keep track of how many events are ingested. 

<hr>

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
