### PR TITLE
Parse now and duration in start and end time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2674,6 +2674,7 @@ dependencies = [
  "hex",
  "hostname",
  "http",
+ "humantime",
  "humantime-serde",
  "itertools 0.10.5",
  "log",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -88,6 +88,7 @@ uptime_lib = "0.2.2"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 xz2 = { version = "*", features = ["static"] }
 nom = "7.1.3"
+humantime = "2.1.0"
 
 [build-dependencies]
 cargo_toml = "0.15"


### PR DESCRIPTION
Fixes #490 .

### Description
Allow user to specify `now` and duration in `endTime` and `startTime` fields instead of giving concrete timestamps.

Note that this only affects the timerange for internal file lookups and does not guarantee restriction exact timeframe for p_timestamp for the query. In that case user is expected to pass in `where p_timestamp < now() and p_timestamp > (now() - interval  '10 minute')` 


<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
