### PR TITLE
fix: error handling on server start when s3 bucket is not found

### DIFF
--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -140,6 +140,10 @@ pub enum ObjectStorageError {
     #[error("{0} not found")]
     NoSuchKey(String),
 
+    // custom 
+    #[error("{0}")]
+    Custom(String),
+
     // Could not connect to object storage
     #[error("Connection Error: {0}")]
     ConnectionError(Box<dyn std::error::Error + Send + Sync + 'static>),

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -140,7 +140,7 @@ pub enum ObjectStorageError {
     #[error("{0} not found")]
     NoSuchKey(String),
 
-    // custom 
+    // custom
     #[error("{0}")]
     Custom(String),
 

--- a/server/src/storage/s3.rs
+++ b/server/src/storage/s3.rs
@@ -256,12 +256,13 @@ impl S3 {
             .with_label_values(&["PUT", status])
             .observe(time);
 
-
         if let Err(object_store::Error::NotFound { source, .. }) = &resp {
-                let source_str = source.to_string();
-                if source_str.contains("<Code>NoSuchBucket</Code>") {
-                    return Err(ObjectStorageError::Custom(format!("Bucket '{}' does not exist in S3.", self.bucket).to_string()));
-                }
+            let source_str = source.to_string();
+            if source_str.contains("<Code>NoSuchBucket</Code>") {
+                return Err(ObjectStorageError::Custom(
+                    format!("Bucket '{}' does not exist in S3.", self.bucket).to_string(),
+                ));
+            }
         }
 
         resp.map(|_| ()).map_err(|err| err.into())

--- a/server/src/storage/s3.rs
+++ b/server/src/storage/s3.rs
@@ -256,6 +256,14 @@ impl S3 {
             .with_label_values(&["PUT", status])
             .observe(time);
 
+
+        if let Err(object_store::Error::NotFound { source, .. }) = &resp {
+                let source_str = source.to_string();
+                if source_str.contains("<Code>NoSuchBucket</Code>") {
+                    return Err(ObjectStorageError::Custom(format!("Bucket '{}' does not exist in S3.", self.bucket).to_string()));
+                }
+        }
+
         resp.map(|_| ()).map_err(|err| err.into())
     }
 

--- a/server/src/storage/store_metadata.rs
+++ b/server/src/storage/store_metadata.rs
@@ -156,12 +156,12 @@ pub async fn resolve_parseable_metadata() -> Result<StorageMetadata, ObjectStora
         ObjectStorageError::UnhandledError(err)
     })?;
 
-    if overwrite_staging {
-        put_staging_metadata(&metadata)?;
-    }
-
     if overwrite_remote {
         put_remote_metadata(&metadata).await?;
+    }
+
+    if overwrite_staging {
+        put_staging_metadata(&metadata)?;
     }
 
     Ok(metadata)


### PR DESCRIPTION
Fixes #574 .

### Description
- Added custom error when S3 bucket is not found.
- Write metdata in staging only when remote metadata write is successful.
