### PR TITLE
Move CORS layer to a seperate feature

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -119,4 +119,4 @@ assets-sha1 = "6abd7b5ca5b9c832ff58b8450cffdc83dd7172bf"
 
 [features]
 permissive_cors = ["dep:tower-http", "dep:actix-cors"]
-debug = ["permissive-cors"]
+debug = ["permissive_cors"]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -22,15 +22,15 @@ parquet = "^47.0.0"
 arrow-flight = "47.0.0"
 tonic = "0.10.0"
 tonic-web = "0.10.0"
-tower-http = { version = "0.4.4", features = ["cors"] }
+tower-http = { version = "0.4.4", features = ["cors"], optional = true }
 
 ### actix dependencies
 actix-web-httpauth = "0.8"
 actix-web = { version = "4.3", features = ["rustls"] }
-actix-cors = "0.6"
 actix-web-prometheus = { version = "0.1" }
 actix-web-static-files = "4.0"
 mime = "0.3.17"
+actix-cors = { version = "0.6", optional = true }
 
 ### other dependencies
 anyhow = { version = "1.0", features = ["backtrace"] }
@@ -118,4 +118,4 @@ assets-url = "https://github.com/parseablehq/console/releases/download/v0.3.1/bu
 assets-sha1 = "6abd7b5ca5b9c832ff58b8450cffdc83dd7172bf"
 
 [features]
-debug = []
+debug = ["dep:tower-http", "dep:actix-cors"]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -118,4 +118,5 @@ assets-url = "https://github.com/parseablehq/console/releases/download/v0.3.1/bu
 assets-sha1 = "6abd7b5ca5b9c832ff58b8450cffdc83dd7172bf"
 
 [features]
-debug = ["dep:tower-http", "dep:actix-cors"]
+permissive_cors = ["dep:tower-http", "dep:actix-cors"]
+debug = ["permissive-cors"]

--- a/server/src/handlers/http.rs
+++ b/server/src/handlers/http.rs
@@ -31,7 +31,7 @@ use openid::Discovered;
 use rustls::{Certificate, PrivateKey, ServerConfig};
 use rustls_pemfile::{certs, pkcs8_private_keys};
 
-#[cfg(feature = "debug")]
+#[cfg(feature = "permissive_cors")]
 use actix_cors::Cors;
 
 use crate::option::CONFIG;
@@ -77,7 +77,7 @@ pub async fn run_http(
             .wrap(actix_web::middleware::Logger::default())
             .wrap(actix_web::middleware::Compress::default());
 
-        #[cfg(feature = "debug")]
+        #[cfg(feature = "permissive_cors")]
         let app = app.wrap(Cors::permissive());
 
         app

--- a/server/src/handlers/livetail.rs
+++ b/server/src/handlers/livetail.rs
@@ -35,7 +35,7 @@ use arrow_flight::{
     HandshakeResponse, PutResult, SchemaResult, Ticket,
 };
 use tonic_web::GrpcWebLayer;
-#[cfg(feature = "debug")]
+#[cfg(feature = "permissive_cors")]
 use tower_http::cors::CorsLayer;
 
 use crate::livetail::{Message, LIVETAIL};
@@ -177,7 +177,7 @@ pub fn server() -> impl Future<Output = Result<(), Box<dyn std::error::Error + S
 
     let builder = Server::builder().accept_http1(true);
 
-    #[cfg(feature = "debug")]
+    #[cfg(feature = "permissive_cors")]
     let builder = builder.layer(CorsLayer::very_permissive().allow_credentials(true));
 
     builder


### PR DESCRIPTION
### Description
This PR removes CORS layer from livetail and actix web. CORS will be available as a separate feature called `permissive_cors` and this feature is included in debug build as well.

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
