### PR TITLE
Use distroless latest instead of nonroot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY . .
 RUN cargo build --release
 
 # final stage
-FROM gcr.io/distroless/cc-debian11:nonroot
+FROM gcr.io/distroless/cc-debian11:latest
 
 WORKDIR /parseable
 


### PR DESCRIPTION
Fixes #442.

### Description
Use `distroless/cc-debian11:latest` instead of `:nonroot` so that mounted storage works properly

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
