### PR TITLE
Pre resolve prefixes for remote query

### DIFF
--- a/server/src/query.rs
+++ b/server/src/query.rs
@@ -33,7 +33,7 @@ use futures_util::stream::FuturesUnordered;
 use futures_util::{future, Future, TryStreamExt};
 use itertools::Itertools;
 use object_store::path::Path as StorePath;
-use object_store::ObjectStore;
+use object_store::{ObjectMeta, ObjectStore};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -265,9 +265,9 @@ async fn resolve_paths(
         }
     }
 
-    let tasks: FuturesUnordered<
-        Pin<Box<dyn Future<Output = Result<Vec<object_store::ObjectMeta>, ObjectStorageError>>>>,
-    > = FuturesUnordered::new();
+    type ResolveFuture = Pin<Box<dyn Future<Output = Result<Vec<ObjectMeta>, ObjectStorageError>>>>;
+
+    let tasks: FuturesUnordered<ResolveFuture> = FuturesUnordered::new();
 
     for (listing_prefix, prefix) in minute_resolve {
         let client = Arc::clone(&client);

--- a/server/src/query.rs
+++ b/server/src/query.rs
@@ -140,7 +140,7 @@ impl Query {
         let prefixes =
             resolve_paths(client, storage.normalize_prefixes(unresolved_prefixes)).await?;
 
-        let remote_listing_table = self.remote_query(dbg!(prefixes), storage)?;
+        let remote_listing_table = self.remote_query(prefixes, storage)?;
 
         let current_minute = Utc::now()
             .with_second(0)
@@ -272,13 +272,11 @@ async fn resolve_paths(
     for (listing_prefix, prefix) in minute_resolve {
         let client = Arc::clone(&client);
         tasks.push(Box::pin(async move {
-            let mut list = dbg!(
-                client
-                    .list(Some(&StorePath::from(listing_prefix)))
-                    .await?
-                    .try_collect::<Vec<_>>()
-                    .await?
-            );
+            let mut list = client
+                .list(Some(&StorePath::from(listing_prefix)))
+                .await?
+                .try_collect::<Vec<_>>()
+                .await?;
 
             list.retain(|object| {
                 prefix.iter().any(|prefix| {
@@ -295,12 +293,12 @@ async fn resolve_paths(
     for prefix in all_resolve {
         let client = Arc::clone(&client);
         tasks.push(Box::pin(async move {
-            dbg!(client
+            client
                 .list(Some(&StorePath::from(prefix)))
                 .await?
                 .try_collect::<Vec<_>>()
                 .await
-                .map_err(Into::into))
+                .map_err(Into::into)
         }));
     }
 

--- a/server/src/query.rs
+++ b/server/src/query.rs
@@ -89,7 +89,6 @@ impl Query {
         self.generate_prefixes()
             .into_iter()
             .map(|key| format!("{}/{}", self.stream_name, key))
-            // latest first
             .collect()
     }
 

--- a/server/src/storage/localfs.rs
+++ b/server/src/storage/localfs.rs
@@ -194,14 +194,25 @@ impl ObjectStorage for LocalFS {
         Ok(())
     }
 
+    fn normalize_prefixes(&self, prefixes: Vec<String>) -> Vec<String> {
+        prefixes
+            .into_iter()
+            .map(|prefix| {
+                let path = self.root.join(prefix);
+                format!("{}", path.display())
+            })
+            .collect()
+    }
+
     fn query_prefixes(&self, prefixes: Vec<String>) -> Vec<ListingTableUrl> {
         prefixes
             .into_iter()
-            .filter_map(|prefix| {
-                let path = self.root.join(prefix);
-                ListingTableUrl::parse(path.to_str().unwrap()).ok()
-            })
+            .filter_map(|prefix| ListingTableUrl::parse(format!("/{}", prefix)).ok())
             .collect()
+    }
+
+    fn store_url(&self) -> url::Url {
+        url::Url::parse("file:///").unwrap()
     }
 }
 

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -67,7 +67,9 @@ pub trait ObjectStorage: Sync + 'static {
     async fn list_streams(&self) -> Result<Vec<LogStream>, ObjectStorageError>;
     async fn list_dates(&self, stream_name: &str) -> Result<Vec<String>, ObjectStorageError>;
     async fn upload_file(&self, key: &str, path: &Path) -> Result<(), ObjectStorageError>;
+    fn normalize_prefixes(&self, prefixes: Vec<String>) -> Vec<String>;
     fn query_prefixes(&self, prefixes: Vec<String>) -> Vec<ListingTableUrl>;
+    fn store_url(&self) -> url::Url;
 
     async fn put_schema(
         &self,

--- a/server/src/storage/s3.rs
+++ b/server/src/storage/s3.rs
@@ -444,6 +444,11 @@ impl ObjectStorage for S3 {
         Ok(())
     }
 
+    // no op on s3
+    fn normalize_prefixes(&self, prefixes: Vec<String>) -> Vec<String> {
+        prefixes
+    }
+
     fn query_prefixes(&self, prefixes: Vec<String>) -> Vec<ListingTableUrl> {
         prefixes
             .into_iter()
@@ -452,6 +457,10 @@ impl ObjectStorage for S3 {
                 ListingTableUrl::parse(path).unwrap()
             })
             .collect()
+    }
+
+    fn store_url(&self) -> url::Url {
+        url::Url::parse(&format!("s3://{}", self.bucket)).unwrap()
     }
 }
 


### PR DESCRIPTION
### Description
Prefixes are resolved into final path before passing it onto listing table. 
<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
