### PR TITLE
Add extra AM labels

### DIFF
--- a/server/src/alerts/target.rs
+++ b/server/src/alerts/target.rs
@@ -319,7 +319,9 @@ impl CallableTarget for AlertManager {
           "labels": {
             "alertname": payload.alert_name,
             "stream": payload.stream,
-            "deployment_id": payload.deployment_id
+            "deployment_instance": payload.deployment_instance,
+            "deployment_id": payload.deployment_id,
+            "deployment_mode": payload.deployment_mode
             },
           "annotations": {
             "message": payload.message,


### PR DESCRIPTION
### Description
Added some extra labels about the parseable instance that is sending the alerts


This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
