### PR TITLE
Load metrics from stats on startup

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -82,6 +82,9 @@ async fn main() -> anyhow::Result<()> {
     // track all parquet files already in the data directory
     storage::CACHED_FILES.track_parquet();
 
+    // load data from stats back to prometheus metrics
+    metrics::load_from_global_stats();
+
     let (localsync_handler, mut localsync_outbox, localsync_inbox) = run_local_sync();
     let (mut remote_sync_handler, mut remote_sync_outbox, mut remote_sync_inbox) =
         object_store_sync();


### PR DESCRIPTION
### Description

Load event_ingested, event_ingested_size and storage_size into registered Prometheus metrics on server startup.

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
