### PR TITLE
Fix get retention api

### DIFF
--- a/server/src/handlers/http.rs
+++ b/server/src/handlers/http.rs
@@ -151,8 +151,11 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
             web::resource("/stats").route(web::get().to(logstream::get_stats)),
         )
         .service(
-            // GET "/logstream/{logstream}/retention" ==> Set retention for given logstream
-            web::resource("/retention").route(web::put().to(logstream::put_retention)),
+            web::resource("/retention")
+                // PUT "/logstream/{logstream}/retention" ==> Set retention for given logstream
+                .route(web::put().to(logstream::put_retention))
+                // GET "/logstream/{logstream}/retention" ==> Get retention for given logstream
+                .route(web::get().to(logstream::get_retention)),
         );
 
     cfg.service(

--- a/server/src/handlers/http/logstream.rs
+++ b/server/src/handlers/http/logstream.rs
@@ -183,6 +183,23 @@ pub async fn put_alert(
     ))
 }
 
+pub async fn get_retention(req: HttpRequest) -> Result<impl Responder, StreamError> {
+    let stream_name: String = req.match_info().get("logstream").unwrap().parse().unwrap();
+    let objectstore = CONFIG.storage().get_object_store();
+
+    if !objectstore.stream_exists(&stream_name).await? {
+        return Err(StreamError::StreamNotFound(stream_name.to_string()));
+    }
+
+    let retention = CONFIG
+        .storage()
+        .get_object_store()
+        .get_retention(&stream_name)
+        .await?;
+
+    Ok((web::Json(retention), StatusCode::OK))
+}
+
 pub async fn put_retention(
     req: HttpRequest,
     body: web::Json<serde_json::Value>,


### PR DESCRIPTION
Fixes #349 

### Description 

Adds a get api to list the retention for a stream

<hr>

This PR has:
- [X] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
