### PR TITLE
Add list stream permission to all roles

### DIFF
--- a/server/src/rbac/role.rs
+++ b/server/src/rbac/role.rs
@@ -164,6 +164,7 @@ pub mod model {
             actions: vec![
                 Action::Ingest,
                 Action::Query,
+                Action::ListStream,
                 Action::GetSchema,
                 Action::GetStats,
                 Action::GetRetention,
@@ -179,6 +180,7 @@ pub mod model {
         RoleBuilder {
             actions: vec![
                 Action::Query,
+                Action::ListStream,
                 Action::GetSchema,
                 Action::GetStats,
                 Action::GetRetention,


### PR DESCRIPTION
### Description

All roles can list stream. The response is not specialized, thus any client of the api has to check for response of `GET logstream/{}/schema` to know if the user has access to it

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
