### PR TITLE
Make tag in reader role optional

### DIFF
--- a/server/src/handlers/http/query.rs
+++ b/server/src/handlers/http/query.rs
@@ -89,7 +89,7 @@ impl FromRequest for Query {
                 match permission {
                     Permission::Stream(Action::All, _) => authorized = true,
                     Permission::StreamWithTag(Action::Query, stream, tag)
-                        if stream == query.stream_name =>
+                        if stream == query.stream_name || stream == "*" =>
                     {
                         authorized = true;
                         if let Some(tag) = tag {

--- a/server/src/rbac/role.rs
+++ b/server/src/rbac/role.rs
@@ -110,7 +110,7 @@ pub mod model {
         Admin,
         Editor,
         Writer { stream: String },
-        Reader { stream: String, tag: String },
+        Reader { stream: String, tag: Option<String> },
     }
 
     impl From<&DefaultPrivilege> for RoleBuilder {
@@ -121,9 +121,14 @@ pub mod model {
                 DefaultPrivilege::Writer { stream } => {
                     writer_perm_builder().with_stream(stream.to_owned())
                 }
-                DefaultPrivilege::Reader { stream, tag } => reader_perm_builder()
-                    .with_stream(stream.to_owned())
-                    .with_tag(tag.to_owned()),
+                DefaultPrivilege::Reader { stream, tag } => {
+                    let mut reader  = reader_perm_builder()
+                    .with_stream(stream.to_owned());
+                    if let Some(tag) = tag {
+                        reader = reader.with_tag(tag.to_owned())
+                    }
+                    reader
+                },
             }
         }
     }

--- a/server/src/rbac/role.rs
+++ b/server/src/rbac/role.rs
@@ -122,13 +122,12 @@ pub mod model {
                     writer_perm_builder().with_stream(stream.to_owned())
                 }
                 DefaultPrivilege::Reader { stream, tag } => {
-                    let mut reader  = reader_perm_builder()
-                    .with_stream(stream.to_owned());
+                    let mut reader = reader_perm_builder().with_stream(stream.to_owned());
                     if let Some(tag) = tag {
                         reader = reader.with_tag(tag.to_owned())
                     }
                     reader
-                },
+                }
             }
         }
     }


### PR DESCRIPTION
### Description
Fixes reader role in RBAC.  

* Make Tags optional 
* Fix authentication for permission with "*" wildcard stream

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
