### PR TITLE
Implement flexible event ingestion and querying

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -67,6 +67,7 @@ ulid = { version = "1.0", features = ["serde"] }
 ureq = { version = "2.5.0", features = ["json"] }
 dashmap = "5.4.0"
 hex = "0.4.3"
+itertools = "0.10.5"
 
 [build-dependencies]
 static-files = "0.2.1"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,7 +17,7 @@ aws-sdk-s3 = "0.19"
 aws-smithy-async = { version = "0.49.0", features = ["rt-tokio"] }
 base64 = "0.20.0"
 bytes = "1"
-chrono = "0.4.19"
+chrono = "0.4.23"
 chrono-humanize = "0.2.2"
 clap = { version = "4.0.32", default-features = false, features = [
     "std",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -65,6 +65,8 @@ actix-web-static-files = "4.0"
 static-files = "0.2.1"
 ulid = { version = "1.0", features = ["serde"] }
 ureq = { version = "2.5.0", features = ["json"] }
+dashmap = "5.4.0"
+hex = "0.4.3"
 
 [build-dependencies]
 static-files = "0.2.1"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -65,9 +65,9 @@ actix-web-static-files = "4.0"
 static-files = "0.2.1"
 ulid = { version = "1.0", features = ["serde"] }
 ureq = { version = "2.5.0", features = ["json"] }
-dashmap = "5.4.0"
 hex = "0.4.3"
 itertools = "0.10.5"
+xxhash-rust = { version = "0.8.6", features = ["xxh3"] }
 
 [build-dependencies]
 static-files = "0.2.1"
@@ -80,7 +80,6 @@ zip = { version = "0.6.3", default_features = false, features = ["deflate"] }
 [dev-dependencies]
 maplit = "1.0.2"
 rstest = "0.15.0"
-serial_test = { version = "0.9.0", default-features = false }
 
 [package.metadata.parseable_ui]
 assets-url = "https://github.com/parseablehq/console/releases/download/v0.0.8/build.zip"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -49,7 +49,7 @@ rustls = "0.20.6"
 rustls-pemfile = "1.0.1"
 rust-flatten-json = "0.2.0"
 semver = "1.0.14"
-serde = "^1.0.8"
+serde = { version = "1.0", features = ["rc"] }
 serde_derive = "^1.0.8"
 serde_json = "^1.0.8"
 thiserror = "1"

--- a/server/src/event.rs
+++ b/server/src/event.rs
@@ -227,7 +227,7 @@ fn commit_schema(
         .expect("map of schemas is serializable");
 
         let storage = CONFIG.storage().get_object_store();
-        futures::executor::block_on(storage.put_schema_map(&stream_name, &schema_map))?;
+        futures::executor::block_on(storage.put_schema_map(stream_name, &schema_map))?;
         stream_metadata.set_unchecked(stream_name, schema_key, schema);
     }
 

--- a/server/src/event.rs
+++ b/server/src/event.rs
@@ -26,7 +26,6 @@ use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::error::ArrowError;
 use datafusion::arrow::json::reader::{infer_json_schema_from_iterator, Decoder, DecoderOptions};
 use datafusion::arrow::record_batch::RecordBatch;
-use md5::Digest;
 use serde_json::Value;
 
 use std::collections::HashMap;
@@ -147,12 +146,12 @@ fn add_default_timestamp_field(schema: Schema) -> Result<Schema, ArrowError> {
 pub fn get_schema_key(body: &Value) -> String {
     let mut list_of_fields: Vec<_> = body.as_object().unwrap().keys().collect();
     list_of_fields.sort();
-    let mut hasher = md5::Md5::new();
+    let mut hasher = xxhash_rust::xxh3::Xxh3::new();
     for field in list_of_fields {
         hasher.update(field.as_bytes())
     }
-
-    hex::encode(hasher.finalize())
+    let hash = hasher.digest();
+    format!("{hash:x}")
 }
 
 fn fields_mismatch(schema: &Schema, body: &Value) -> bool {

--- a/server/src/event.rs
+++ b/server/src/event.rs
@@ -1,33 +1,34 @@
+/*
+* Parseable Server (C) 2022 - 2023 Parseable, Inc.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*
+*/
+
 mod writer;
 
-/*
- * Parseable Server (C) 2022 - 2023 Parseable, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- *
- */
 use arrow_schema::{DataType, Field, TimeUnit};
 use chrono::Utc;
 use datafusion::arrow::array::{Array, TimestampMillisecondArray};
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::error::ArrowError;
-
 use datafusion::arrow::json::reader::{infer_json_schema_from_iterator, Decoder, DecoderOptions};
 use datafusion::arrow::record_batch::RecordBatch;
 use md5::Digest;
 use serde_json::Value;
+
 use std::collections::HashMap;
 use std::ops::DerefMut;
 use std::sync::Arc;

--- a/server/src/event/writer.rs
+++ b/server/src/event/writer.rs
@@ -1,0 +1,204 @@
+/*
+ * Parseable Server (C) 2022 - 2023 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+use datafusion::arrow::{ipc::writer::StreamWriter, record_batch::RecordBatch};
+use lazy_static::lazy_static;
+use std::borrow::Borrow;
+use std::collections::HashMap;
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::sync::{Mutex, RwLock};
+
+use crate::storage::StorageDir;
+
+use self::errors::StreamWriterError;
+
+type ArrowWriter<T> = StreamWriter<T>;
+type LocalWriter<T> = Mutex<Option<ArrowWriter<T>>>;
+
+lazy_static! {
+    #[derive(Default)]
+    pub static ref STREAM_WRITERS: RwLock<WriterTable<String, String, File>> = RwLock::new(WriterTable::new());
+}
+
+impl STREAM_WRITERS {
+    // append to a existing stream
+    pub fn append_to_local(
+        stream: &str,
+        schema_key: &str,
+        record: &RecordBatch,
+    ) -> Result<(), StreamWriterError> {
+        let hashmap_guard = STREAM_WRITERS
+            .read()
+            .map_err(|_| StreamWriterError::RwPoisoned)?;
+
+        match hashmap_guard.get(stream, schema_key) {
+            Some(localwriter) => {
+                let mut writer_guard = localwriter
+                    .lock()
+                    .map_err(|_| StreamWriterError::MutexPoisoned)?;
+
+                // if it's some writer then we write without dropping any lock
+                // hashmap cannot be brought mutably at any point until this finishes
+                if let Some(ref mut writer) = *writer_guard {
+                    writer.write(record).map_err(StreamWriterError::Writer)?;
+                } else {
+                    // pass on this mutex to set entry so that it can be reused
+                    // we have a guard for underlying entry thus
+                    // hashmap must not be availible as mutable to any other thread
+                    let writer = init_new_stream_writer_file(stream, schema_key, record)?;
+                    writer_guard.replace(writer); // replace the stream writer behind this mutex
+                }
+            }
+            // entry is not present thus we create it
+            None => {
+                // this requires mutable borrow of the map so we drop this read lock and wait for write lock
+                drop(hashmap_guard);
+                STREAM_WRITERS::create_entry(stream.to_owned(), schema_key.to_owned(), record)?;
+            }
+        };
+        Ok(())
+    }
+
+    // create a new entry with new stream_writer
+    // Only create entry for valid streams
+    fn create_entry(
+        stream: String,
+        schema_key: String,
+        record: &RecordBatch,
+    ) -> Result<(), StreamWriterError> {
+        let mut hashmap_guard = STREAM_WRITERS
+            .write()
+            .map_err(|_| StreamWriterError::RwPoisoned)?;
+
+        let writer = init_new_stream_writer_file(&stream, &schema_key, record)?;
+
+        hashmap_guard.insert(stream, schema_key, Mutex::new(Some(writer)));
+
+        Ok(())
+    }
+
+    pub fn delete_stream(stream: &str) {
+        STREAM_WRITERS.write().unwrap().delete_stream(stream);
+    }
+
+    pub fn unset_all() -> Result<(), StreamWriterError> {
+        let table = STREAM_WRITERS
+            .read()
+            .map_err(|_| StreamWriterError::RwPoisoned)?;
+
+        for writer in table.iter() {
+            if let Some(mut streamwriter) = writer
+                .lock()
+                .map_err(|_| StreamWriterError::MutexPoisoned)?
+                .take()
+            {
+                let _ = streamwriter.finish();
+            }
+        }
+
+        Ok(())
+    }
+}
+
+pub struct WriterTable<A, B, T>
+where
+    A: Eq + std::hash::Hash,
+    B: Eq + std::hash::Hash,
+    T: Write,
+{
+    table: HashMap<A, HashMap<B, LocalWriter<T>>>,
+}
+
+impl<A, B, T> WriterTable<A, B, T>
+where
+    A: Eq + std::hash::Hash,
+    B: Eq + std::hash::Hash,
+    T: Write,
+{
+    pub fn new() -> Self {
+        let table = HashMap::new();
+        Self { table }
+    }
+
+    fn get<X, Y>(&self, a: &X, b: &Y) -> Option<&LocalWriter<T>>
+    where
+        A: Borrow<X>,
+        B: Borrow<Y>,
+        X: Eq + std::hash::Hash + ?Sized,
+        Y: Eq + std::hash::Hash + ?Sized,
+    {
+        self.table.get(a)?.get(b)
+    }
+
+    fn insert(&mut self, a: A, b: B, v: LocalWriter<T>) {
+        let inner = self.table.entry(a).or_default();
+        inner.insert(b, v);
+    }
+
+    pub fn delete_stream<X>(&mut self, stream: &X)
+    where
+        A: Borrow<X>,
+        X: Eq + std::hash::Hash + ?Sized,
+    {
+        self.table.remove(stream);
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &LocalWriter<T>> {
+        self.table.values().flat_map(|inner| inner.values())
+    }
+}
+
+fn init_new_stream_writer_file(
+    stream_name: &str,
+    schema_key: &str,
+    record: &RecordBatch,
+) -> Result<ArrowWriter<std::fs::File>, StreamWriterError> {
+    let dir = StorageDir::new(stream_name);
+    let path = dir.path_by_current_time(schema_key);
+
+    std::fs::create_dir_all(dir.data_path)?;
+
+    let file = OpenOptions::new().create(true).append(true).open(path)?;
+
+    let mut stream_writer = StreamWriter::try_new(file, &record.schema())
+        .expect("File and RecordBatch both are checked");
+
+    stream_writer
+        .write(record)
+        .map_err(StreamWriterError::Writer)?;
+
+    Ok(stream_writer)
+}
+
+pub mod errors {
+    use arrow_schema::ArrowError;
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum StreamWriterError {
+        #[error("Arrow writer failed: {0}")]
+        Writer(#[from] ArrowError),
+        #[error("Io Error when creating new file: {0}")]
+        Io(#[from] std::io::Error),
+        #[error("RwLock was poisoned")]
+        RwPoisoned,
+        #[error("Mutex was poisoned")]
+        MutexPoisoned,
+    }
+}

--- a/server/src/handlers/event.rs
+++ b/server/src/handlers/event.rs
@@ -103,10 +103,12 @@ async fn push_logs(
             for mut body in array {
                 merge(&mut body, tags_n_metadata.clone().into_iter());
                 let body = flatten_json_body(&body).unwrap();
+                let schema_key = event::get_schema_key(&body);
 
                 let event = event::Event {
                     body,
                     stream_name: stream_name.clone(),
+                    schema_key: schema_key,
                 };
 
                 event.process().await?;
@@ -114,10 +116,12 @@ async fn push_logs(
         }
         mut body @ Value::Object(_) => {
             merge(&mut body, tags_n_metadata.into_iter());
-
+            let body = flatten_json_body(&body).unwrap();
+            let schema_key = event::get_schema_key(&body);
             let event = event::Event {
-                body: flatten_json_body(&body).unwrap(),
+                body,
                 stream_name,
+                schema_key,
             };
 
             event.process().await?;

--- a/server/src/handlers/event.rs
+++ b/server/src/handlers/event.rs
@@ -24,7 +24,7 @@ use crate::option::CONFIG;
 use crate::query::Query;
 use crate::response::QueryResponse;
 use crate::utils::header_parsing::{collect_labelled_headers, ParseHeaderError};
-use crate::utils::{flatten_json_body, merge};
+use crate::utils::json::{flatten_json_body, merge};
 
 use self::error::{PostError, QueryError};
 

--- a/server/src/handlers/event.rs
+++ b/server/src/handlers/event.rs
@@ -39,7 +39,7 @@ pub async fn query(_req: HttpRequest, json: web::Json<Value>) -> Result<HttpResp
 
     let storage = CONFIG.storage().get_object_store();
 
-    let query_result = query.execute(&*storage).await;
+    let query_result = query.execute(storage).await;
 
     query_result
         .map(Into::<QueryResponse>::into)

--- a/server/src/handlers/event.rs
+++ b/server/src/handlers/event.rs
@@ -108,7 +108,7 @@ async fn push_logs(
                 let event = event::Event {
                     body,
                     stream_name: stream_name.clone(),
-                    schema_key: schema_key,
+                    schema_key,
                 };
 
                 event.process().await?;

--- a/server/src/handlers/logstream.rs
+++ b/server/src/handlers/logstream.rs
@@ -27,7 +27,7 @@ use crate::alerts::Alerts;
 use crate::event;
 use crate::metadata::STREAM_INFO;
 use crate::option::CONFIG;
-use crate::storage::StorageDir;
+use crate::storage::{LogStream, StorageDir};
 use crate::{metadata, validator};
 
 use self::error::StreamError;
@@ -59,7 +59,13 @@ pub async fn delete(req: HttpRequest) -> Result<impl Responder, StreamError> {
 }
 
 pub async fn list(_: HttpRequest) -> impl Responder {
-    web::Json(STREAM_INFO.list_streams())
+    let res: Vec<LogStream> = STREAM_INFO
+        .list_streams()
+        .into_iter()
+        .map(|stream| LogStream { name: stream })
+        .collect();
+
+    web::Json(res)
 }
 
 pub async fn schema(req: HttpRequest) -> Result<impl Responder, StreamError> {

--- a/server/src/handlers/logstream.rs
+++ b/server/src/handlers/logstream.rs
@@ -25,8 +25,9 @@ use serde_json::Value;
 
 use crate::alerts::Alerts;
 use crate::event;
+use crate::metadata::STREAM_INFO;
 use crate::option::CONFIG;
-use crate::storage::{ObjectStorageError, StorageDir};
+use crate::storage::StorageDir;
 use crate::{metadata, validator};
 
 use self::error::StreamError;
@@ -37,19 +38,13 @@ pub async fn delete(req: HttpRequest) -> Result<impl Responder, StreamError> {
 
     let objectstore = CONFIG.storage().get_object_store();
 
-    if objectstore.get_schema(&stream_name).await.is_err() {
+    if !objectstore.stream_exists(&stream_name).await? {
         return Err(StreamError::StreamNotFound(stream_name.to_string()));
     }
 
     objectstore.delete_stream(&stream_name).await?;
     metadata::STREAM_INFO.delete_stream(&stream_name);
-
-    if event::STREAM_WRITERS::delete_entry(&stream_name).is_err() {
-        log::warn!(
-            "failed to delete log stream event writers for stream {}",
-            stream_name
-        )
-    }
+    event::STREAM_WRITERS::delete_stream(&stream_name);
 
     let stream_dir = StorageDir::new(&stream_name);
     if fs::remove_dir_all(&stream_dir.data_path).is_err() {
@@ -76,20 +71,11 @@ pub async fn list(_: HttpRequest) -> impl Responder {
 pub async fn schema(req: HttpRequest) -> Result<impl Responder, StreamError> {
     let stream_name: String = req.match_info().get("logstream").unwrap().parse().unwrap();
 
-    match metadata::STREAM_INFO.schema(&stream_name) {
-        Ok(schema) => Ok((web::Json(schema), StatusCode::OK)),
-        Err(_) => match CONFIG
-            .storage()
-            .get_object_store()
-            .get_schema(&stream_name)
-            .await
-        {
-            Ok(Some(schema)) => Ok((web::Json(Some(schema)), StatusCode::OK)),
-            Ok(None) => Err(StreamError::UninitializedLogstream),
-            Err(ObjectStorageError::NoSuchKey(_)) => Err(StreamError::StreamNotFound(stream_name)),
-            Err(err) => Err(err.into()),
-        },
-    }
+    let schemas = STREAM_INFO
+        .schema_map(&stream_name)
+        .map_err(|_| StreamError::StreamNotFound(stream_name.to_owned()))?;
+
+    Ok((web::Json(schemas), StatusCode::OK))
 }
 
 pub async fn get_alert(req: HttpRequest) -> Result<impl Responder, StreamError> {
@@ -164,19 +150,21 @@ pub async fn put_alert(
 
     validator::alert(&alerts)?;
 
-    match metadata::STREAM_INFO.schema(&stream_name) {
-        Ok(Some(schema)) => {
-            let invalid_alert = alerts
-                .alerts
-                .iter()
-                .find(|alert| !alert.rule.valid_for_schema(&schema));
+    let schemas = STREAM_INFO
+        .schema_map(&stream_name)
+        .map_err(|_| StreamError::StreamNotFound(stream_name.to_owned()))?;
 
-            if let Some(alert) = invalid_alert {
-                return Err(StreamError::InvalidAlert(alert.name.to_string()));
-            }
+    if schemas.len() == 0 {
+        return Err(StreamError::UninitializedLogstream);
+    }
+
+    for alert in &alerts.alerts {
+        if !schemas
+            .values()
+            .any(|schema| alert.rule.valid_for_schema(schema))
+        {
+            return Err(StreamError::InvalidAlert(alert.name.to_owned()));
         }
-        Ok(None) => return Err(StreamError::UninitializedLogstream),
-        Err(_) => return Err(StreamError::StreamNotFound(stream_name)),
     }
 
     CONFIG
@@ -255,7 +243,7 @@ pub async fn create_stream(stream_name: String) -> Result<(), StreamError> {
             status: StatusCode::INTERNAL_SERVER_ERROR,
         });
     }
-    metadata::STREAM_INFO.add_stream(stream_name.to_string(), None, Alerts::default());
+    metadata::STREAM_INFO.add_stream(stream_name.to_string());
 
     Ok(())
 }

--- a/server/src/handlers/logstream.rs
+++ b/server/src/handlers/logstream.rs
@@ -154,7 +154,7 @@ pub async fn put_alert(
         .schema_map(&stream_name)
         .map_err(|_| StreamError::StreamNotFound(stream_name.to_owned()))?;
 
-    if schemas.len() == 0 {
+    if schemas.is_empty() {
         return Err(StreamError::UninitializedLogstream);
     }
 

--- a/server/src/metadata.rs
+++ b/server/src/metadata.rs
@@ -19,7 +19,7 @@
 use datafusion::arrow::datatypes::Schema;
 use lazy_static::lazy_static;
 use std::collections::HashMap;
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 
 use crate::alerts::Alerts;
 use crate::event::Event;
@@ -38,7 +38,7 @@ lazy_static! {
 
 #[derive(Debug, Default)]
 pub struct LogStreamMetadata {
-    pub schema: HashMap<String, Schema>,
+    pub schema: HashMap<String, Arc<Schema>>,
     pub alerts: Alerts,
     pub stats: StatsCounter,
 }
@@ -78,7 +78,7 @@ impl STREAM_INFO {
         &self,
         stream_name: &str,
         schema_key: &str,
-    ) -> Result<Option<Schema>, MetadataError> {
+    ) -> Result<Option<Arc<Schema>>, MetadataError> {
         let map = self.read().expect(LOCK_EXPECT);
         let schemas = map
             .get(stream_name)
@@ -88,7 +88,10 @@ impl STREAM_INFO {
         Ok(schemas.get(schema_key).cloned())
     }
 
-    pub fn schema_map(&self, stream_name: &str) -> Result<HashMap<String, Schema>, MetadataError> {
+    pub fn schema_map(
+        &self,
+        stream_name: &str,
+    ) -> Result<HashMap<String, Arc<Schema>>, MetadataError> {
         let map = self.read().expect(LOCK_EXPECT);
         let schemas = map
             .get(stream_name)

--- a/server/src/metadata.rs
+++ b/server/src/metadata.rs
@@ -107,18 +107,14 @@ impl STREAM_INFO {
 
     pub fn merged_schema(&self, stream_name: &str) -> Result<Schema, MetadataError> {
         let map = self.read().expect(LOCK_EXPECT);
-        let schemas = map
+        let schemas = &map
             .get(stream_name)
             .ok_or(MetadataError::StreamMetaNotFound(stream_name.to_string()))?
             .schema;
-        let schema = Schema::try_merge(
-            schemas.values()
-                .map(|schema| &**schema)
-                .cloned(),
-        )
-        .expect("mergeable schemas"));
+        let schema = Schema::try_merge(schemas.values().map(|schema| &**schema).cloned())
+            .expect("mergeable schemas");
 
-        OK(schema)
+        Ok(schema)
     }
 
     pub fn set_alert(&self, stream_name: &str, alerts: Alerts) -> Result<(), MetadataError> {

--- a/server/src/migration.rs
+++ b/server/src/migration.rs
@@ -1,3 +1,22 @@
+/*
+* Parseable Server (C) 2022 - 2023 Parseable, Inc.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*
+*/
+
 mod schema_migration;
 mod stream_metadata_migration;
 

--- a/server/src/migration.rs
+++ b/server/src/migration.rs
@@ -29,7 +29,7 @@ async fn migration_stream(stream: &str, storage: &dyn ObjectStorage) -> anyhow::
         .and_then(|meta| meta.get("version"))
         .and_then(|version| version.as_str());
 
-    if let Some("v1") = maybe_v1 {
+    if matches!(maybe_v1, Some("v1")) {
         let new_stream_metadata = stream_metadata_migration::v1_v2(stream_metadata);
         storage
             .put_object(&path, to_bytes(&new_stream_metadata))

--- a/server/src/migration.rs
+++ b/server/src/migration.rs
@@ -1,0 +1,53 @@
+mod schema_migration;
+mod stream_metadata_migration;
+
+use bytes::Bytes;
+use relative_path::RelativePathBuf;
+use serde::Serialize;
+
+use crate::{option::Config, storage::ObjectStorage};
+
+pub async fn run_migration(config: &Config) -> anyhow::Result<()> {
+    let storage = config.storage().get_object_store();
+    let streams = storage.list_streams().await?;
+
+    for stream in streams {
+        migration_stream(&stream.name, &*storage).await?
+    }
+
+    Ok(())
+}
+
+async fn migration_stream(stream: &str, storage: &dyn ObjectStorage) -> anyhow::Result<()> {
+    let path = RelativePathBuf::from_iter([stream, ".stream.json"]);
+    let stream_metadata = storage.get_object(&path).await?;
+    let stream_metadata: serde_json::Value =
+        serde_json::from_slice(&stream_metadata).expect("stream.json is valid json");
+
+    let maybe_v1 = stream_metadata
+        .as_object()
+        .and_then(|meta| meta.get("version"))
+        .and_then(|version| version.as_str());
+
+    if let Some("v1") = maybe_v1 {
+        let new_stream_metadata = stream_metadata_migration::v1_v2(stream_metadata);
+        storage
+            .put_object(&path, to_bytes(&new_stream_metadata))
+            .await?;
+
+        let schema_path = RelativePathBuf::from_iter([stream, ".schema"]);
+        let schema = storage.get_object(&schema_path).await?;
+        let schema = serde_json::from_slice(&schema).ok();
+        let map = schema_migration::v1_v2(schema)?;
+        storage.put_object(&schema_path, to_bytes(&map)).await?;
+    }
+
+    Ok(())
+}
+
+#[inline(always)]
+fn to_bytes(any: &(impl ?Sized + Serialize)) -> Bytes {
+    serde_json::to_vec(any)
+        .map(|any| any.into())
+        .expect("serialize cannot fail")
+}

--- a/server/src/migration/schema_migration.rs
+++ b/server/src/migration/schema_migration.rs
@@ -1,0 +1,32 @@
+use std::collections::HashMap;
+
+use arrow_schema::{DataType, Field, Schema, TimeUnit};
+use itertools::Itertools;
+use md5::Digest;
+
+pub(super) fn v1_v2(schema: Option<Schema>) -> anyhow::Result<HashMap<String, Schema>> {
+    let Some(schema) = schema else { return Ok(HashMap::new()) };
+    let schema = Schema::try_merge(vec![
+        Schema::new(vec![Field::new(
+            "p_timestamp",
+            DataType::Timestamp(TimeUnit::Millisecond, None),
+            true,
+        )]),
+        schema,
+    ])?;
+
+    let list_of_fields = schema
+        .fields()
+        .iter()
+        // skip p_timestamp
+        .skip(1)
+        .map(|f| f.name())
+        .sorted();
+    let mut hasher = md5::Md5::new();
+    list_of_fields.for_each(|field| hasher.update(field.as_bytes()));
+    let key = hex::encode(hasher.finalize());
+    let mut map = HashMap::new();
+    map.insert(key, schema);
+
+    Ok(map)
+}

--- a/server/src/migration/schema_migration.rs
+++ b/server/src/migration/schema_migration.rs
@@ -1,3 +1,22 @@
+/*
+* Parseable Server (C) 2022 - 2023 Parseable, Inc.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*
+*/
+
 use std::collections::HashMap;
 
 use arrow_schema::{DataType, Field, Schema, TimeUnit};

--- a/server/src/migration/stream_metadata_migration.rs
+++ b/server/src/migration/stream_metadata_migration.rs
@@ -1,0 +1,14 @@
+use serde_json::{json, Value};
+
+pub fn v1_v2(mut stream_metadata: Value) -> Value {
+    let default_stats = json!({
+        "events": 0,
+        "ingestion": 0,
+        "storage": 0
+    });
+    let stream_metadata_map = stream_metadata.as_object_mut().unwrap();
+    stream_metadata_map.entry("stats").or_insert(default_stats);
+    stream_metadata_map.insert("version".to_owned(), Value::String("v2".into()));
+    stream_metadata_map.insert("objectstore-format".to_owned(), Value::String("v2".into()));
+    stream_metadata
+}

--- a/server/src/migration/stream_metadata_migration.rs
+++ b/server/src/migration/stream_metadata_migration.rs
@@ -1,3 +1,22 @@
+/*
+* Parseable Server (C) 2022 - 2023 Parseable, Inc.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*
+*/
+
 use serde_json::{json, Value};
 
 pub fn v1_v2(mut stream_metadata: Value) -> Value {

--- a/server/src/query.rs
+++ b/server/src/query.rs
@@ -49,7 +49,7 @@ fn get_value(value: &Value, key: Key) -> Result<&str, Key> {
 pub struct Query {
     pub query: String,
     pub stream_name: String,
-    pub schemas: HashMap<String, Schema>,
+    pub schemas: HashMap<String, Arc<Schema>>,
     pub start: DateTime<Utc>,
     pub end: DateTime<Utc>,
 }
@@ -89,7 +89,8 @@ impl Query {
     }
 
     pub fn get_schema(&self) -> Schema {
-        Schema::try_merge(self.schemas.clone().into_values()).expect("mergable shcemas")
+        Schema::try_merge(self.schemas.values().map(|schema| schema.as_ref()).cloned())
+            .expect("mergable shcemas")
     }
 
     /// Execute query on object storage(and if necessary on cache as well) with given stream information

--- a/server/src/query.rs
+++ b/server/src/query.rs
@@ -145,7 +145,6 @@ fn time_from_path(path: &Path) -> DateTime<Utc> {
         .to_str()
         .expect("filename is valid");
 
-    // split by . and skip first part because that is schema key.
     // Next three in order will be date, hour and minute
     let mut components = prefix.splitn(3, '.');
 
@@ -200,9 +199,7 @@ mod tests {
 
     #[test]
     fn test_time_from_parquet_path() {
-        let path = PathBuf::from(
-            "schema_key_rlength.date=2022-01-01.hour=00.minute=00.hostname.data.parquet",
-        );
+        let path = PathBuf::from("date=2022-01-01.hour=00.minute=00.hostname.data.parquet");
         let time = time_from_path(path.as_path());
         assert_eq!(time.timestamp(), 1640995200);
     }

--- a/server/src/query.rs
+++ b/server/src/query.rs
@@ -49,7 +49,7 @@ fn get_value(value: &Value, key: Key) -> Result<&str, Key> {
 pub struct Query {
     pub query: String,
     pub stream_name: String,
-    pub schemas: HashMap<String, Arc<Schema>>,
+    pub merged_schema: Arc<Schema>,
     pub start: DateTime<Utc>,
     pub end: DateTime<Utc>,
 }
@@ -88,9 +88,8 @@ impl Query {
         res
     }
 
-    pub fn get_schema(&self) -> Schema {
-        Schema::try_merge(self.schemas.values().map(|schema| schema.as_ref()).cloned())
-            .expect("mergable shcemas")
+    pub fn get_schema(&self) -> Arc<Schema> {
+        self.merged_schema
     }
 
     /// Execute query on object storage(and if necessary on cache as well) with given stream information

--- a/server/src/query.rs
+++ b/server/src/query.rs
@@ -174,7 +174,7 @@ pub mod error {
 #[cfg(test)]
 mod tests {
     use super::{time_from_path, Query};
-    use crate::{alerts::Alerts, metadata::STREAM_INFO};
+    use crate::metadata::STREAM_INFO;
     use datafusion::arrow::datatypes::Schema;
     use datafusion::arrow::datatypes::{DataType, Field};
     use rstest::*;
@@ -222,7 +222,7 @@ mod tests {
     #[serial_test::serial]
     fn query_parse_prefix_with_some_schema(#[case] prefix: &str, #[case] right: &[&str]) {
         clear_map();
-        STREAM_INFO.add_stream("stream_name".to_string(), Some(schema()), Alerts::default());
+        STREAM_INFO.add_stream("stream_name".to_string());
 
         let query = Value::from_str(prefix).unwrap();
         let query = Query::parse(query).unwrap();
@@ -244,7 +244,7 @@ mod tests {
     #[serial_test::serial]
     fn query_parse_prefix_with_no_schema(#[case] prefix: &str) {
         clear_map();
-        STREAM_INFO.add_stream("stream_name".to_string(), None, Alerts::default());
+        STREAM_INFO.add_stream("stream_name".to_string());
 
         let query = Value::from_str(prefix).unwrap();
         assert!(Query::parse(query).is_err());

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -254,8 +254,6 @@ impl StorageDir {
 
 #[derive(Debug, thiserror::Error)]
 pub enum MoveDataError {
-    #[error("Unable to Open file after moving")]
-    Open,
     #[error("Unable to create recordbatch stream")]
     Arrow(#[from] ArrowError),
     #[error("Could not generate parquet file")]
@@ -264,8 +262,6 @@ pub enum MoveDataError {
     ObjectStorage(#[from] ObjectStorageError),
     #[error("Could not generate parquet file")]
     Create,
-    #[error("Could not delete temp arrow file")]
-    Delete,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -205,7 +205,7 @@ impl StorageDir {
         Self { data_path }
     }
 
-    fn filename_by_time(time: NaiveDateTime) -> String {
+    fn file_time_suffix(time: NaiveDateTime) -> String {
         let uri = utils::date_to_prefix(time.date())
             + &utils::hour_to_prefix(time.hour())
             + &utils::minute_to_prefix(time.minute(), OBJECT_STORE_DATA_GRANULARITY).unwrap();
@@ -214,13 +214,18 @@ impl StorageDir {
         format!("{local_uri}{hostname}.data.arrows")
     }
 
-    fn filename_by_current_time() -> String {
-        let datetime = Utc::now();
-        Self::filename_by_time(datetime.naive_utc())
+    fn filename_by_time(stream_hash: &str, time: NaiveDateTime) -> String {
+        format!("{}.{}", stream_hash, Self::file_time_suffix(time))
     }
 
-    pub fn path_by_current_time(&self) -> PathBuf {
-        self.data_path.join(Self::filename_by_current_time())
+    fn filename_by_current_time(stream_hash: &str) -> String {
+        let datetime = Utc::now();
+        Self::filename_by_time(stream_hash, datetime.naive_utc())
+    }
+
+    pub fn path_by_current_time(&self, stream_hash: &str) -> PathBuf {
+        self.data_path
+            .join(Self::filename_by_current_time(stream_hash))
     }
 
     pub fn arrow_files(&self) -> Vec<PathBuf> {

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -19,6 +19,7 @@
 use crate::metadata::STREAM_INFO;
 use crate::option::CONFIG;
 
+use crate::stats::Stats;
 use crate::storage::file_link::{FileLink, FileTable};
 use crate::utils;
 
@@ -66,13 +67,16 @@ const ACCESS_ALL: &str = "all";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ObjectStoreFormat {
+    /// Version of schema registry
     pub version: String,
+    /// Version for change in the way how parquet are generated/stored.
     #[serde(rename = "objectstore-format")]
     pub objectstore_format: String,
     #[serde(rename = "created-at")]
     pub created_at: String,
     pub owner: Owner,
     pub permissions: Vec<Permisssion>,
+    pub stats: Stats,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -112,6 +116,7 @@ impl Default for ObjectStoreFormat {
             created_at: Local::now().to_rfc3339(),
             owner: Owner::new("".to_string(), "".to_string()),
             permissions: vec![Permisssion::new("parseable".to_string())],
+            stats: Stats::default(),
         }
     }
 }

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -107,7 +107,7 @@ impl Permisssion {
 impl Default for ObjectStoreFormat {
     fn default() -> Self {
         Self {
-            version: "v1".to_string(),
+            version: "v2".to_string(),
             objectstore_format: "v1".to_string(),
             created_at: Local::now().to_rfc3339(),
             owner: Owner::new("".to_string(), "".to_string()),

--- a/server/src/storage/localfs.rs
+++ b/server/src/storage/localfs.rs
@@ -191,7 +191,7 @@ impl ObjectStorage for LocalFS {
 
         let config = ListingTableConfig::new_with_multi_paths(prefixes)
             .with_listing_options(listing_options)
-            .with_schema(Arc::clone(&query.schema));
+            .with_schema(Arc::new(query.get_schema()));
 
         Ok(Some(ListingTable::try_new(config)?))
     }

--- a/server/src/storage/localfs.rs
+++ b/server/src/storage/localfs.rs
@@ -191,7 +191,7 @@ impl ObjectStorage for LocalFS {
 
         let config = ListingTableConfig::new_with_multi_paths(prefixes)
             .with_listing_options(listing_options)
-            .with_schema(Arc::new(query.get_schema()));
+            .with_schema(Arc::new(query.get_schema().clone()));
 
         Ok(Some(ListingTable::try_new(config)?))
     }

--- a/server/src/storage/localfs.rs
+++ b/server/src/storage/localfs.rs
@@ -21,6 +21,7 @@ use std::{
     sync::Arc,
 };
 
+use arrow_schema::Schema;
 use async_trait::async_trait;
 use bytes::Bytes;
 use datafusion::{
@@ -28,6 +29,7 @@ use datafusion::{
         file_format::parquet::ParquetFormat,
         listing::{ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl},
     },
+    error::DataFusionError,
     execution::runtime_env::{RuntimeConfig, RuntimeEnv},
 };
 use fs_extra::file::{move_file, CopyOptions};
@@ -36,7 +38,7 @@ use relative_path::RelativePath;
 use tokio::fs;
 use tokio_stream::wrappers::ReadDirStream;
 
-use crate::{option::validation, query::Query, utils::validate_path_is_writeable};
+use crate::{option::validation, utils::validate_path_is_writeable};
 
 use super::{LogStream, ObjectStorage, ObjectStorageError, ObjectStorageProvider};
 
@@ -166,9 +168,12 @@ impl ObjectStorage for LocalFS {
         Ok(())
     }
 
-    fn query_table(&self, query: &Query) -> Result<Option<ListingTable>, ObjectStorageError> {
-        let prefixes: Vec<ListingTableUrl> = query
-            .get_prefixes()
+    fn query_table(
+        &self,
+        prefixes: Vec<String>,
+        schema: Arc<Schema>,
+    ) -> Result<Option<ListingTable>, DataFusionError> {
+        let prefixes: Vec<ListingTableUrl> = prefixes
             .into_iter()
             .filter_map(|prefix| {
                 let path = self.root.join(prefix);
@@ -191,7 +196,7 @@ impl ObjectStorage for LocalFS {
 
         let config = ListingTableConfig::new_with_multi_paths(prefixes)
             .with_listing_options(listing_options)
-            .with_schema(Arc::new(query.get_schema().clone()));
+            .with_schema(schema);
 
         Ok(Some(ListingTable::try_new(config)?))
     }

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -159,6 +159,14 @@ pub trait ObjectStorage: Sync + 'static {
         }
     }
 
+    async fn get_stream_metadata(
+        &self,
+        stream_name: &str,
+    ) -> Result<ObjectStoreFormat, ObjectStorageError> {
+        let stream_metadata = self.get_object(&stream_json_path(stream_name)).await?;
+        Ok(serde_json::from_slice(&stream_metadata).expect("parseable config is valid json"))
+    }
+
     async fn get_stats(&self, stream_name: &str) -> Result<Stats, ObjectStorageError> {
         let stream_metadata = self.get_object(&stream_json_path(stream_name)).await?;
         let stream_metadata: Value =

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -135,7 +135,7 @@ pub trait ObjectStorage: Sync + 'static {
     async fn get_schema_map(
         &self,
         stream_name: &str,
-    ) -> Result<HashMap<String, Schema>, ObjectStorageError> {
+    ) -> Result<HashMap<String, Arc<Schema>>, ObjectStorageError> {
         let schema = self.get_object(&schema_path(stream_name)).await?;
         let schema = serde_json::from_slice(&schema).expect("schema map is valid json");
         Ok(schema)

--- a/server/src/storage/s3.rs
+++ b/server/src/storage/s3.rs
@@ -345,7 +345,7 @@ impl ObjectStorage for S3 {
 
         let config = ListingTableConfig::new_with_multi_paths(prefixes)
             .with_listing_options(listing_options)
-            .with_schema(Arc::new(query.get_schema()));
+            .with_schema(Arc::new(query.get_schema().clone()));
 
         Ok(Some(ListingTable::try_new(config)?))
     }

--- a/server/src/storage/s3.rs
+++ b/server/src/storage/s3.rs
@@ -345,7 +345,7 @@ impl ObjectStorage for S3 {
 
         let config = ListingTableConfig::new_with_multi_paths(prefixes)
             .with_listing_options(listing_options)
-            .with_schema(Arc::clone(&query.schema));
+            .with_schema(Arc::new(query.get_schema()));
 
         Ok(Some(ListingTable::try_new(config)?))
     }

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -271,13 +271,9 @@ impl TimePeriod {
         }
     }
 
-    pub fn generate_prefixes(&self, prefix: &str) -> Vec<String> {
-        let prefix = format!("{prefix}/");
-
+    pub fn generate_prefixes(&self) -> Vec<String> {
         let end_minute = self.end.minute() + u32::from(self.end.second() > 0);
-
         self.generate_date_prefixes(
-            &prefix,
             self.start.date_naive(),
             self.end.date_naive(),
             (self.start.hour(), self.start.minute()),
@@ -371,7 +367,6 @@ impl TimePeriod {
 
     pub fn generate_date_prefixes(
         &self,
-        prefix: &str,
         start_date: NaiveDate,
         end_date: NaiveDate,
         start_time: (u32, u32),
@@ -381,7 +376,7 @@ impl TimePeriod {
         let mut date = start_date;
 
         while date <= end_date {
-            let prefix = prefix.to_owned() + &date_to_prefix(date);
+            let prefix = date_to_prefix(date);
             let is_start = date == start_date;
             let is_end = date == end_date;
 
@@ -426,66 +421,66 @@ mod tests {
     #[rstest]
     #[case::same_minute(
         "2022-06-11T16:30:00+00:00", "2022-06-11T16:30:59+00:00",
-        &["stream_name/date=2022-06-11/hour=16/minute=30/"]
+        &["date=2022-06-11/hour=16/minute=30/"]
     )]
     #[case::same_hour_different_minute(
         "2022-06-11T16:57:00+00:00", "2022-06-11T16:59:00+00:00",
         &[
-            "stream_name/date=2022-06-11/hour=16/minute=57/",
-            "stream_name/date=2022-06-11/hour=16/minute=58/"
+            "date=2022-06-11/hour=16/minute=57/",
+            "date=2022-06-11/hour=16/minute=58/"
         ]
     )]
     #[case::same_hour_with_00_to_59_minute_block(
         "2022-06-11T16:00:00+00:00", "2022-06-11T16:59:59+00:00",   
-        &["stream_name/date=2022-06-11/hour=16/"]
+        &["date=2022-06-11/hour=16/"]
     )]
     #[case::same_date_different_hours_coherent_minute(
         "2022-06-11T15:00:00+00:00", "2022-06-11T17:00:00+00:00",
        &[
-            "stream_name/date=2022-06-11/hour=15/",
-            "stream_name/date=2022-06-11/hour=16/"
+            "date=2022-06-11/hour=15/",
+            "date=2022-06-11/hour=16/"
         ]
     )]
     #[case::same_date_different_hours_incoherent_minutes(
         "2022-06-11T15:59:00+00:00", "2022-06-11T16:01:00+00:00", 
         &[
-            "stream_name/date=2022-06-11/hour=15/minute=59/",
-            "stream_name/date=2022-06-11/hour=16/minute=00/"
+            "date=2022-06-11/hour=15/minute=59/",
+            "date=2022-06-11/hour=16/minute=00/"
         ]
     )]
     #[case::same_date_different_hours_whole_hours_between_incoherent_minutes(
         "2022-06-11T15:59:00+00:00", "2022-06-11T17:01:00+00:00", 
         &[
-            "stream_name/date=2022-06-11/hour=15/minute=59/",
-            "stream_name/date=2022-06-11/hour=16/",
-            "stream_name/date=2022-06-11/hour=17/minute=00/"
+            "date=2022-06-11/hour=15/minute=59/",
+            "date=2022-06-11/hour=16/",
+            "date=2022-06-11/hour=17/minute=00/"
         ]
     )]
     #[case::different_date_coherent_hours_and_minutes(
         "2022-06-11T00:00:00+00:00", "2022-06-13T00:00:00+00:00", 
         &[
-            "stream_name/date=2022-06-11/",
-            "stream_name/date=2022-06-12/"
+            "date=2022-06-11/",
+            "date=2022-06-12/"
         ]
     )]
     #[case::different_date_incoherent_hours_coherent_minutes(
         "2022-06-11T23:00:01+00:00", "2022-06-12T01:59:59+00:00", 
         &[
-            "stream_name/date=2022-06-11/hour=23/",
-            "stream_name/date=2022-06-12/hour=00/",
-            "stream_name/date=2022-06-12/hour=01/"
+            "date=2022-06-11/hour=23/",
+            "date=2022-06-12/hour=00/",
+            "date=2022-06-12/hour=01/"
         ]
     )]
     #[case::different_date_incoherent_hours_incoherent_minutes(
         "2022-06-11T23:59:59+00:00", "2022-06-12T00:01:00+00:00", 
         &[
-            "stream_name/date=2022-06-11/hour=23/minute=59/",
-            "stream_name/date=2022-06-12/hour=00/minute=00/"
+            "date=2022-06-11/hour=23/minute=59/",
+            "date=2022-06-12/hour=00/minute=00/"
         ]
     )]
     fn prefix_generation(#[case] start: &str, #[case] end: &str, #[case] right: &[&str]) {
         let time_period = time_period_from_str(start, end);
-        let prefixes = time_period.generate_prefixes("stream_name");
+        let prefixes = time_period.generate_prefixes();
         let left = prefixes.iter().map(String::as_str).collect::<Vec<&str>>();
         assert_eq!(left.as_slice(), right);
     }

--- a/server/src/utils/batch_adapter.rs
+++ b/server/src/utils/batch_adapter.rs
@@ -1,0 +1,43 @@
+/*
+ * Parseable Server (C) 2022 - 2023 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use arrow_schema::Schema;
+use datafusion::arrow::array::new_null_array;
+use datafusion::arrow::array::ArrayRef;
+use datafusion::arrow::record_batch::RecordBatch;
+
+use std::sync::Arc;
+
+pub fn adapt_batch(table_schema: &Schema, batch: RecordBatch) -> RecordBatch {
+    let batch_schema = &*batch.schema();
+
+    let mut cols: Vec<ArrayRef> = Vec::with_capacity(table_schema.fields().len());
+    let batch_cols = batch.columns().to_vec();
+
+    for table_field in table_schema.fields() {
+        if let Some((batch_idx, _)) = batch_schema.column_with_name(table_field.name().as_str()) {
+            cols.push(Arc::clone(&batch_cols[batch_idx]));
+        } else {
+            cols.push(new_null_array(table_field.data_type(), batch.num_rows()))
+        }
+    }
+
+    let merged_schema = Arc::new(table_schema.clone());
+
+    RecordBatch::try_new(merged_schema, cols).unwrap()
+}

--- a/server/src/utils/header_parsing.rs
+++ b/server/src/utils/header_parsing.rs
@@ -1,0 +1,81 @@
+/*
+ * Parseable Server (C) 2022 - 2023 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+const MAX_HEADERS_ALLOWED: usize = 10;
+use actix_web::{HttpRequest, HttpResponse, ResponseError};
+
+pub fn collect_labelled_headers(
+    req: &HttpRequest,
+    prefix: &str,
+    kv_separator: char,
+) -> Result<String, ParseHeaderError> {
+    // filter out headers which has right prefix label and convert them into str;
+    let headers = req.headers().iter().filter_map(|(key, value)| {
+        let key = key.as_str().strip_prefix(prefix)?;
+        Some((key, value))
+    });
+
+    let mut labels: Vec<String> = Vec::new();
+
+    for (key, value) in headers {
+        let value = value.to_str().map_err(|_| ParseHeaderError::InvalidValue)?;
+        if key.is_empty() {
+            return Err(ParseHeaderError::Emptykey);
+        }
+        if key.contains(kv_separator) {
+            return Err(ParseHeaderError::SeperatorInKey(kv_separator));
+        }
+        if value.contains(kv_separator) {
+            return Err(ParseHeaderError::SeperatorInValue(kv_separator));
+        }
+
+        labels.push(format!("{}={}", key, value));
+    }
+
+    if labels.len() > MAX_HEADERS_ALLOWED {
+        return Err(ParseHeaderError::MaxHeadersLimitExceeded);
+    }
+
+    Ok(labels.join(&kv_separator.to_string()))
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ParseHeaderError {
+    #[error("Too many headers received. Limit is of 5 headers")]
+    MaxHeadersLimitExceeded,
+    #[error("A value passed in header can't be formatted to plain visible ASCII")]
+    InvalidValue,
+    #[error("Invalid Key was passed which terminated just after the end of prefix")]
+    Emptykey,
+    #[error("A key passed in header contains reserved char {0}")]
+    SeperatorInKey(char),
+    #[error("A value passed in header contains reserved char {0}")]
+    SeperatorInValue(char),
+    #[error("Stream name not found in header [x-p-stream]")]
+    MissingStreamName,
+}
+
+impl ResponseError for ParseHeaderError {
+    fn status_code(&self) -> http::StatusCode {
+        http::StatusCode::BAD_REQUEST
+    }
+
+    fn error_response(&self) -> HttpResponse {
+        HttpResponse::build(self.status_code()).body(self.to_string())
+    }
+}

--- a/server/src/utils/header_parsing.rs
+++ b/server/src/utils/header_parsing.rs
@@ -44,7 +44,7 @@ pub fn collect_labelled_headers(
             return Err(ParseHeaderError::SeperatorInValue(kv_separator));
         }
 
-        labels.push(format!("{}={}", key, value));
+        labels.push(format!("{key}={value}"));
     }
 
     if labels.len() > MAX_HEADERS_ALLOWED {

--- a/server/src/utils/json.rs
+++ b/server/src/utils/json.rs
@@ -1,0 +1,42 @@
+/*
+ * Parseable Server (C) 2022 - 2023 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use serde_json;
+use serde_json::json;
+use serde_json::Value;
+
+pub fn flatten_json_body(body: &serde_json::Value) -> Result<Value, serde_json::Error> {
+    let mut flat_value: Value = json!({});
+    flatten_json::flatten(body, &mut flat_value, None, false, Some("_")).unwrap();
+    Ok(flat_value)
+}
+
+pub fn merge(value: &mut Value, fields: impl Iterator<Item = (String, Value)>) {
+    if let Value::Object(m) = value {
+        for (k, v) in fields {
+            match m.get_mut(&k) {
+                Some(val) => {
+                    *val = v;
+                }
+                None => {
+                    m.insert(k, v);
+                }
+            }
+        }
+    }
+}

--- a/server/src/utils/uid.rs
+++ b/server/src/utils/uid.rs
@@ -1,0 +1,25 @@
+/*
+ * Parseable Server (C) 2022 - 2023 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use ulid::Ulid;
+
+pub type Uid = Ulid;
+
+pub fn gen() -> Ulid {
+    Ulid::new()
+}

--- a/server/src/utils/update.rs
+++ b/server/src/utils/update.rs
@@ -1,0 +1,95 @@
+/*
+ * Parseable Server (C) 2022 - 2023 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use crate::banner::about::current;
+use std::env;
+use std::{path::Path, time::Duration};
+
+use anyhow::anyhow;
+use chrono::{DateTime, Utc};
+use ulid::Ulid;
+
+use crate::storage::StorageMetadata;
+
+static K8S_ENV_TO_CHECK: &str = "KUBERNETES_SERVICE_HOST";
+
+#[derive(Debug)]
+pub struct LatestRelease {
+    pub version: semver::Version,
+    pub date: DateTime<Utc>,
+}
+
+fn is_docker() -> bool {
+    Path::new("/.dockerenv").exists()
+}
+
+fn is_k8s() -> bool {
+    env::var(K8S_ENV_TO_CHECK).is_ok()
+}
+
+fn platform() -> &'static str {
+    if is_k8s() {
+        "Kubernetes"
+    } else if is_docker() {
+        "Docker"
+    } else {
+        "Native"
+    }
+}
+
+// User Agent for Download API call
+// Format: Parseable/<UID>/<version>/<commit_hash> (<OS>; <Platform>)
+fn user_agent(uid: &Ulid) -> String {
+    let info = os_info::get();
+    format!(
+        "Parseable/{}/{}/{} ({}; {})",
+        uid,
+        current().0,
+        current().1,
+        info.os_type(),
+        platform()
+    )
+}
+
+pub fn get_latest(meta: &StorageMetadata) -> Result<LatestRelease, anyhow::Error> {
+    let agent = ureq::builder()
+        .user_agent(user_agent(&meta.deployment_id).as_str())
+        .timeout(Duration::from_secs(8))
+        .build();
+
+    let json: serde_json::Value = agent
+        .get("https://download.parseable.io/latest-version")
+        .call()?
+        .into_json()?;
+
+    let version = json["tag_name"]
+        .as_str()
+        .and_then(|ver| ver.strip_prefix('v'))
+        .and_then(|ver| semver::Version::parse(ver).ok())
+        .ok_or_else(|| anyhow!("Failed parsing version"))?;
+
+    let date = json["published_at"]
+        .as_str()
+        .ok_or_else(|| anyhow!("Failed parsing published date"))?;
+
+    let date = chrono::DateTime::parse_from_rfc3339(date)
+        .expect("date-time from github is in rfc3339 format")
+        .into();
+
+    Ok(LatestRelease { version, date })
+}

--- a/server/src/validator.rs
+++ b/server/src/validator.rs
@@ -16,6 +16,8 @@
  *
  */
 
+use std::sync::Arc;
+
 use crate::alerts::rule::base::{NumericRule, StringRule};
 use crate::alerts::rule::{ColumnRule, ConsecutiveNumericRule, ConsecutiveStringRule};
 use crate::alerts::{Alerts, Rule};
@@ -158,18 +160,18 @@ pub fn query(query: &str, start_time: &str, end_time: &str) -> Result<Query, Que
 
     let stream_name = tokens[stream_name_index].to_string();
 
-    let schemas = STREAM_INFO.schema_map(&stream_name)?;
-
-    if schemas.is_empty() {
+    if !STREAM_INFO.stream_initialized(&stream_name)? {
         return Err(QueryValidationError::UninitializedStream);
     }
+
+    let merged_schema = Arc::new(STREAM_INFO.merged_schema(&stream_name)?);
 
     Ok(Query {
         stream_name: tokens[stream_name_index].to_string(),
         start,
         end,
         query: query.to_string(),
-        schemas,
+        merged_schema,
     })
 }
 

--- a/server/src/validator.rs
+++ b/server/src/validator.rs
@@ -164,15 +164,13 @@ pub fn query(query: &str, start_time: &str, end_time: &str) -> Result<Query, Que
         return Err(QueryValidationError::UninitializedStream);
     }
 
-    // Ok(Query {
-    //     stream_name: tokens[stream_name_index].to_string(),
-    //     start,
-    //     end,
-    //     query: query.to_string(),
-    //     schema,
-    // });
-
-    todo!();
+    Ok(Query {
+        stream_name: tokens[stream_name_index].to_string(),
+        start,
+        end,
+        query: query.to_string(),
+        schemas,
+    })
 }
 
 pub mod error {

--- a/server/src/validator.rs
+++ b/server/src/validator.rs
@@ -16,8 +16,6 @@
  *
  */
 
-use std::sync::Arc;
-
 use crate::alerts::rule::base::{NumericRule, StringRule};
 use crate::alerts::rule::{ColumnRule, ConsecutiveNumericRule, ConsecutiveStringRule};
 use crate::alerts::{Alerts, Rule};
@@ -160,18 +158,21 @@ pub fn query(query: &str, start_time: &str, end_time: &str) -> Result<Query, Que
 
     let stream_name = tokens[stream_name_index].to_string();
 
-    let schema = match STREAM_INFO.schema(&stream_name)? {
-        Some(schema) => Arc::new(schema),
-        None => return Err(QueryValidationError::UninitializedStream),
-    };
+    let schemas = STREAM_INFO.schema_map(&stream_name)?;
 
-    Ok(Query {
-        stream_name: tokens[stream_name_index].to_string(),
-        start,
-        end,
-        query: query.to_string(),
-        schema,
-    })
+    if schemas.len() == 0 {
+        return Err(QueryValidationError::UninitializedStream);
+    }
+
+    // Ok(Query {
+    //     stream_name: tokens[stream_name_index].to_string(),
+    //     start,
+    //     end,
+    //     query: query.to_string(),
+    //     schema,
+    // });
+
+    todo!();
 }
 
 pub mod error {

--- a/server/src/validator.rs
+++ b/server/src/validator.rs
@@ -160,7 +160,7 @@ pub fn query(query: &str, start_time: &str, end_time: &str) -> Result<Query, Que
 
     let schemas = STREAM_INFO.schema_map(&stream_name)?;
 
-    if schemas.len() == 0 {
+    if schemas.is_empty() {
         return Err(QueryValidationError::UninitializedStream);
     }
 


### PR DESCRIPTION
Fixes #195

### Description

This PR adds the capability to ingest events with varying schemas. During ingestion, events with the same schema are stored in separate files which are then merged into a single Parquet file. This allows for schema to dynamically change over time without having any impact on performance. 