### PR TITLE
Use aws_profile to fetch credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2970,7 +2970,7 @@ dependencies = [
 
 [[package]]
 name = "parseable"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/server/src/storage/s3.rs
+++ b/server/src/storage/s3.rs
@@ -88,7 +88,7 @@ pub struct S3Config {
     // Use aws profile name to fetch credentials
     #[arg(
         long,
-        env = "P_S3_PROFILE_NAME",
+        env = "P_AWS_PROFILE_NAME",
         value_name = "profile",
         conflicts_with_all = ["access_key_id", "secret_key"],
         required = false
@@ -129,6 +129,24 @@ pub struct S3Config {
         default_value = "false"
     )]
     pub skip_tls: bool,
+
+    /// Set client to fallback to imdsv1
+    #[arg(
+        long,
+        env = "P_AWS_IMDSV1_FALLBACK",
+        value_name = "bool",
+        default_value = "false"
+    )]
+    pub imdsv1_fallback: bool,
+
+    /// Set instance metadata endpoint to use.
+    #[arg(
+        long,
+        env = "P_AWS_METADATA_ENDPOINT",
+        value_name = "url",
+        required = false
+    )]
+    pub metadata_endpoint: Option<String>,
 }
 
 impl S3Config {
@@ -148,6 +166,10 @@ impl S3Config {
             .with_virtual_hosted_style_request(!self.use_path_style)
             .with_allow_http(true);
 
+        if self.set_checksum {
+            builder = builder.with_checksum_algorithm(Checksum::SHA256)
+        }
+
         if let Some((access_key, secret_key)) =
             self.access_key_id.as_ref().zip(self.secret_key.as_ref())
         {
@@ -160,8 +182,12 @@ impl S3Config {
             builder = builder.with_profile(profile);
         }
 
-        if self.set_checksum {
-            builder = builder.with_checksum_algorithm(Checksum::SHA256)
+        if self.imdsv1_fallback {
+            builder = builder.with_imdsv1_fallback()
+        }
+
+        if let Some(metadata_endpoint) = &self.metadata_endpoint {
+            builder = builder.with_metadata_endpoint(metadata_endpoint)
         }
 
         builder.with_client_options(client_options)


### PR DESCRIPTION
Fixes #372.

### Description

Alternate method to fetch credentials on AWS. 

AwsBuilder's `with_profile` builder method name is exposed as a configuration option with env `P_S3_PROFILE_NAME`. This option conflicts with `P_S3_ACCESS_KEY` and `P_S3_SECRET_KEY`

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
