### PR TITLE
Report latency at server startup (#551)

### DIFF
--- a/server/src/banner.rs
+++ b/server/src/banner.rs
@@ -79,11 +79,14 @@ fn status_info(config: &Config, scheme: &str, id: Uid) {
     );
 }
 
+/// Prints information about the `ObjectStorage`.
+/// - Mode (`Local drive`, `S3 bucket`)
+/// - Staging (temporary landing point for incoming events)
+/// - Store (path where the data is stored)
+/// - Latency
 async fn storage_info(config: &Config) {
     let storage = config.storage();
-    let object_store = storage.get_object_store();
-
-    let latency = object_store.get_latency().await;
+    let latency = storage.get_object_store().get_latency().await;
 
     eprintln!(
         "

--- a/server/src/banner.rs
+++ b/server/src/banner.rs
@@ -17,15 +17,11 @@
  *
  */
 
-use std::time::Duration;
-
 use crossterm::style::Stylize;
 
 use crate::about;
 use crate::utils::uid::Uid;
 use crate::{option::Config, storage::StorageMetadata};
-
-const ACCEPTABLE_LATENCY_SECONDS: u64 = 1;
 
 pub async fn print(config: &Config, meta: &StorageMetadata) {
     print_ascii_art();
@@ -88,7 +84,6 @@ async fn storage_info(config: &Config) {
     let object_store = storage.get_object_store();
 
     let latency = object_store.get_latency().await;
-    let latency_text = format!("{:?}", latency);
 
     eprintln!(
         "
@@ -96,19 +91,11 @@ async fn storage_info(config: &Config) {
         Mode:               \"{}\"
         Staging:            \"{}\"
         Store:              \"{}\"
-        Latency:            \"{}\"",
+        Latency:            \"{:?}\"",
         "Storage:".to_string().bold(),
         config.mode_string(),
         config.staging_dir().to_string_lossy(),
         storage.get_endpoint(),
-        if is_latency_acceptable(latency) {
-            latency_text.green()
-        } else {
-            latency_text.red()
-        }
+        latency
     )
-}
-
-fn is_latency_acceptable(latency: Duration) -> bool {
-    latency <= Duration::new(ACCEPTABLE_LATENCY_SECONDS, 0)
 }

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -75,11 +75,10 @@ pub trait ObjectStorage: Sync + 'static {
     async fn upload_file(&self, key: &str, path: &Path) -> Result<(), ObjectStorageError>;
 
     async fn get_latency(&self) -> Duration {
-        let start = Instant::now();
-
         let path = RelativePathBuf::from_path(".parseable.json").unwrap();
-        let _ = self.get_object(&path).await;
 
+        let start = Instant::now();
+        let _ = self.get_object(&path).await;
         start.elapsed()
     }
 

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -74,7 +74,11 @@ pub trait ObjectStorage: Sync + 'static {
     async fn list_dates(&self, stream_name: &str) -> Result<Vec<String>, ObjectStorageError>;
     async fn upload_file(&self, key: &str, path: &Path) -> Result<(), ObjectStorageError>;
 
+    /// Returns the amount of time taken by the `ObjectStore` to perform a get
+    /// call.
     async fn get_latency(&self) -> Duration {
+        // It's Ok to `unwrap` here. The hardcoded value will always Result in
+        // an `Ok`.
         let path = RelativePathBuf::from_path(".parseable.json").unwrap();
 
         let start = Instant::now();

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -38,7 +38,13 @@ use relative_path::RelativePath;
 use relative_path::RelativePathBuf;
 use serde_json::Value;
 
-use std::{collections::HashMap, fs, path::Path, sync::Arc};
+use std::{
+    collections::HashMap,
+    fs,
+    path::Path,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 // metadata file names in a Stream prefix
 pub(super) const STREAM_METADATA_FILE_NAME: &str = ".stream.json";
@@ -67,6 +73,16 @@ pub trait ObjectStorage: Sync + 'static {
     async fn list_streams(&self) -> Result<Vec<LogStream>, ObjectStorageError>;
     async fn list_dates(&self, stream_name: &str) -> Result<Vec<String>, ObjectStorageError>;
     async fn upload_file(&self, key: &str, path: &Path) -> Result<(), ObjectStorageError>;
+
+    async fn get_latency(&self) -> Duration {
+        let start = Instant::now();
+
+        let path = RelativePathBuf::from_path(".parseable.json").unwrap();
+        let _ = self.get_object(&path).await;
+
+        start.elapsed()
+    }
+
     fn normalize_prefixes(&self, prefixes: Vec<String>) -> Vec<String>;
     fn query_prefixes(&self, prefixes: Vec<String>) -> Vec<ListingTableUrl>;
     fn store_url(&self) -> url::Url;


### PR DESCRIPTION
Fixes #551.

### Description

Report object store latency at server startup.

- Measure the `[time]` taken to get the `.parseable.json` object from the store at server startup
- Print `[time]` on the banner

---

- [x] Add docs / comments
