### PR TITLE
Query staging data

### DIFF
--- a/server/src/event/writer.rs
+++ b/server/src/event/writer.rs
@@ -18,21 +18,42 @@
  */
 
 mod file_writer;
+mod mem_writer;
 
 use std::{
     collections::HashMap,
-    sync::{Mutex, RwLock},
+    sync::{Arc, Mutex, RwLock},
 };
 
-use self::{errors::StreamWriterError, file_writer::FileWriter};
+use self::{errors::StreamWriterError, file_writer::FileWriter, mem_writer::MemWriter};
 use arrow_array::RecordBatch;
+use arrow_schema::Schema;
 use derive_more::{Deref, DerefMut};
 use once_cell::sync::Lazy;
 
 pub static STREAM_WRITERS: Lazy<WriterTable> = Lazy::new(WriterTable::default);
 
+#[derive(Default)]
+pub struct Writer {
+    pub mem: MemWriter<1024>,
+    pub disk: FileWriter,
+}
+
+impl Writer {
+    fn push(
+        &mut self,
+        stream_name: &str,
+        schema_key: &str,
+        rb: RecordBatch,
+    ) -> Result<(), StreamWriterError> {
+        self.disk.push(stream_name, schema_key, &rb)?;
+        self.mem.push(schema_key, rb);
+        Ok(())
+    }
+}
+
 #[derive(Deref, DerefMut, Default)]
-pub struct WriterTable(RwLock<HashMap<String, Mutex<FileWriter>>>);
+pub struct WriterTable(RwLock<HashMap<String, Mutex<Writer>>>);
 
 impl WriterTable {
     // append to a existing stream
@@ -49,7 +70,7 @@ impl WriterTable {
                 stream_writer
                     .lock()
                     .unwrap()
-                    .push(stream_name, schema_key, &record)?;
+                    .push(stream_name, schema_key, record)?;
             }
             None => {
                 drop(hashmap_guard);
@@ -60,10 +81,10 @@ impl WriterTable {
                     writer
                         .lock()
                         .unwrap()
-                        .push(stream_name, schema_key, &record)?;
+                        .push(stream_name, schema_key, record)?;
                 } else {
-                    let mut writer = FileWriter::default();
-                    writer.push(stream_name, schema_key, &record)?;
+                    let mut writer = Writer::default();
+                    writer.push(stream_name, schema_key, record)?;
                     map.insert(stream_name.to_owned(), Mutex::new(writer));
                 }
             }
@@ -81,8 +102,26 @@ impl WriterTable {
         drop(table);
         for writer in map.into_values() {
             let writer = writer.into_inner().unwrap();
-            writer.close_all();
+            writer.disk.close_all();
         }
+    }
+
+    pub fn recordbatches_cloned(
+        &self,
+        stream_name: &str,
+        schema: &Arc<Schema>,
+    ) -> Option<Vec<RecordBatch>> {
+        let records = self
+            .0
+            .read()
+            .unwrap()
+            .get(stream_name)?
+            .lock()
+            .unwrap()
+            .mem
+            .recordbatch_cloned(schema);
+
+        Some(records)
     }
 }
 

--- a/server/src/event/writer.rs
+++ b/server/src/event/writer.rs
@@ -38,7 +38,7 @@ pub static STREAM_WRITERS: Lazy<WriterTable> = Lazy::new(WriterTable::default);
 
 #[derive(Default)]
 pub struct Writer {
-    pub mem: MemWriter<1024>,
+    pub mem: MemWriter<16384>,
     pub disk: FileWriter,
 }
 

--- a/server/src/event/writer/file_writer.rs
+++ b/server/src/event/writer/file_writer.rs
@@ -17,17 +17,15 @@
  *
  */
 
-use arrow_array::{RecordBatch, TimestampMillisecondArray};
-use arrow_ipc::writer::StreamWriter;
-use chrono::Utc;
-use derive_more::{Deref, DerefMut};
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
 use std::path::PathBuf;
-use std::sync::Arc;
+
+use arrow_array::RecordBatch;
+use arrow_ipc::writer::StreamWriter;
+use derive_more::{Deref, DerefMut};
 
 use crate::storage::staging::StorageDir;
-use crate::utils;
 
 use super::errors::StreamWriterError;
 
@@ -47,24 +45,17 @@ impl FileWriter {
         schema_key: &str,
         record: &RecordBatch,
     ) -> Result<(), StreamWriterError> {
-        let record = utils::arrow::replace_columns(
-            record.schema(),
-            record,
-            &[0],
-            &[Arc::new(get_timestamp_array(record.num_rows()))],
-        );
-
         match self.get_mut(schema_key) {
             Some(writer) => {
                 writer
                     .writer
-                    .write(&record)
+                    .write(record)
                     .map_err(StreamWriterError::Writer)?;
             }
             // entry is not present thus we create it
             None => {
                 // this requires mutable borrow of the map so we drop this read lock and wait for write lock
-                let (path, writer) = init_new_stream_writer_file(stream_name, schema_key, &record)?;
+                let (path, writer) = init_new_stream_writer_file(stream_name, schema_key, record)?;
                 self.insert(
                     schema_key.to_owned(),
                     ArrowWriter {
@@ -83,10 +74,6 @@ impl FileWriter {
             _ = writer.writer.finish();
         }
     }
-}
-
-fn get_timestamp_array(size: usize) -> TimestampMillisecondArray {
-    TimestampMillisecondArray::from_value(Utc::now().timestamp_millis(), size)
 }
 
 fn init_new_stream_writer_file(

--- a/server/src/event/writer/mem_writer.rs
+++ b/server/src/event/writer/mem_writer.rs
@@ -1,0 +1,120 @@
+/*
+ * Parseable Server (C) 2022 - 2023 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use std::{collections::HashSet, sync::Arc};
+
+use arrow_array::RecordBatch;
+use arrow_schema::Schema;
+use arrow_select::concat::concat_batches;
+use itertools::Itertools;
+
+use crate::utils::arrow::adapt_batch;
+
+/// Structure to keep recordbatches in memory.
+///
+/// Any new schema is updated in the schema map.
+/// Recordbatches are pushed to mutable buffer first and then concated together and pushed to read buffer
+#[derive(Debug)]
+pub struct MemWriter<const N: usize> {
+    schema: Schema,
+    // for checking uniqueness of schema
+    schema_map: HashSet<String>,
+    read_buffer: Vec<RecordBatch>,
+    mutable_buffer: MutableBuffer<N>,
+}
+
+impl<const N: usize> Default for MemWriter<N> {
+    fn default() -> Self {
+        Self {
+            schema: Schema::empty(),
+            schema_map: HashSet::default(),
+            read_buffer: Vec::default(),
+            mutable_buffer: MutableBuffer::default(),
+        }
+    }
+}
+
+impl<const N: usize> MemWriter<N> {
+    pub fn push(&mut self, schema_key: &str, rb: RecordBatch) {
+        if !self.schema_map.contains(schema_key) {
+            self.schema_map.insert(schema_key.to_owned());
+            self.schema = Schema::try_merge([self.schema.clone(), (*rb.schema()).clone()]).unwrap();
+        }
+
+        if let Some(record) = self.mutable_buffer.push(rb) {
+            let record = concat_records(&Arc::new(self.schema.clone()), &record);
+            self.read_buffer.push(record);
+        }
+    }
+
+    pub fn recordbatch_cloned(&self, schema: &Arc<Schema>) -> Vec<RecordBatch> {
+        let mut read_buffer = self.read_buffer.clone();
+        if self.mutable_buffer.rows > 0 {
+            let rb = concat_records(schema, &self.mutable_buffer.inner);
+            read_buffer.push(rb)
+        }
+
+        read_buffer
+            .into_iter()
+            .map(|rb| adapt_batch(schema, &rb))
+            .collect()
+    }
+}
+
+fn concat_records(schema: &Arc<Schema>, record: &[RecordBatch]) -> RecordBatch {
+    let records = record.iter().map(|x| adapt_batch(schema, x)).collect_vec();
+    let record = concat_batches(schema, records.iter()).unwrap();
+    record
+}
+
+#[derive(Debug, Default)]
+struct MutableBuffer<const N: usize> {
+    pub inner: Vec<RecordBatch>,
+    pub rows: usize,
+}
+
+impl<const N: usize> MutableBuffer<N> {
+    fn push(&mut self, rb: RecordBatch) -> Option<Vec<RecordBatch>> {
+        if self.rows + rb.num_rows() >= N {
+            let left = N - self.rows;
+            let right = rb.num_rows() - left;
+            let left_slice = rb.slice(0, left);
+            let right_slice = if left < rb.num_rows() {
+                Some(rb.slice(left, right))
+            } else {
+                None
+            };
+            self.inner.push(left_slice);
+            // take all records
+            let src = Vec::with_capacity(self.inner.len());
+            let inner = std::mem::replace(&mut self.inner, src);
+            self.rows = 0;
+
+            if let Some(right_slice) = right_slice {
+                self.rows = right_slice.num_rows();
+                self.inner.push(right_slice);
+            }
+
+            Some(inner)
+        } else {
+            self.rows += rb.num_rows();
+            self.inner.push(rb);
+            None
+        }
+    }
+}

--- a/server/src/query.rs
+++ b/server/src/query.rs
@@ -17,6 +17,7 @@
  */
 
 mod filter_optimizer;
+mod table_provider;
 
 use chrono::TimeZone;
 use chrono::{DateTime, Utc};
@@ -30,19 +31,21 @@ use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::prelude::*;
 use itertools::Itertools;
 use serde_json::Value;
-use std::path::Path;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use sysinfo::{System, SystemExt};
 
 use crate::event::DEFAULT_TIMESTAMP_KEY;
 use crate::option::CONFIG;
-use crate::storage::ObjectStorageError;
 use crate::storage::{ObjectStorage, OBJECT_STORE_DATA_GRANULARITY};
+use crate::storage::{ObjectStorageError, StorageDir};
 use crate::utils::TimePeriod;
 use crate::validator;
 
 use self::error::{ExecuteError, ParseError};
 use self::filter_optimizer::FilterOptimizerRule;
+use self::table_provider::QueryTableProvider;
 
 type Key = &'static str;
 fn get_value(value: &Value, key: Key) -> Result<&str, Key> {
@@ -124,30 +127,15 @@ impl Query {
         storage: Arc<dyn ObjectStorage + Send>,
     ) -> Result<(Vec<RecordBatch>, Vec<String>), ExecuteError> {
         let ctx = self.create_session_context();
-        let prefixes = storage.query_prefixes(self.get_prefixes());
+        let remote_listing_table = self._remote_query(storage)?;
+        let staging_prefixes = get_staging_prefixes(&self.stream_name, self.start, self.end);
+        let table = QueryTableProvider::new(
+            staging_prefixes.into_values().collect(),
+            remote_listing_table,
+            self.schema.clone(),
+        );
 
-        if prefixes.is_empty() {
-            return Ok((Vec::new(), Vec::new()));
-        }
-
-        let file_format = ParquetFormat::default().with_enable_pruning(Some(true));
-        let listing_options = ListingOptions {
-            file_extension: ".parquet".to_string(),
-            file_sort_order: vec![vec![col(DEFAULT_TIMESTAMP_KEY).sort(true, false)]],
-            infinite_source: false,
-            format: Arc::new(file_format),
-            table_partition_cols: vec![],
-            collect_stat: true,
-            target_partitions: 32,
-        };
-
-        let config = ListingTableConfig::new_with_multi_paths(prefixes)
-            .with_listing_options(listing_options)
-            .with_schema(self.schema.clone());
-
-        let table = Arc::new(ListingTable::try_new(config)?);
-
-        ctx.register_table(&*self.stream_name, table)
+        ctx.register_table(&*self.stream_name, Arc::new(table))
             .map_err(ObjectStorageError::DataFusionError)?;
         // execute the query and collect results
         let df = ctx.sql(self.query.as_str()).await?;
@@ -165,15 +153,51 @@ impl Query {
 
         Ok((results, fields))
     }
+
+    fn _remote_query(
+        &self,
+        storage: Arc<dyn ObjectStorage + Send>,
+    ) -> Result<Option<Arc<ListingTable>>, ExecuteError> {
+        let prefixes = storage.query_prefixes(self.get_prefixes());
+        if prefixes.is_empty() {
+            return Ok(None);
+        }
+        let file_format = ParquetFormat::default().with_enable_pruning(Some(true));
+        let file_sort_order = vec![vec![col(DEFAULT_TIMESTAMP_KEY).sort(true, false)]];
+        let listing_options = ListingOptions {
+            file_extension: ".parquet".to_string(),
+            file_sort_order,
+            infinite_source: false,
+            format: Arc::new(file_format),
+            table_partition_cols: vec![],
+            collect_stat: true,
+            target_partitions: 32,
+        };
+        let config = ListingTableConfig::new_with_multi_paths(prefixes)
+            .with_listing_options(listing_options)
+            .with_schema(self.schema.clone());
+
+        let listing_table = Arc::new(ListingTable::try_new(config)?);
+        Ok(Some(listing_table))
+    }
 }
 
-#[allow(unused)]
+fn get_staging_prefixes(
+    stream_name: &str,
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+) -> HashMap<PathBuf, Vec<PathBuf>> {
+    let dir = StorageDir::new(stream_name);
+    let mut files = dir.arrow_files_grouped_by_time();
+    files.retain(|k, _| path_intersects_query(k, start, end));
+    files
+}
+
 fn path_intersects_query(path: &Path, starttime: DateTime<Utc>, endtime: DateTime<Utc>) -> bool {
     let time = time_from_path(path);
     starttime <= time && time <= endtime
 }
 
-#[allow(unused)]
 fn time_from_path(path: &Path) -> DateTime<Utc> {
     let prefix = path
         .file_name()

--- a/server/src/query/table_provider.rs
+++ b/server/src/query/table_provider.rs
@@ -189,7 +189,7 @@ impl<T: Iterator<Item = RecordBatch>> Iterator for ConcatIterator<T> {
         self.buffer.clear();
 
         //return resulting batch
-        return Some(res);
+        Some(res)
     }
 }
 

--- a/server/src/query/table_provider.rs
+++ b/server/src/query/table_provider.rs
@@ -25,7 +25,7 @@ use datafusion::datasource::streaming::{PartitionStream, StreamingTable};
 use datafusion::datasource::TableProvider;
 use datafusion::error::DataFusionError;
 use datafusion::execution::context::SessionState;
-use datafusion::logical_expr::TableType;
+use datafusion::logical_expr::{TableProviderFilterPushDown, TableType};
 use datafusion::physical_plan::empty::EmptyExec;
 use datafusion::physical_plan::union::UnionExec;
 use datafusion::physical_plan::{ExecutionPlan, RecordBatchStream};
@@ -115,6 +115,16 @@ impl TableProvider for QueryTableProvider {
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
         self.create_physical_plan(ctx, projection, filters, limit)
             .await
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> datafusion::error::Result<Vec<TableProviderFilterPushDown>> {
+        Ok(filters
+            .iter()
+            .map(|_| TableProviderFilterPushDown::Inexact)
+            .collect())
     }
 }
 

--- a/server/src/query/table_provider.rs
+++ b/server/src/query/table_provider.rs
@@ -16,48 +16,46 @@
  *
  */
 
-use arrow_select::concat::concat;
 use async_trait::async_trait;
 use datafusion::arrow::datatypes::{Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::datasource::listing::ListingTable;
-use datafusion::datasource::streaming::{PartitionStream, StreamingTable};
-use datafusion::datasource::TableProvider;
+
+use datafusion::datasource::{MemTable, TableProvider};
 use datafusion::error::DataFusionError;
 use datafusion::execution::context::SessionState;
 use datafusion::logical_expr::{TableProviderFilterPushDown, TableType};
 use datafusion::physical_plan::empty::EmptyExec;
 use datafusion::physical_plan::union::UnionExec;
-use datafusion::physical_plan::{ExecutionPlan, RecordBatchStream};
+use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::Expr;
-use futures_util::{Stream, StreamExt};
 
 use std::any::Any;
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::vec;
 
-use crate::utils::arrow::MergedRecordReader;
-
 pub struct QueryTableProvider {
-    // ( arrow files ) sorted by time asc
-    staging_arrows: Vec<Vec<PathBuf>>,
+    staging: Option<MemTable>,
     // remote table
     storage: Option<Arc<ListingTable>>,
     schema: Arc<Schema>,
 }
 
 impl QueryTableProvider {
-    pub fn new(
-        staging_arrows: Vec<Vec<PathBuf>>,
+    pub fn try_new(
+        staging: Option<Vec<RecordBatch>>,
         storage: Option<Arc<ListingTable>>,
         schema: Arc<Schema>,
-    ) -> Self {
-        Self {
-            staging_arrows,
+    ) -> Result<Self, DataFusionError> {
+        let memtable = staging
+            .map(|records| MemTable::try_new(schema.clone(), vec![records]))
+            .transpose()?;
+
+        Ok(Self {
+            staging: memtable,
             storage,
             schema,
-        }
+        })
     }
 
     async fn create_physical_plan(
@@ -68,10 +66,11 @@ impl QueryTableProvider {
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
         let mut exec = vec![];
-        let local_table = get_streaming_table(self.staging_arrows.clone(), self.schema.clone());
-        if let Some(table) = local_table {
+
+        if let Some(table) = &self.staging {
             exec.push(table.scan(ctx, projection, filters, limit).await?)
         }
+
         if let Some(storage_listing) = self.storage.clone() {
             exec.push(
                 storage_listing
@@ -129,138 +128,5 @@ impl TableProvider for QueryTableProvider {
             .iter()
             .map(|_| TableProviderFilterPushDown::Inexact)
             .collect())
-    }
-}
-
-// create streaming table from arrow files on staging.
-// partitions are created in sorted order.
-// if partition cannot be created mid way then only latest available partitions are returned
-fn get_streaming_table(
-    staging_arrow: Vec<Vec<PathBuf>>,
-    schema: Arc<Schema>,
-) -> Option<StreamingTable> {
-    let mut partitions: Vec<Arc<dyn PartitionStream>> = Vec::new();
-
-    for files in staging_arrow {
-        let partition = ArrowFilesPartition {
-            schema: schema.clone(),
-            files,
-        };
-        partitions.push(Arc::new(partition))
-    }
-
-    if partitions.is_empty() {
-        None
-    } else {
-        //todo remove unwrap
-        Some(StreamingTable::try_new(schema, partitions).unwrap())
-    }
-}
-
-struct ConcatIterator<T: Iterator<Item = RecordBatch>> {
-    buffer: Vec<RecordBatch>,
-    schema: Arc<Schema>,
-    max_size: usize,
-    iter: T,
-}
-
-impl<T: Iterator<Item = RecordBatch>> Iterator for ConcatIterator<T> {
-    type Item = RecordBatch;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let mut size = 0;
-
-        while size < self.max_size {
-            if let Some(rb) = self.iter.next() {
-                size += rb.num_rows();
-                self.buffer.push(rb);
-            } else {
-                break;
-            }
-        }
-
-        if self.buffer.is_empty() {
-            return None;
-        }
-
-        // create new batch
-        let field_num = self.schema.fields().len();
-        let mut arrays = Vec::with_capacity(field_num);
-        for i in 0..field_num {
-            let array = concat(
-                &self
-                    .buffer
-                    .iter()
-                    .map(|batch| batch.column(i).as_ref())
-                    .collect::<Vec<_>>(),
-            )
-            .expect("all records are of same schema and valid");
-            arrays.push(array);
-        }
-        let res = RecordBatch::try_new(self.schema.clone(), arrays).unwrap();
-
-        // clear buffer
-        self.buffer.clear();
-
-        //return resulting batch
-        Some(res)
-    }
-}
-
-struct ArrowRecordBatchStream<T: Stream<Item = RecordBatch> + Unpin> {
-    schema: Arc<Schema>,
-    stream: T,
-}
-
-impl<T> Stream for ArrowRecordBatchStream<T>
-where
-    T: Stream<Item = RecordBatch> + Unpin,
-{
-    type Item = Result<RecordBatch, DataFusionError>;
-
-    fn poll_next(
-        self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Self::Item>> {
-        self.get_mut().stream.poll_next_unpin(cx).map(|x| x.map(Ok))
-    }
-}
-
-impl<T> RecordBatchStream for ArrowRecordBatchStream<T>
-where
-    T: Stream<Item = RecordBatch> + Unpin,
-{
-    fn schema(&self) -> SchemaRef {
-        self.schema.clone()
-    }
-}
-
-struct ArrowFilesPartition {
-    schema: Arc<Schema>,
-    files: Vec<PathBuf>,
-}
-
-impl PartitionStream for ArrowFilesPartition {
-    fn schema(&self) -> &SchemaRef {
-        &self.schema
-    }
-
-    fn execute(
-        &self,
-        _ctx: Arc<datafusion::execution::TaskContext>,
-    ) -> datafusion::physical_plan::SendableRecordBatchStream {
-        let reader = MergedRecordReader::try_new(&self.files).unwrap();
-        let reader = reader.merged_iter(self.schema.clone());
-        let reader = ConcatIterator {
-            buffer: Vec::new(),
-            schema: self.schema.clone(),
-            max_size: 10000,
-            iter: reader,
-        };
-
-        Box::pin(ArrowRecordBatchStream {
-            schema: self.schema.clone(),
-            stream: futures::stream::iter(reader),
-        })
     }
 }

--- a/server/src/query/table_provider.rs
+++ b/server/src/query/table_provider.rs
@@ -80,7 +80,7 @@ impl QueryTableProvider {
             );
         }
 
-        let exec: Arc<dyn ExecutionPlan> = if exec.len() == 0 {
+        let exec: Arc<dyn ExecutionPlan> = if exec.is_empty() {
             Arc::new(EmptyExec::new(false, self.schema.clone()))
         } else if exec.len() == 1 {
             exec.pop().unwrap()

--- a/server/src/query/table_provider.rs
+++ b/server/src/query/table_provider.rs
@@ -82,7 +82,7 @@ impl QueryTableProvider {
 
         let exec: Arc<dyn ExecutionPlan> = if exec.is_empty() {
             let schema = match projection {
-                Some(projection) => Arc::new(self.schema.project(&projection)?),
+                Some(projection) => Arc::new(self.schema.project(projection)?),
                 None => self.schema.clone(),
             };
             Arc::new(EmptyExec::new(false, schema))

--- a/server/src/query/table_provider.rs
+++ b/server/src/query/table_provider.rs
@@ -81,7 +81,11 @@ impl QueryTableProvider {
         }
 
         let exec: Arc<dyn ExecutionPlan> = if exec.is_empty() {
-            Arc::new(EmptyExec::new(false, self.schema.clone()))
+            let schema = match projection {
+                Some(projection) => Arc::new(self.schema.project(&projection)?),
+                None => self.schema.clone(),
+            };
+            Arc::new(EmptyExec::new(false, schema))
         } else if exec.len() == 1 {
             exec.pop().unwrap()
         } else {

--- a/server/src/query/table_provider.rs
+++ b/server/src/query/table_provider.rs
@@ -1,7 +1,24 @@
+/*
+ * Parseable Server (C) 2022 - 2023 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 use arrow_select::concat::concat;
 use async_trait::async_trait;
 use datafusion::arrow::datatypes::{Schema, SchemaRef};
-
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::datasource::listing::ListingTable;
 use datafusion::datasource::streaming::{PartitionStream, StreamingTable};
@@ -14,6 +31,7 @@ use datafusion::physical_plan::union::UnionExec;
 use datafusion::physical_plan::{ExecutionPlan, RecordBatchStream};
 use datafusion::prelude::Expr;
 use futures_util::{Stream, StreamExt};
+
 use std::any::Any;
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/server/src/query/table_provider.rs
+++ b/server/src/query/table_provider.rs
@@ -1,0 +1,234 @@
+use arrow_select::concat::concat;
+use async_trait::async_trait;
+use datafusion::arrow::datatypes::{Schema, SchemaRef};
+
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::datasource::listing::ListingTable;
+use datafusion::datasource::streaming::{PartitionStream, StreamingTable};
+use datafusion::datasource::TableProvider;
+use datafusion::error::DataFusionError;
+use datafusion::execution::context::SessionState;
+use datafusion::logical_expr::TableType;
+use datafusion::physical_plan::empty::EmptyExec;
+use datafusion::physical_plan::union::UnionExec;
+use datafusion::physical_plan::{ExecutionPlan, RecordBatchStream};
+use datafusion::prelude::Expr;
+use futures_util::{Stream, StreamExt};
+use std::any::Any;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::vec;
+
+use crate::utils::arrow::MergedRecordReader;
+
+pub struct QueryTableProvider {
+    // ( arrow files ) sorted by time asc
+    staging_arrows: Vec<Vec<PathBuf>>,
+    // remote table
+    storage: Option<Arc<ListingTable>>,
+    schema: Arc<Schema>,
+}
+
+impl QueryTableProvider {
+    pub fn new(
+        staging_arrows: Vec<Vec<PathBuf>>,
+        storage: Option<Arc<ListingTable>>,
+        schema: Arc<Schema>,
+    ) -> Self {
+        Self {
+            staging_arrows,
+            storage,
+            schema,
+        }
+    }
+
+    async fn create_physical_plan(
+        &self,
+        ctx: &SessionState,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        let mut exec = vec![];
+        let local_table = get_streaming_table(self.staging_arrows.clone(), self.schema.clone());
+        if let Some(table) = local_table {
+            exec.push(table.scan(ctx, projection, filters, limit).await?)
+        }
+        if let Some(storage_listing) = self.storage.clone() {
+            exec.push(
+                storage_listing
+                    .scan(ctx, projection, filters, limit)
+                    .await?,
+            );
+        }
+
+        let exec: Arc<dyn ExecutionPlan> = if exec.len() == 0 {
+            Arc::new(EmptyExec::new(false, self.schema.clone()))
+        } else if exec.len() == 1 {
+            exec.pop().unwrap()
+        } else {
+            Arc::new(UnionExec::new(exec))
+        };
+
+        Ok(exec)
+    }
+}
+
+#[async_trait]
+impl TableProvider for QueryTableProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        ctx: &SessionState,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        self.create_physical_plan(ctx, projection, filters, limit)
+            .await
+    }
+}
+
+// create streaming table from arrow files on staging.
+// partitions are created in sorted order.
+// if partition cannot be created mid way then only latest available partitions are returned
+fn get_streaming_table(
+    staging_arrow: Vec<Vec<PathBuf>>,
+    schema: Arc<Schema>,
+) -> Option<StreamingTable> {
+    let mut partitions: Vec<Arc<dyn PartitionStream>> = Vec::new();
+
+    for files in staging_arrow {
+        let partition = ArrowFilesPartition {
+            schema: schema.clone(),
+            files,
+        };
+        partitions.push(Arc::new(partition))
+    }
+
+    if partitions.is_empty() {
+        None
+    } else {
+        //todo remove unwrap
+        Some(StreamingTable::try_new(schema, partitions).unwrap())
+    }
+}
+
+struct ConcatIterator<T: Iterator<Item = RecordBatch>> {
+    buffer: Vec<RecordBatch>,
+    schema: Arc<Schema>,
+    max_size: usize,
+    iter: T,
+}
+
+impl<T: Iterator<Item = RecordBatch>> Iterator for ConcatIterator<T> {
+    type Item = RecordBatch;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut size = 0;
+
+        while size < self.max_size {
+            if let Some(rb) = self.iter.next() {
+                size += rb.num_rows();
+                self.buffer.push(rb);
+            } else {
+                break;
+            }
+        }
+
+        if self.buffer.len() == 0 {
+            return None;
+        }
+
+        // create new batch
+        let field_num = self.schema.fields().len();
+        let mut arrays = Vec::with_capacity(field_num);
+        for i in 0..field_num {
+            let array = concat(
+                &self
+                    .buffer
+                    .iter()
+                    .map(|batch| batch.column(i).as_ref())
+                    .collect::<Vec<_>>(),
+            )
+            .expect("all records are of same schema and valid");
+            arrays.push(array);
+        }
+        let res = RecordBatch::try_new(self.schema.clone(), arrays).unwrap();
+
+        // clear buffer
+        self.buffer.clear();
+
+        //return resulting batch
+        return Some(res);
+    }
+}
+
+struct ArrowRecordBatchStream<T: Stream<Item = RecordBatch> + Unpin> {
+    schema: Arc<Schema>,
+    stream: T,
+}
+
+impl<T> Stream for ArrowRecordBatchStream<T>
+where
+    T: Stream<Item = RecordBatch> + Unpin,
+{
+    type Item = Result<RecordBatch, DataFusionError>;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.get_mut().stream.poll_next_unpin(cx).map(|x| x.map(Ok))
+    }
+}
+
+impl<T> RecordBatchStream for ArrowRecordBatchStream<T>
+where
+    T: Stream<Item = RecordBatch> + Unpin,
+{
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
+struct ArrowFilesPartition {
+    schema: Arc<Schema>,
+    files: Vec<PathBuf>,
+}
+
+impl PartitionStream for ArrowFilesPartition {
+    fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    fn execute(
+        &self,
+        _ctx: Arc<datafusion::execution::TaskContext>,
+    ) -> datafusion::physical_plan::SendableRecordBatchStream {
+        let reader = MergedRecordReader::try_new(&self.files).unwrap();
+        let reader = reader.merged_iter(self.schema.clone());
+        let reader = ConcatIterator {
+            buffer: Vec::new(),
+            schema: self.schema.clone(),
+            max_size: 10000,
+            iter: reader,
+        };
+
+        Box::pin(ArrowRecordBatchStream {
+            schema: self.schema.clone(),
+            stream: futures::stream::iter(reader),
+        })
+    }
+}

--- a/server/src/query/table_provider.rs
+++ b/server/src/query/table_provider.rs
@@ -147,7 +147,7 @@ impl<T: Iterator<Item = RecordBatch>> Iterator for ConcatIterator<T> {
             }
         }
 
-        if self.buffer.len() == 0 {
+        if self.buffer.is_empty() {
             return None;
         }
 

--- a/server/src/storage/staging.rs
+++ b/server/src/storage/staging.rs
@@ -99,7 +99,6 @@ impl StorageDir {
         paths
     }
 
-    #[allow(unused)]
     pub fn arrow_files_grouped_by_time(&self) -> HashMap<PathBuf, Vec<PathBuf>> {
         // hashmap <time, vec[paths]>
         let mut grouped_arrow_file: HashMap<PathBuf, Vec<PathBuf>> = HashMap::new();
@@ -206,7 +205,7 @@ pub fn convert_disk_files_to_parquet(
         let schema = Arc::new(merged_schema);
         let mut writer = ArrowWriter::try_new(parquet_file, schema.clone(), Some(props))?;
 
-        for ref record in record_reader.merged_iter(&schema) {
+        for ref record in record_reader.merged_iter(schema) {
             writer.write(record)?;
         }
 

--- a/server/src/storage/staging.rs
+++ b/server/src/storage/staging.rs
@@ -99,6 +99,7 @@ impl StorageDir {
         paths
     }
 
+    #[allow(dead_code)]
     pub fn arrow_files_grouped_by_time(&self) -> HashMap<PathBuf, Vec<PathBuf>> {
         // hashmap <time, vec[paths]>
         let mut grouped_arrow_file: HashMap<PathBuf, Vec<PathBuf>> = HashMap::new();

--- a/server/src/utils/arrow/batch_adapter.rs
+++ b/server/src/utils/arrow/batch_adapter.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 // log stream schema.
 // This is necessary because all the record batches in a log
 // stream need to have all the fields.
-pub fn adapt_batch(table_schema: &Schema, batch: RecordBatch) -> RecordBatch {
+pub fn adapt_batch(table_schema: &Schema, batch: &RecordBatch) -> RecordBatch {
     let batch_schema = &*batch.schema();
     let batch_cols = batch.columns().to_vec();
 

--- a/server/src/utils/arrow/merged_reader.rs
+++ b/server/src/utils/arrow/merged_reader.rs
@@ -52,7 +52,7 @@ impl MergedRecordReader {
             let b_time = get_timestamp_millis(b);
             a_time < b_time
         })
-        .map(move |batch| adapt_batch(&schema, batch))
+        .map(move |batch| adapt_batch(&schema, &batch))
     }
 
     pub fn merged_schema(&self) -> Schema {


### PR DESCRIPTION
Fixes #445.

### Description
 Implements and makes use of a custom query table provider which combines  `ListingTable` and `MemTable` for querying remote data and staging data together.  

[UnionExec](https://docs.rs/datafusion/latest/datafusion/physical_plan/union/struct.UnionExec.html) is used to combine two inputs together. This can be switched out for SortPreservingMergeExec if output is interleaving staging and remote data together on something like `select * from table`

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
