### PR TITLE
fix: ensure checking the global cache before enabling stream cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ env-file
 parseable
 parseable_*
 parseable-env-secret
-cache
+cache*
+

--- a/server/src/handlers/http/logstream.rs
+++ b/server/src/handlers/http/logstream.rs
@@ -253,7 +253,7 @@ pub async fn put_enable_cache(
 
     STREAM_INFO.set_stream_cache(&stream_name, enable_cache)?;
     Ok((
-        format!("Cache setting updated for log stream {stream_name}"),
+        format!("Cache set to {enable_cache} for log stream {stream_name}"),
         StatusCode::OK,
     ))
 }

--- a/server/src/metadata.rs
+++ b/server/src/metadata.rs
@@ -220,7 +220,7 @@ pub mod error {
 
         #[derive(Debug, thiserror::Error)]
         pub enum MetadataError {
-            #[error("Metadata for stream {0} not found. Maybe the stream does not exist")]
+            #[error("Metadata for stream {0} not found. Please create the stream and try again")]
             StreamMetaNotFound(String),
         }
 


### PR DESCRIPTION
This PR adds a check to ensure global cache is enabled in the enable stream cache API. We don't allow enabling stream cache because it is misleading to enable cache if global cache is not enabled / configured.

