### PR TITLE
Resolve not found to root

### DIFF
--- a/server/src/handlers/http.rs
+++ b/server/src/handlers/http.rs
@@ -248,7 +248,7 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
             .service(user_api),
     )
     // GET "/" ==> Serve the static frontend directory
-    .service(ResourceFiles::new("/", generated));
+    .service(ResourceFiles::new("/", generated).resolve_not_found_to_root());
 }
 
 fn base_path() -> String {


### PR DESCRIPTION
### Description

`actix_web_static_files` provides way to resolve resource lookup to index when nothing matching is found.

This allows routing on any non matching resource to be taken care by UI router.  

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
