### PR TITLE
Skip localfs lost+found folders

### DIFF
--- a/server/src/storage/localfs.rs
+++ b/server/src/storage/localfs.rs
@@ -157,7 +157,7 @@ impl ObjectStorage for LocalFS {
         let directories = directories
             .filter_map(|res| async {
                 let entry = res.ok()?;
-                if entry.file_type().await.ok()?.is_dir() {
+                if entry.file_type().await.ok()?.is_dir() && entry.file_name() != "lost+found" {
                     Some(LogStream {
                         name: entry
                             .path()


### PR DESCRIPTION
### Description
Skips the lost+found folder when using localfs as a stream.

<hr>

This PR has:
- [X] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
