### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3666,9 +3666,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.28.4"
+version = "0.29.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c2f3ca6693feb29a89724516f016488e9aafc7f37264f898593ee4b942f31b"
+checksum = "c7cb97a5a85a136d84e75d5c3cf89655090602efb1be0d8d5337b7e386af2908"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -3730,13 +3730,15 @@ dependencies = [
 
 [[package]]
 name = "thread-priority"
-version = "0.10.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978519ae4c6891352f964b88da4ab5a3a9b74a40247cda5baee145dae6cd3b71"
+checksum = "0c56ce92f1285eaaa11fc1a3201e25de97898c50e87caa4c2aee836fe05288de"
 dependencies = [
+ "bitflags",
  "cfg-if",
  "libc",
  "log",
+ "rustversion",
  "winapi",
 ]
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -74,9 +74,9 @@ semver = "1.0"
 serde = { version = "1.0", features = ["rc"] }
 serde_json = "1.0"
 static-files = "0.2"
-sysinfo = "0.28.4"
+sysinfo = "0.29.6"
 thiserror = "1"
-thread-priority = "0.10"
+thread-priority = "0.13.1"
 tokio = { version = "1.28", default-features = false, features = [
   "sync",
   "macros",


### PR DESCRIPTION
### Description
* Bump sysinfo to version to 0.29.6  
* Bump thread_priority version to 0.13.1
<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
