### PR TITLE
Fix LocalFS stream listing

### DIFF
--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -57,7 +57,7 @@ use std::{
 };
 
 // metadata file names in a Stream prefix
-const STREAM_METADATA_FILE_NAME: &str = ".stream.json";
+pub(super) const STREAM_METADATA_FILE_NAME: &str = ".stream.json";
 pub(super) const PARSEABLE_METADATA_FILE_NAME: &str = ".parseable.json";
 const SCHEMA_FILE_NAME: &str = ".schema";
 const ALERT_FILE_NAME: &str = ".alert.json";


### PR DESCRIPTION
Fixes #318  .

### Description

Fix listing in local storage mode. Looks for `.stream.json` in the directory only then counts it as a valid stream candidate

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
