### PR TITLE
Set file_size attribute directly from file metadata

### DIFF
--- a/server/src/catalog/manifest.rs
+++ b/server/src/catalog/manifest.rs
@@ -97,6 +97,8 @@ pub fn create_from_parquet_file(
     };
 
     let file = std::fs::File::open(fs_file_path)?;
+    manifest_file.file_size = file.metadata()?.len();
+
     let file = parquet::file::serialized_reader::SerializedFileReader::new(file)?;
     let file_meta = file.metadata().file_metadata();
     let row_groups = file.metadata().row_groups();
@@ -105,9 +107,6 @@ pub fn create_from_parquet_file(
     manifest_file.ingestion_size = row_groups
         .iter()
         .fold(0, |acc, x| acc + x.total_byte_size() as u64);
-    manifest_file.file_size = row_groups
-        .iter()
-        .fold(0, |acc, x| acc + x.compressed_size() as u64);
 
     let columns = column_statistics(row_groups);
     manifest_file.columns = columns.into_values().collect();


### PR DESCRIPTION
Fixes #575.

### Description
Datafusion PartitionedFile struct relies on correct file url and file size. This file size is used for calculating offset for reading the parquet footer. Wrong file size can lead to query issues.

This PR aims to fix that issue

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
