### PR TITLE
Fix: Missing `:` in build yaml files

### DIFF
--- a/.github/workflows/build-push-edge-debug.yaml
+++ b/.github/workflows/build-push-edge-debug.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx

--- a/.github/workflows/build-push-edge.yaml
+++ b/.github/workflows/build-push-edge.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
Update on Issue Created by PR [#612](https://github.com/parseablehq/parseable/pull/612)
Missing `:` character after name in build yaml files 

### Description
In PR [#612](https://github.com/parseablehq/parseable/pull/612) I forgot the `:` on line 20 of 
- `build-push-edge.yaml`
- `build-push-edge-debug.yaml`

I apologize for this silly mistake.

