### PR TITLE
Retention config shouldn't need logstream to be initialized

### DIFF
--- a/server/src/handlers/http/logstream.rs
+++ b/server/src/handlers/http/logstream.rs
@@ -212,10 +212,6 @@ pub async fn put_retention(
         Err(err) => return Err(StreamError::InvalidRetentionConfig(err)),
     };
 
-    if !STREAM_INFO.stream_initialized(&stream_name)? {
-        return Err(StreamError::UninitializedLogstream);
-    }
-
     CONFIG
         .storage()
         .get_object_store()


### PR DESCRIPTION
### Description

It is common for users to create stream and set the retention (and be done with initial config) before sending logs to the log stream.

Accordingly we're going to add support in Helm chart to declaratively create logstream and set retention.

To allow that setup we need to ensure log stream retention can be set before log stream has events (i.e. initialized)


This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
