### PR TITLE
relax cors permissions for port 8001 (gRPC) for live tail

### DIFF
--- a/server/src/handlers/livetail.rs
+++ b/server/src/handlers/livetail.rs
@@ -237,9 +237,5 @@ fn extract_cookie(header: &MetadataMap) -> Option<Cookie> {
 }
 
 fn cross_origin_config() -> CorsLayer {
-    if cfg!(feature = "debug") {
-        CorsLayer::very_permissive().allow_credentials(true)
-    } else {
-        CorsLayer::new()
-    }
+    CorsLayer::very_permissive().allow_credentials(true)
 }


### PR DESCRIPTION
Required for https://github.com/parseablehq/console/pull/164