### PR TITLE
Deduplicate privilege entries

### DIFF
--- a/server/src/handlers/http/rbac.rs
+++ b/server/src/handlers/http/rbac.rs
@@ -16,6 +16,8 @@
  *
  */
 
+use std::collections::HashSet;
+
 use crate::{
     option::CONFIG,
     rbac::{
@@ -124,7 +126,8 @@ pub async fn put_role(
 ) -> Result<String, RBACError> {
     let username = username.into_inner();
     let role = role.into_inner();
-    let role: Vec<DefaultPrivilege> = serde_json::from_value(role)?;
+    let role: HashSet<DefaultPrivilege> = serde_json::from_value(role)?;
+    let role = role.into_iter().collect();
 
     if !Users.contains(&username) {
         return Err(RBACError::UserDoesNotExist);

--- a/server/src/rbac/role.rs
+++ b/server/src/rbac/role.rs
@@ -104,7 +104,7 @@ impl RoleBuilder {
 pub mod model {
     use super::{Action, RoleBuilder};
 
-    #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Hash)]
     #[serde(tag = "privilege", content = "resource", rename_all = "lowercase")]
     pub enum DefaultPrivilege {
         Admin,


### PR DESCRIPTION
### Description

Remove duplicate entries when updating roles for a user. 

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
