### PR TITLE
Proper Error Message if the Storage is in an invalid state

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -55,10 +55,10 @@ use crate::localcache::LocalCacheManager;
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
     let storage = CONFIG.storage().get_object_store();
+    CONFIG.validate_storage().await?;
     migration::run_metadata_migration(&CONFIG).await?;
     let metadata = storage::resolve_parseable_metadata().await?;
     CONFIG.validate_staging()?;
-    CONFIG.validate_storage().await?;
     banner::print(&CONFIG, &metadata).await;
     rbac::map::init(&metadata);
     metadata.set_global();

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -58,6 +58,7 @@ async fn main() -> anyhow::Result<()> {
     migration::run_metadata_migration(&CONFIG).await?;
     let metadata = storage::resolve_parseable_metadata().await?;
     CONFIG.validate_staging()?;
+    CONFIG.validate_storage().await?;
     banner::print(&CONFIG, &metadata).await;
     rbac::map::init(&metadata);
     metadata.set_global();

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -55,10 +55,9 @@ use crate::localcache::LocalCacheManager;
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
     let storage = CONFIG.storage().get_object_store();
-    CONFIG.validate_storage().await?;
+    CONFIG.validate().await?;
     migration::run_metadata_migration(&CONFIG).await?;
     let metadata = storage::resolve_parseable_metadata().await?;
-    CONFIG.validate_staging()?;
     banner::print(&CONFIG, &metadata).await;
     rbac::map::init(&metadata);
     metadata.set_global();

--- a/server/src/migration.rs
+++ b/server/src/migration.rs
@@ -32,6 +32,8 @@ use crate::{
     storage::{ObjectStorage, ObjectStorageError},
 };
 
+/// Migrate the metdata from v1 or v2 to v3
+/// This is a one time migration
 pub async fn run_metadata_migration(config: &Config) -> anyhow::Result<()> {
     let object_store = config.storage().get_object_store();
     let storage_metadata = get_storage_metadata(&*object_store).await?;

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -111,20 +111,20 @@ impl Config {
         let has_parseable_json = obj_store.get_object(&rel_path).await.is_ok();
 
         let has_dirs = match obj_store.list_dirs_in_storage().await {
-            Ok(dirs) => dirs.is_empty(),
+            Ok(dirs) => !dirs.is_empty(),
             Err(_) => false,
         };
 
         let has_streams = obj_store.list_streams().await.is_ok();
 
-        if has_dirs || has_parseable_json && has_streams {
+        if !has_dirs || has_parseable_json && has_streams {
             Ok(())
         } else if has_parseable_json && !has_streams {
             Err(ObjectStorageError::Custom(
                 "Could not start the server because storage contains stale data from previous deployment, please choose an empty storage and restart the server. Join us on Parseable Slack to report this incident : launchpass.com/parseable"
                 .to_owned(),
             ))
-        } else if !has_parseable_json && !has_streams && !has_dirs {
+        } else if !has_parseable_json && !has_streams && has_dirs {
             Err(ObjectStorageError::Custom(
                 "Storage contains some stale data, Please provide an Empty Storage".to_owned(),
             ))

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -126,7 +126,7 @@ impl Config {
             ))
         } else if !has_parseable_json && !has_streams && has_dirs {
             Err(ObjectStorageError::Custom(
-                "Could not start the server because storage contains some stale data, Please provide an Empty Storage.\nJoin us on Parseable Slack to report this incident : launchpass.com/parseable".to_owned(),
+                "Could not start the server because storage contains some stale data, please provide an empty storage and restart the server.\nJoin us on Parseable Slack to report this incident : launchpass.com/parseable".to_owned(),
             ))
         } else {
             Err(ObjectStorageError::Custom(

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -126,11 +126,11 @@ impl Config {
             ))
         } else if !has_parseable_json && !has_streams && has_dirs {
             Err(ObjectStorageError::Custom(
-                "Storage contains some stale data, Please provide an Empty Storage".to_owned(),
+                "Could not start the server because storage contains some stale data, Please provide an Empty Storage".to_owned(),
             ))
         } else {
             Err(ObjectStorageError::Custom(
-                "Parseable config is missing, but streams are present in Storage.\nJoin us on Parseable Slack"
+                "Could not start the server because storage contains stale data from previous deployment.\nJoin us on Parseable Slack"
                 .to_owned()
             ))
         }

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -99,12 +99,10 @@ impl Config {
         }
     }
 
-    pub fn validate_staging(&self) -> anyhow::Result<()> {
-        let staging_path = self.staging_dir();
-        validate_path_is_writeable(staging_path)
-    }
 
-    pub async fn validate_storage(&self) -> Result<(), ObjectStorageError> {
+
+
+    pub async fn validate(&self) -> Result<(), ObjectStorageError> {
         let obj_store = self.storage.get_object_store();
         let rel_path = relative_path::RelativePathBuf::from(".parseable.json");
 

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -28,7 +28,6 @@ use url::Url;
 
 use crate::oidc::{self, OpenidConfig};
 use crate::storage::{FSConfig, ObjectStorageError, ObjectStorageProvider, S3Config};
-use crate::utils::validate_path_is_writeable;
 
 pub const MIN_CACHE_SIZE_BYTES: u64 = 1000u64.pow(3); // 1 GiB
 
@@ -98,9 +97,6 @@ impl Config {
             _ => unreachable!(),
         }
     }
-
-
-
 
     pub async fn validate(&self) -> Result<(), ObjectStorageError> {
         let obj_store = self.storage.get_object_store();

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -121,7 +121,8 @@ impl Config {
             Ok(())
         } else if has_parseable_json && !has_streams {
             Err(ObjectStorageError::Custom(
-                "Parseable config found, but the Storage contains some stale data.".to_owned(),
+                "Could not start the server because storage contains stale data from previous deployment, please choose an empty storage and restart the server. Join us on Parseable Slack to report this incident : launchpass.com/parseable"
+                .to_owned(),
             ))
         } else if !has_parseable_json && !has_streams && !has_dirs {
             Err(ObjectStorageError::Custom(

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -121,16 +121,16 @@ impl Config {
             Ok(())
         } else if has_parseable_json && !has_streams {
             Err(ObjectStorageError::Custom(
-                "Could not start the server because storage contains stale data from previous deployment, please choose an empty storage and restart the server. Join us on Parseable Slack to report this incident : launchpass.com/parseable"
+                "Could not start the server because storage contains stale data from previous deployment, please choose an empty storage and restart the server.\nJoin us on Parseable Slack to report this incident : launchpass.com/parseable"
                 .to_owned(),
             ))
         } else if !has_parseable_json && !has_streams && has_dirs {
             Err(ObjectStorageError::Custom(
-                "Could not start the server because storage contains some stale data, Please provide an Empty Storage".to_owned(),
+                "Could not start the server because storage contains some stale data, Please provide an Empty Storage.\nJoin us on Parseable Slack to report this incident : launchpass.com/parseable".to_owned(),
             ))
         } else {
             Err(ObjectStorageError::Custom(
-                "Could not start the server because storage contains stale data from previous deployment.\nJoin us on Parseable Slack"
+                "Could not start the server because storage contains stale data from previous deployment.\nJoin us on Parseable Slack to report this incident : launchpass.com/parseable"
                 .to_owned()
             ))
         }

--- a/server/src/storage/localfs.rs
+++ b/server/src/storage/localfs.rs
@@ -32,7 +32,7 @@ use tokio::fs::{self, DirEntry};
 use tokio_stream::wrappers::ReadDirStream;
 
 use crate::metrics::storage::{localfs::REQUEST_RESPONSE_TIME, StorageMetrics};
-use crate::{option::validation, utils::validate_path_is_writeable};
+use crate::option::validation;
 
 use super::{object_storage, LogStream, ObjectStorage, ObjectStorageError, ObjectStorageProvider};
 
@@ -139,8 +139,8 @@ impl ObjectStorage for LocalFS {
     }
 
     async fn check(&self) -> Result<(), ObjectStorageError> {
-        fs::create_dir_all(&self.root).await?;
-        validate_path_is_writeable(&self.root)
+        fs::create_dir_all(&self.root)
+            .await
             .map_err(|e| ObjectStorageError::UnhandledError(e.into()))
     }
 

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -75,6 +75,7 @@ pub trait ObjectStorage: Sync + 'static {
     async fn check(&self) -> Result<(), ObjectStorageError>;
     async fn delete_stream(&self, stream_name: &str) -> Result<(), ObjectStorageError>;
     async fn list_streams(&self) -> Result<Vec<LogStream>, ObjectStorageError>;
+    async fn list_dirs_in_storage(&self) -> Result<Vec<String>, ObjectStorageError>;
     async fn list_dates(&self, stream_name: &str) -> Result<Vec<String>, ObjectStorageError>;
     async fn upload_file(&self, key: &str, path: &Path) -> Result<(), ObjectStorageError>;
 

--- a/server/src/storage/s3.rs
+++ b/server/src/storage/s3.rs
@@ -470,6 +470,18 @@ impl ObjectStorage for S3 {
     fn store_url(&self) -> url::Url {
         url::Url::parse(&format!("s3://{}", self.bucket)).unwrap()
     }
+
+    async fn list_dirs_in_storage(&self) -> Result<Vec<String>, ObjectStorageError> {
+        let pre = object_store::path::Path::from("/");
+        let resp = self.client.list_with_delimiter(Some(&pre)).await?;
+
+        Ok(resp
+            .common_prefixes
+            .iter()
+            .flat_map(|path| path.parts())
+            .map(|name| name.as_ref().to_string())
+            .collect::<Vec<_>>())
+    }
 }
 
 impl From<object_store::Error> for ObjectStorageError {

--- a/server/src/storage/store_metadata.rs
+++ b/server/src/storage/store_metadata.rs
@@ -92,8 +92,8 @@ impl StorageMetadata {
     }
 }
 
-// always returns remote metadata as it is source of truth
-// overwrites staging metadata while updating storage info
+/// always returns remote metadata as it is source of truth
+/// overwrites staging metadata while updating storage info
 pub async fn resolve_parseable_metadata() -> Result<StorageMetadata, ObjectStorageError> {
     let staging_metadata = get_staging_metadata()?;
     let storage = CONFIG.storage().get_object_store();
@@ -168,7 +168,7 @@ pub async fn resolve_parseable_metadata() -> Result<StorageMetadata, ObjectStora
 // variant contain remote metadata
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EnvChange {
-    /// No change in env i.e both staging and remote have same id  
+    /// No change in env i.e both staging and remote have same id
     /// or deployment id of staging is not matching with that of remote
     None(StorageMetadata),
     /// Metadata not found in storage. Treated as possible misconfiguration on user side.

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -23,8 +23,6 @@ pub mod json;
 pub mod uid;
 pub mod update;
 
-use std::path::Path;
-
 use chrono::{DateTime, NaiveDate, Timelike, Utc};
 
 #[allow(dead_code)]
@@ -41,17 +39,6 @@ pub fn hostname_unchecked() -> String {
 #[allow(dead_code)]
 pub fn capitalize_ascii(s: &str) -> String {
     s[0..1].to_uppercase() + &s[1..]
-}
-
-pub fn validate_path_is_writeable(path: &Path) -> anyhow::Result<()> {
-    let Ok(md) = std::fs::metadata(path) else {
-        anyhow::bail!("Could not read metadata for staging dir")
-    };
-    let permissions = md.permissions();
-    if permissions.readonly() {
-        anyhow::bail!("Staging directory {} is not writable", path.display())
-    }
-    Ok(())
 }
 
 /// Convert minutes to a slot range
@@ -263,7 +250,7 @@ mod tests {
         ]
     )]
     #[case::same_hour_with_00_to_59_minute_block(
-        "2022-06-11T16:00:00+00:00", "2022-06-11T16:59:59+00:00",   
+        "2022-06-11T16:00:00+00:00", "2022-06-11T16:59:59+00:00",
         &["date=2022-06-11/hour=16/"]
     )]
     #[case::same_date_different_hours_coherent_minute(
@@ -274,14 +261,14 @@ mod tests {
         ]
     )]
     #[case::same_date_different_hours_incoherent_minutes(
-        "2022-06-11T15:59:00+00:00", "2022-06-11T16:01:00+00:00", 
+        "2022-06-11T15:59:00+00:00", "2022-06-11T16:01:00+00:00",
         &[
             "date=2022-06-11/hour=15/minute=59/",
             "date=2022-06-11/hour=16/minute=00/"
         ]
     )]
     #[case::same_date_different_hours_whole_hours_between_incoherent_minutes(
-        "2022-06-11T15:59:00+00:00", "2022-06-11T17:01:00+00:00", 
+        "2022-06-11T15:59:00+00:00", "2022-06-11T17:01:00+00:00",
         &[
             "date=2022-06-11/hour=15/minute=59/",
             "date=2022-06-11/hour=16/",
@@ -289,14 +276,14 @@ mod tests {
         ]
     )]
     #[case::different_date_coherent_hours_and_minutes(
-        "2022-06-11T00:00:00+00:00", "2022-06-13T00:00:00+00:00", 
+        "2022-06-11T00:00:00+00:00", "2022-06-13T00:00:00+00:00",
         &[
             "date=2022-06-11/",
             "date=2022-06-12/"
         ]
     )]
     #[case::different_date_incoherent_hours_coherent_minutes(
-        "2022-06-11T23:00:01+00:00", "2022-06-12T01:59:59+00:00", 
+        "2022-06-11T23:00:01+00:00", "2022-06-12T01:59:59+00:00",
         &[
             "date=2022-06-11/hour=23/",
             "date=2022-06-12/hour=00/",
@@ -304,7 +291,7 @@ mod tests {
         ]
     )]
     #[case::different_date_incoherent_hours_incoherent_minutes(
-        "2022-06-11T23:59:59+00:00", "2022-06-12T00:01:00+00:00", 
+        "2022-06-11T23:59:59+00:00", "2022-06-12T00:01:00+00:00",
         &[
             "date=2022-06-11/hour=23/minute=59/",
             "date=2022-06-12/hour=00/minute=00/"


### PR DESCRIPTION
Fixes #615.

### Description

Return the proper Error Message if the Data Store is in an invalid state.

Invalid States
- `.parseable.json` does not exists but directories with `.stream.json` exist
- `.parseable.json` does not exists but directories with `.stream.json` do not exist
- `.parseable.json` does not exists and directories without `.stream.json` exists

Added a validation step to check if the Storage Location is in a valid state.

- Add new trait in `ObjectStorage`:  `async fn list_dirs_in_storage(&self) -> Result<Vec<String>, ObjectStorageError>`
- Impl list_dirs_in_storage for `localfs` and `s3`
- Add a validation method for checking if the Data Store is in a valid state.

<hr>

This PR has:
- [x ] been tested to ensure log ingestion and log query works.
- [ x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
