### PR TITLE
Fix demo url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Parseable is written in Rust and uses Apache Arrow and Parquet as underlying dat
 
 Parseable consumes up to **_~80% lower memory_** and **_~50% lower CPU_** than Elastic for similar ingestion throughput.
 
-- [Parseable UI Demo (Credentials: admin,admin) ↗︎](https://www.parseable.io/docs/)
+- [Parseable UI Demo (Credentials: admin,admin) ↗︎](https://demo.parseable.io)
 - [Grafana Dashboard Demo ↗︎](http://demo.parseable.io:3000/dashboards)
 
 ## :rocket: Features


### PR DESCRIPTION
### Description

README.md contained the wrong URL for the UI Demo link. This change fixes that.

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
