### PR TITLE
Update gh workflows for multi arch build

### DIFF
--- a/.github/workflows/build-push-edge-debug.yaml
+++ b/.github/workflows/build-push-edge-debug.yaml
@@ -17,6 +17,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to Docker Hub
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
@@ -36,3 +42,4 @@ jobs:
           file: ./Dockerfile.debug
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/parseable:edge-debug
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build-push-edge.yaml
+++ b/.github/workflows/build-push-edge.yaml
@@ -17,6 +17,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to Docker Hub
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
@@ -28,7 +34,7 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: parseable/parseable
-      
+
       - name: Build and push
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
@@ -36,3 +42,4 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/parseable:edge
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Fixes [#163](https://github.com/parseablehq/parseable/issues/163)


### Description

Add support to build images for **linux/arm64**, **linux/amd64**

Update to the 
    - `.github/workflows/build-push-edge-debug.yaml`
    - `.github/workflows/build-push-edge.yaml`
workflow to build multi-arch images for the edge-debug and edge tags respectively.

From the [Docker documentation](https://docs.docker.com/build/ci/github-actions/multi-platform/):

QEMU and Docker Buildx needed to be setup in the workflow to build multi-arch images.

The documentation suggests using the `docker/build-push-action@v5` action to build multi-arch images. So I updated the same.

<hr>

This PR has:
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.

- [x] Is able to build multi-arch images for the edge-debug and edge tags respectively, tested manually
