### PR TITLE
Sort inferred fields

### DIFF
--- a/server/src/event/format/json.rs
+++ b/server/src/event/format/json.rs
@@ -24,6 +24,7 @@ use arrow_array::RecordBatch;
 use arrow_json::reader::{infer_json_schema_from_iterator, ReaderBuilder};
 use arrow_schema::{DataType, Field, Fields, Schema};
 use datafusion::arrow::util::bit_util::round_upto_multiple_of_64;
+use itertools::Itertools;
 use serde_json::Value;
 use std::{collections::HashMap, sync::Arc};
 
@@ -73,7 +74,12 @@ impl EventFormat for Event {
                         return Err(anyhow!("Could not merge schema of this event with that of the existing stream. {:?}", err));
                     }
                     is_first = true;
-                    infer_schema.fields.iter().cloned().collect()
+                    infer_schema
+                        .fields
+                        .iter()
+                        .cloned()
+                        .sorted_by(|a, b| a.name().cmp(b.name()))
+                        .collect()
                 }
                 Err(err) => {
                     return Err(anyhow!(


### PR DESCRIPTION
### Description
Fix cases where inferred schema breaks arrow file writer invariants. 

Similarly to collect_keys, all fields will be sorted by their name.

<hr>

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
