### PR TITLE
Query param for attaching fields to response json

### DIFF
--- a/server/src/handlers/http/query.rs
+++ b/server/src/handlers/http/query.rs
@@ -44,7 +44,7 @@ pub async fn query(
     let time = Instant::now();
 
     // format output json to include field names
-    let with_fields = params.get("withFields").cloned().unwrap_or(false);
+    let with_fields = params.get("fields").cloned().unwrap_or(false);
     // Fill missing columns with null
     let fill_null = params
         .get("fillNull")

--- a/server/src/handlers/http/query.rs
+++ b/server/src/handlers/http/query.rs
@@ -18,12 +18,13 @@
 
 use actix_web::error::ErrorUnauthorized;
 use actix_web::http::header::ContentType;
-use actix_web::web::Json;
+use actix_web::web::{self, Json};
 use actix_web::{FromRequest, HttpRequest, Responder};
 use actix_web_httpauth::extractors::basic::BasicAuth;
 use futures_util::Future;
 use http::StatusCode;
 use serde_json::Value;
+use std::collections::HashMap;
 use std::pin::Pin;
 use std::time::Instant;
 
@@ -36,22 +37,37 @@ use crate::rbac::role::{Action, Permission};
 use crate::rbac::Users;
 use crate::response::QueryResponse;
 
-pub async fn query(query: Query) -> Result<impl Responder, QueryError> {
+pub async fn query(
+    query: Query,
+    web::Query(params): web::Query<HashMap<String, bool>>,
+) -> Result<impl Responder, QueryError> {
     let time = Instant::now();
 
+    // format output json to include field names
+    let with_fields = params.get("withFields").cloned().unwrap_or(false);
+    // Fill missing columns with null
+    let fill_null = params
+        .get("fillNull")
+        .cloned()
+        .or(Some(query.fill_null))
+        .unwrap_or(false);
+
     let storage = CONFIG.storage().get_object_store();
-    let query_result = query.execute(storage).await;
-    let query_result = query_result
-        .map(|(records, fields)| QueryResponse::new(records, fields, query.fill_null))
-        .map(|response| response.to_http())
-        .map_err(|e| e.into());
+    let (records, fields) = query.execute(storage).await?;
+    let response = QueryResponse {
+        records,
+        fields,
+        fill_null,
+        with_fields,
+    }
+    .to_http();
 
     let time = time.elapsed().as_secs_f64();
     QUERY_EXECUTE_TIME
         .with_label_values(&[query.stream_name.as_str()])
         .observe(time);
 
-    query_result
+    Ok(response)
 }
 
 impl FromRequest for Query {


### PR DESCRIPTION
### Description

This PR adds query parameters to format response output. Mainly duplicating existing fill null option to query param and adding a `withFields` param options.

Attaching schema to output can benefit cases where client wants to display table but the table API wants all table columns to be defined first. 

#### Example 
```
{{endpoint}}/api/v1/query?fields=true
```
```
"query": "select min(p_timestamp), max(p_timestamp) from {{stream_name}}",
....
```
```
{
    "fields": [
        "MIN(app.p_timestamp)",
        "MAX(app.p_timestamp)"
    ],
    "records": [
        {
            "MAX(app.p_timestamp)": "2023-08-07T05:55:59.738",
            "MIN(app.p_timestamp)": "2023-08-07T05:55:20.335"
        }
    ]
}
``` 


<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
