### PR TITLE
Fix staging parquet file checks in sync and query

### DIFF
--- a/server/src/query/table_provider.rs
+++ b/server/src/query/table_provider.rs
@@ -67,13 +67,6 @@ impl QueryTableProvider {
         }
     }
 
-    pub fn remove_preserve(&self) {
-        let mut parquet_cached = crate::storage::CACHED_FILES.lock().expect("no poisoning");
-        for file in &self.parquet_files {
-            parquet_cached.remove(file)
-        }
-    }
-
     async fn create_physical_plan(
         &self,
         ctx: &SessionState,
@@ -108,6 +101,15 @@ impl QueryTableProvider {
         }
 
         Ok(Arc::new(UnionExec::new(exec)))
+    }
+}
+
+impl Drop for QueryTableProvider {
+    fn drop(&mut self) {
+        let mut parquet_cached = crate::storage::CACHED_FILES.lock().expect("no poisoning");
+        for file in &self.parquet_files {
+            parquet_cached.remove(file)
+        }
     }
 }
 

--- a/server/src/storage/file_link.rs
+++ b/server/src/storage/file_link.rs
@@ -97,7 +97,7 @@ impl<L: Link + Default> FileTable<L> {
         }
     }
 
-    pub fn get_mut(&mut self, path: &Path) -> &mut L {
-        self.inner.get_mut(path).unwrap()
+    pub fn get_mut(&mut self, path: &Path) -> Option<&mut L> {
+        self.inner.get_mut(path)
     }
 }


### PR DESCRIPTION
Fixes #258 
### Description
* Move remove link procedure to Drop impl for table provider because it always has to run on exit.
* If any parquet file path is not in File table during lookup then we treat it as if it is already uploaded and skip past it 
* Fixed possibility of double upsert when generating possible parquet paths for query. 
<hr>

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
