### PR TITLE
Set the compression to SNAPPY

### DIFF
--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -43,6 +43,7 @@ services:
       - P_USERNAME=parseableadmin
       - P_PASSWORD=parseableadmin
       - P_CHECK_UPDATE=false
+      - P_PARQUET_COMPRESSION_ALGO=snappy
     networks:
       - parseable-internal
     healthcheck:


### PR DESCRIPTION
This is necessary for https://github.com/parseablehq/quest/pull/47 to work. When default compression algorithm was used, parquet files had unknown compression and couldn't be loaded during integrity testing using https://github.com/xitongsys/parquet-go.