### PR TITLE
Try default decoder option

### DIFF
--- a/server/src/event/format/json.rs
+++ b/server/src/event/format/json.rs
@@ -99,13 +99,9 @@ impl EventFormat for Event {
 
     // Convert the Data type (defined above) to arrow record batch
     fn decode(data: Self::Data, schema: Arc<Schema>) -> Result<RecordBatch, anyhow::Error> {
-        let array_capacity = round_upto_multiple_of_64(data.len());
         let value_iter: &mut (dyn Iterator<Item = Value>) = &mut data.into_iter();
 
-        let reader = Decoder::new(
-            schema,
-            DecoderOptions::new().with_batch_size(array_capacity),
-        );
+        let reader = Decoder::new(schema, DecoderOptions::new());
         match reader.next_batch(&mut value_iter.map(Ok)) {
             Ok(Some(recordbatch)) => Ok(recordbatch),
             Err(err) => Err(anyhow!("Failed to create recordbatch due to {:?}", err)),


### PR DESCRIPTION
### Description

When creating recordbatch use default decoder option instead of rounding to next multiple of 64. Default decoder option is 1024. This was changed in event refactor, changing it back to 1024 might make better memory alignment for disk writes

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
