### PR TITLE
create more build target platform work flow file: github-release.yml

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,152 @@
+name: GitHub  Release
+
+on:
+  push:
+    tags:
+    - v[0-9]+.[0-9]+.[0-9]+*
+
+jobs:
+  release:
+    name: Publish to Github Relases
+    outputs:
+      rc: ${{ steps.check-tag.outputs.rc }}
+
+    strategy:
+      matrix:
+        include:
+        - target: aarch64-unknown-linux-musl
+          os: ubuntu-latest
+          use-cross: true
+          cargo-flags: ""
+        - target: aarch64-apple-darwin
+          os: macos-latest
+          use-cross: true
+          cargo-flags: ""
+        - target: aarch64-pc-windows-msvc
+          os: windows-latest
+          use-cross: true
+          cargo-flags: "--no-default-features"
+        - target: x86_64-apple-darwin
+          os: macos-latest
+          cargo-flags: ""
+        - target: x86_64-pc-windows-msvc
+          os: windows-latest
+          cargo-flags: ""
+        - target: x86_64-unknown-linux-musl
+          os: ubuntu-latest
+          use-cross: true
+          cargo-flags: ""
+        - target: i686-unknown-linux-musl
+          os: ubuntu-latest
+          use-cross: true
+          cargo-flags: ""
+        - target: i686-pc-windows-msvc
+          os: windows-latest
+          use-cross: true
+          cargo-flags: ""
+        - target: armv7-unknown-linux-musleabihf
+          os: ubuntu-latest
+          use-cross: true
+          cargo-flags: ""
+        - target: arm-unknown-linux-musleabihf
+          os: ubuntu-latest
+          use-cross: true
+          cargo-flags: ""
+        - target: mips-unknown-linux-musl
+          os: ubuntu-latest
+          use-cross: true
+          cargo-flags: "--no-default-features"
+        - target: mipsel-unknown-linux-musl
+          os: ubuntu-latest
+          use-cross: true
+          cargo-flags: "--no-default-features"
+        - target: mips64-unknown-linux-gnuabi64
+          os: ubuntu-latest
+          use-cross: true
+          cargo-flags: "--no-default-features"
+        - target: mips64el-unknown-linux-gnuabi64
+          os: ubuntu-latest
+          use-cross: true
+          cargo-flags: "--no-default-features"
+    runs-on: ${{matrix.os}}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Check Tag
+      id: check-tag
+      shell: bash
+      run: |
+        tag=${GITHUB_REF##*/}
+        echo "::set-output name=version::$tag"
+        if [[ "$tag" =~ [0-9]+.[0-9]+.[0-9]+$ ]]; then
+          echo "::set-output name=rc::false"
+        else
+          echo "::set-output name=rc::true"
+        fi
+    - name: Install Rust Toolchain Components
+      uses: actions-rs/toolchain@v1
+      with:
+        override: true
+        target: ${{ matrix.target }}
+        toolchain: stable
+        profile: minimal # minimal component installation (ie, no documentation)
+        
+    - name: Install OpenSSL
+      if: runner.os == 'Linux'
+      run: sudo apt-get install -y libssl-dev
+  
+    - name: Show Version Information (Rust, cargo, GCC)
+      shell: bash
+      run: |
+        gcc --version || true
+        rustup -V
+        rustup toolchain list
+        rustup default
+        cargo -V
+        rustc -V
+      
+    - name: Build
+      uses: actions-rs/cargo@v1
+      with:
+        use-cross: ${{ matrix.use-cross }}
+        command: build
+        args: --locked --release --target=${{ matrix.target }} ${{ matrix.cargo-flags }}
+
+    - name: Build Archive
+      shell: bash
+      id: package
+      env:
+        target: ${{ matrix.target }}
+        version:  ${{ steps.check-tag.outputs.version }}
+      run: |
+        set -euxo pipefail
+        bin=${GITHUB_REPOSITORY##*/}
+        src=`pwd`
+        dist=$src/dist
+        name=$bin-$version-$target
+        executable=target/$target/release/$bin
+        if [[ "$RUNNER_OS" == "Windows" ]]; then
+          executable=$executable.exe
+        fi
+        mkdir $dist
+        cp $executable $dist
+        cd $dist
+        if [[ "$RUNNER_OS" == "Windows" ]]; then
+            archive=$dist/$name.zip
+            7z a $archive *
+            echo "::set-output name=archive::`pwd -W`/$name.zip"
+        else
+            archive=$dist/$name.tar.gz
+            tar czf $archive *
+            echo "::set-output name=archive::$archive"
+        fi
+    - name: Publish Archive
+      uses: softprops/action-gh-release@v0.1.15
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      with:
+        draft: false
+        files: ${{ steps.package.outputs.archive }}
+        prerelease: ${{ steps.check-tag.outputs.rc == 'true' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I add a new github workflow file to create more platform build target 
        - target: aarch64-unknown-linux-musl
         
        - target: aarch64-apple-darwin
         
        - target: aarch64-pc-windows-msvc
          
        - target: x86_64-apple-darwin
          
        - target: x86_64-pc-windows-msvc
          
        - target: x86_64-unknown-linux-musl
         
        - target: i686-unknown-linux-musl
         
        - target: i686-pc-windows-msvc
         
        - target: armv7-unknown-linux-musleabihf
         
        - target: arm-unknown-linux-musleabihf
         
        - target: mips-unknown-linux-musl
         
        - target: mipsel-unknown-linux-musl
         
        - target: mips64-unknown-linux-gnuabi64
         
        - target: mips64el-unknown-linux-gnuabi64
         