### PR TITLE
Parse escape sequence for string and display errors

### DIFF
--- a/server/src/alerts/rule.rs
+++ b/server/src/alerts/rule.rs
@@ -379,7 +379,7 @@ impl ConsecutiveRepeatState {
 
 fn string_or_struct<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
-    T: Deserialize<'de> + FromStr<Err = Box<dyn std::error::Error>>,
+    T: Deserialize<'de> + FromStr<Err = String>,
     D: Deserializer<'de>,
 {
     // This is a Visitor that forwards string types to T's `FromStr` impl and
@@ -391,7 +391,7 @@ where
 
     impl<'de, T> Visitor<'de> for StringOrStruct<T>
     where
-        T: Deserialize<'de> + FromStr<Err = Box<dyn std::error::Error>>,
+        T: Deserialize<'de> + FromStr<Err = String>,
     {
         type Value = T;
 


### PR DESCRIPTION
### Description

Adds ability to escape `"`,  `\n`, ..etc when defining string rules.

Use existing verbose error type from nom to display error. The error type usually will contains stack trace for parser and their subparser. 

To customize error any further, this will require a custom nom error type.

#### Error  Example

```
failed to set alert configuration for log stream app due to err: 0: at line 1, in IsNot:
(verb =% "\list" or verb =% "get") and (objectRef_resource = "secrets" and user_username =% "admin")
          ^

1: at line 1, in Alt:
(verb =% "\list" or verb =% "get") and (objectRef_resource = "secrets" and user_username =% "admin")
          ^
```

```
failed to set alert configuration for log stream app due to err: 0: at line 1:
(verb =% "list" or) and (objectRef_resource = "secrets" and user_username =% "admin")
                ^
expected ')', found o


```

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
