### PR TITLE
Fix help messages for environment variables / flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ env-file
 parseable
 parseable_*
 parseable-env-secret
+cache

--- a/server/src/banner.rs
+++ b/server/src/banner.rs
@@ -45,14 +45,17 @@ fn print_ascii_art() {
     "#;
 
     eprint!("{ascii_name}");
-    eprintln!(
-        "
-    Welcome to Parseable Server!"
-    );
 }
 
 fn status_info(config: &Config, scheme: &str, id: Uid) {
-    let url = format!("\"{}://{}\"", scheme, config.parseable.address).underlined();
+    let address = format!(
+        "\"{}://{}\" ({}), \":{}\" (gRPC)",
+        scheme,
+        config.parseable.address,
+        scheme.to_ascii_uppercase(),
+        config.parseable.grpc_port
+    );
+
     let mut credentials =
         String::from("\"As set in P_USERNAME and P_PASSWORD environment variables\"");
 
@@ -67,13 +70,19 @@ fn status_info(config: &Config, scheme: &str, id: Uid) {
 
     eprintln!(
         "
+    Welcome to Parseable Server! Deployment UID: \"{}\"",
+    id.to_string(),
+    );
+
+    eprintln!(
+        "
     {}
-        URL:                {}
+        Address:            {}
         Credentials:        {}
         Deployment UID:     \"{}\"
         LLM Status:         \"{}\"",
         "Server:".to_string().bold(),
-        url,
+        address,
         credentials,
         id.to_string(),
         llm_status
@@ -83,8 +92,8 @@ fn status_info(config: &Config, scheme: &str, id: Uid) {
 /// Prints information about the `ObjectStorage`.
 /// - Mode (`Local drive`, `S3 bucket`)
 /// - Staging (temporary landing point for incoming events)
-/// - Store (path where the data is stored)
-/// - Latency
+/// - Cache (local cache of data)
+/// - Store (path where the data is stored and its latency)
 async fn storage_info(config: &Config) {
     let storage = config.storage();
     let latency = storage.get_object_store().get_latency().await;
@@ -93,29 +102,32 @@ async fn storage_info(config: &Config) {
         "
     {}
         Mode:               \"{}\"
-        Staging:            \"{}\"
-        Store:              \"{}\"
-        Latency:            \"{:?}\"",
+        Staging:            \"{}\"",
         "Storage:".to_string().bold(),
         config.mode_string(),
         config.staging_dir().to_string_lossy(),
-        storage.get_endpoint(),
-        latency
     );
 
     if let Some(path) = &config.parseable.local_cache_path {
-        let size: SpecificSize<human_size::Gigabyte> =
+        let size: SpecificSize<human_size::Gigibyte> =
             SpecificSize::new(config.parseable.local_cache_size as f64, human_size::Byte)
                 .unwrap()
                 .into();
 
         eprintln!(
             "\
-    {:8}Cache:              \"{}\"
-        Cache Size:         \"{}\"",
+    {:8}Cache:              \"{}\", (size: {})",
             "",
             path.display(),
             size
         );
     }
+
+    eprintln!(
+        "\
+    {:8}Store:              \"{}\", (latency: {:?})",
+        "",
+        storage.get_endpoint(),
+        latency
+    );
 }

--- a/server/src/banner.rs
+++ b/server/src/banner.rs
@@ -71,7 +71,7 @@ fn status_info(config: &Config, scheme: &str, id: Uid) {
     eprintln!(
         "
     Welcome to Parseable Server! Deployment UID: \"{}\"",
-    id.to_string(),
+        id.to_string(),
     );
 
     eprintln!(

--- a/server/src/catalog/manifest.rs
+++ b/server/src/catalog/manifest.rs
@@ -43,6 +43,7 @@ pub enum SortOrder {
 }
 
 pub type SortInfo = (String, SortOrder);
+pub const CURRENT_MANIFEST_VERSION: &str = "v1";
 
 /// An entry in a manifest which points to a single file.
 /// Additionally, it is meant to store the statistics for the file it
@@ -67,7 +68,7 @@ pub struct Manifest {
 impl Default for Manifest {
     fn default() -> Self {
         Self {
-            version: "v1".to_string(),
+            version: CURRENT_MANIFEST_VERSION.to_string(),
             files: Vec::default(),
         }
     }

--- a/server/src/catalog/snapshot.rs
+++ b/server/src/catalog/snapshot.rs
@@ -22,6 +22,7 @@ use chrono::{DateTime, Utc};
 
 use crate::query::PartialTimeFilter;
 
+pub const CURRENT_SNAPSHOT_VERSION: &str = "v1";
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Snapshot {
     pub version: String,
@@ -31,7 +32,7 @@ pub struct Snapshot {
 impl Default for Snapshot {
     fn default() -> Self {
         Self {
-            version: "v1".to_string(),
+            version: CURRENT_SNAPSHOT_VERSION.to_string(),
             manifest_list: Vec::default(),
         }
     }

--- a/server/src/localcache.rs
+++ b/server/src/localcache.rs
@@ -25,11 +25,13 @@ use itertools::{Either, Itertools};
 use object_store::{local::LocalFileSystem, ObjectStore};
 use once_cell::sync::OnceCell;
 use tokio::{fs, sync::Mutex};
+use human_size::{SpecificSize, Gigibyte, Byte};
 
 use crate::option::CONFIG;
 
 pub const STREAM_CACHE_FILENAME: &str = ".cache.json";
 pub const CACHE_META_FILENAME: &str = ".cache_meta.json";
+pub const CURRENT_CACHE_VERSION: &str = "v1";
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct LocalCache {
@@ -42,7 +44,7 @@ pub struct LocalCache {
 impl LocalCache {
     fn new() -> Self {
         Self {
-            version: "v1".to_string(),
+            version: CURRENT_CACHE_VERSION.to_string(),
             current_size: 0,
             files: Cache::new(100),
         }
@@ -58,7 +60,7 @@ pub struct CacheMeta {
 impl CacheMeta {
     fn new() -> Self {
         Self {
-            version: "v1".to_string(),
+            version: CURRENT_CACHE_VERSION.to_string(),
             size_capacity: 0,
         }
     }
@@ -97,7 +99,8 @@ impl LocalCacheManager {
 
     pub async fn validate(&self, config_capacity: u64) -> Result<(), CacheError> {
         fs::create_dir_all(&self.cache_path).await?;
-        let path = cache_meta_path(&self.cache_path).unwrap();
+        let path = cache_meta_path(&self.cache_path)
+        .map_err(|err| CacheError::ObjectStoreError(err.into()))?;
         let resp = self
             .filesystem
             .get(&path)
@@ -107,7 +110,15 @@ impl LocalCacheManager {
         let updated_cache = match resp {
             Ok(bytes) => {
                 let mut meta: CacheMeta = serde_json::from_slice(&bytes)?;
-                if !meta.size_capacity == config_capacity {
+                if meta.size_capacity != config_capacity {
+                    // log the change in cache size
+                    let configured_size_human: SpecificSize<Gigibyte> = SpecificSize::new(config_capacity as f64, Byte).unwrap().into();
+                    let current_size_human: SpecificSize<Gigibyte> = SpecificSize::new(meta.size_capacity as f64, Byte).unwrap().into();
+                    log::warn!(
+                        "Cache size is updated from {} to {}",
+                        current_size_human,
+                        configured_size_human
+                    );
                     meta.size_capacity = config_capacity;
                     Some(meta)
                 } else {
@@ -123,10 +134,6 @@ impl LocalCacheManager {
         };
 
         if let Some(updated_cache) = updated_cache {
-            log::info!(
-                "Cache is updated to new size of {} Bytes",
-                &updated_cache.size_capacity
-            );
             self.filesystem
                 .put(&path, serde_json::to_vec(&updated_cache)?.into())
                 .await?

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -54,7 +54,6 @@ use crate::localcache::LocalCacheManager;
 #[actix_web::main]
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
-    CONFIG.validate();
     let storage = CONFIG.storage().get_object_store();
     CONFIG.validate_staging()?;
     migration::run_metadata_migration(&CONFIG).await?;

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -609,9 +609,9 @@ pub mod validation {
         str::FromStr,
     };
 
-    use human_size::{SpecificSize,multiples};
     use crate::option::MIN_CACHE_SIZE_BYTES;
     use crate::storage::LOCAL_SYNC_INTERVAL;
+    use human_size::{multiples, SpecificSize};
 
     pub fn file_path(s: &str) -> Result<PathBuf, String> {
         if s.is_empty() {
@@ -684,7 +684,9 @@ pub mod validation {
     }
 
     pub fn upload_interval(s: &str) -> Result<u64, String> {
-        let u = s.parse::<u64>().map_err(|_| "invalid upload interval".to_string())?;
+        let u = s
+            .parse::<u64>()
+            .map_err(|_| "invalid upload interval".to_string())?;
         if u < LOCAL_SYNC_INTERVAL {
             return Err("object storage upload interval must be 60 seconds or more".to_string());
         }

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -30,9 +30,9 @@ mod s3;
 pub mod staging;
 mod store_metadata;
 
-pub use localfs::{FSConfig, LocalFS};
+pub use localfs::FSConfig;
 pub use object_storage::{ObjectStorage, ObjectStorageProvider};
-pub use s3::{S3Config, S3};
+pub use s3::S3Config;
 pub use store_metadata::{
     put_remote_metadata, put_staging_metadata, resolve_parseable_metadata, StorageMetadata,
 };

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -49,7 +49,7 @@ pub fn validate_path_is_writeable(path: &Path) -> anyhow::Result<()> {
     };
     let permissions = md.permissions();
     if permissions.readonly() {
-        anyhow::bail!("Staging directory {} is unwritable", path.display())
+        anyhow::bail!("Staging directory {} is not writable", path.display())
     }
     Ok(())
 }


### PR DESCRIPTION
This PR also adds
* fix startup check for cache size and improve the error message
* gRPC port number in startup banner.
* Human readable input for size / capacity type environment variable

Fixes #586

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
