### PR TITLE
Separated out Ingest and Query functionality of the server

### DIFF
--- a/server/src/handlers/http.rs
+++ b/server/src/handlers/http.rs
@@ -32,7 +32,7 @@ use openid::Discovered;
 use rustls::{Certificate, PrivateKey, ServerConfig};
 use rustls_pemfile::{certs, pkcs8_private_keys};
 
-use crate::option::CONFIG;
+use crate::option::{CONFIG, Mode};
 use crate::rbac::role::Action;
 
 use self::middleware::{DisAllowRootUser, RouteExt};
@@ -301,6 +301,37 @@ pub fn configure_routes(
     // Base path "{url}/api/v1"
     let web_scope = web::scope(&base_path());
 
+    // let web_scope = match CONFIG.parseable.mode {
+    //     Mode::Query | Mode::All => {
+            // In Query Mode
+            // POST "/query" ==> Get results of the SQL query passed in request body
+    //         web_scope
+    //         .service(
+    //             web::resource("/query")
+    //                 .route(web::post().to(query::query).authorize(Action::Query)),
+    //         )
+    //         .service(user_api)
+    //         .service(llm_query_api)
+    //         .service(oauth_api)
+    //         .service(role_api)
+    //     }
+
+    //     Mode::Ingest | Mode::All => {
+            // In Ingest Mode
+    //         web_scope
+            // POST "/ingest" ==> Post logs to given log stream based on header
+    //         .service(
+    //             web::resource("/ingest")
+    //                 .route(
+    //                     web::post()
+    //                         .to(ingest::ingest)
+    //                         .authorize_for_stream(Action::Ingest),
+    //                 )
+    //                 .app_data(web::PayloadConfig::default().limit(MAX_EVENT_PAYLOAD_SIZE)),
+    //         )
+    //     }
+    // };
+
     let web_scope = if CONFIG.parseable.mode == crate::option::Mode::Query
         || CONFIG.parseable.mode == crate::option::Mode::All
     {
@@ -316,6 +347,9 @@ pub fn configure_routes(
             .service(oauth_api)
             .service(role_api)
     } else {
+        unreachable!("Invalid mode")
+    };
+    let web_scope = if CONFIG.parseable.mode == crate::option::Mode::Ingest || CONFIG.parseable.mode == crate::option::Mode::All {
         // In Ingest Mode
         web_scope
             // POST "/ingest" ==> Post logs to given log stream based on header
@@ -328,6 +362,8 @@ pub fn configure_routes(
                     )
                     .app_data(web::PayloadConfig::default().limit(MAX_EVENT_PAYLOAD_SIZE)),
             )
+    } else {
+        unreachable!("Invalid mode")
     };
 
     // Deny request if username is same as the env variable P_USERNAME.

--- a/server/src/handlers/http/middleware.rs
+++ b/server/src/handlers/http/middleware.rs
@@ -27,9 +27,12 @@ use actix_web::{
 };
 use futures_util::future::LocalBoxFuture;
 
-use crate::handlers::{
-    AUTHORIZATION_KEY, KINESIS_COMMON_ATTRIBUTES_KEY, LOG_SOURCE_KEY, LOG_SOURCE_KINESIS,
-    STREAM_NAME_HEADER_KEY,
+use crate::{
+    handlers::{
+        AUTHORIZATION_KEY, KINESIS_COMMON_ATTRIBUTES_KEY, LOG_SOURCE_KEY, LOG_SOURCE_KINESIS,
+        STREAM_NAME_HEADER_KEY,
+    },
+    option::Mode,
 };
 use crate::{
     option::CONFIG,
@@ -250,5 +253,100 @@ where
             }
             fut.await
         })
+    }
+}
+
+/// ModeFilterMiddleware factory
+pub struct ModeFilter;
+
+/// PathFilterMiddleware needs to implement Service trait
+impl<S, B> Transform<S, ServiceRequest> for ModeFilter
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type InitError = ();
+    type Transform = ModeFilterMiddleware<S>;
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ready(Ok(ModeFilterMiddleware { service }))
+    }
+}
+
+/// Actual middleware service
+pub struct ModeFilterMiddleware<S> {
+    service: S,
+}
+
+/// Impl the service trait for the middleware service
+impl<S, B> Service<ServiceRequest> for ModeFilterMiddleware<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S::Future: 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    // impl poll_ready
+    actix_web::dev::forward_ready!(service);
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        let path = req.path();
+        let mode = &CONFIG.parseable.mode;
+
+        // change error messages based on mode
+        match mode {
+            Mode::Query => {
+                let cond = path.split('/').any(|x| x == "ingest");
+                if cond {
+                    Box::pin(async {
+                        Err(actix_web::error::ErrorUnauthorized(
+                            "Ingest API cannot be accessed in Query Mode",
+                        ))
+                    })
+                } else {
+                    let fut = self.service.call(req);
+
+                    Box::pin(async move {
+                        let res = fut.await?;
+                        Ok(res)
+                    })
+                }
+            }
+
+            Mode::Ingest => {
+                let accessable_endpoints = ["ingest", "logstream", "liveness", "readiness"];
+                let cond = path.split('/').any(|x| accessable_endpoints.contains(&x));
+                if !cond {
+                    Box::pin(async {
+                        Err(actix_web::error::ErrorUnauthorized(
+                            "Only Ingestion API can be accessed in Ingest Mode",
+                        ))
+                    })
+                } else {
+                    let fut = self.service.call(req);
+
+                    Box::pin(async move {
+                        let res = fut.await?;
+                        Ok(res)
+                    })
+                }
+            }
+
+            Mode::All => {
+                let fut = self.service.call(req);
+
+                Box::pin(async move {
+                    let res = fut.await?;
+                    Ok(res)
+                })
+            }
+        }
     }
 }

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -361,12 +361,14 @@ impl FromArgMatches for Server {
             .get_one::<String>(Self::MODE)
             // .cloned()
             //.expect("default for mode")
-            .expect("Mode not set").as_str() {
-                "query" => Mode::Query,
-                "ingest" => Mode::Ingest,
-                "all" => Mode::All,
-                _ => unreachable!(),
-            };
+            .expect("Mode not set")
+            .as_str()
+        {
+            "query" => Mode::Query,
+            "ingest" => Mode::Ingest,
+            "all" => Mode::All,
+            _ => unreachable!(),
+        };
 
         Ok(())
     }

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -251,6 +251,9 @@ pub struct Server {
 
     /// Parquet compression algorithm
     pub parquet_compression: Compression,
+
+    /// Mode of operation
+    pub mode: String,
 }
 
 impl FromArgMatches for Server {
@@ -354,6 +357,12 @@ impl FromArgMatches for Server {
             _ => None,
         };
 
+        self.mode = m
+            .get_one::<String>(Self::MODE)
+            .cloned()
+            //.expect("default for mode")
+            .expect("Mode not set");
+
         Ok(())
     }
 }
@@ -382,6 +391,7 @@ impl Server {
     pub const QUERY_MEM_POOL_SIZE: &'static str = "query-mempool-size";
     pub const ROW_GROUP_SIZE: &'static str = "row-group-size";
     pub const PARQUET_COMPRESSION_ALGO: &'static str = "compression-algo";
+    pub const MODE: &'static str = "mode";
     pub const DEFAULT_USERNAME: &'static str = "admin";
     pub const DEFAULT_PASSWORD: &'static str = "admin";
 
@@ -578,6 +588,18 @@ impl Server {
                     .default_value("16384")
                     .value_parser(value_parser!(usize))
                     .help("Number of rows in a row group"),
+            ).arg(
+                Arg::new(Self::MODE)
+                    .long(Self::MODE)
+                    .env("P_MODE")
+                    .value_name("STRING")
+                    .required(true)
+                    // .default_value("all")
+                    .value_parser([
+                        "query",
+                        "ingest",
+                        "all"])
+                    .help("Mode of operation"),
             )
             .arg(
                 Arg::new(Self::PARQUET_COMPRESSION_ALGO)

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -598,7 +598,7 @@ impl Server {
                     .long(Self::MODE)
                     .env("P_MODE")
                     .value_name("STRING")
-                    .required(true)
+                    .required(false)
                     .default_value("all")
                     .value_parser([
                         "query",

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -359,8 +359,6 @@ impl FromArgMatches for Server {
 
         self.mode = match m
             .get_one::<String>(Self::MODE)
-            // .cloned()
-            //.expect("default for mode")
             .expect("Mode not set")
             .as_str()
         {

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -601,7 +601,7 @@ impl Server {
                     .env("P_MODE")
                     .value_name("STRING")
                     .required(true)
-                    // .default_value("all")
+                    .default_value("all")
                     .value_parser([
                         "query",
                         "ingest",

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -253,7 +253,7 @@ pub struct Server {
     pub parquet_compression: Compression,
 
     /// Mode of operation
-    pub mode: String,
+    pub mode: Mode,
 }
 
 impl FromArgMatches for Server {
@@ -357,11 +357,16 @@ impl FromArgMatches for Server {
             _ => None,
         };
 
-        self.mode = m
+        self.mode = match m
             .get_one::<String>(Self::MODE)
-            .cloned()
+            // .cloned()
             //.expect("default for mode")
-            .expect("Mode not set");
+            .expect("Mode not set").as_str() {
+                "query" => Mode::Query,
+                "ingest" => Mode::Ingest,
+                "all" => Mode::All,
+                _ => unreachable!(),
+            };
 
         Ok(())
     }
@@ -624,6 +629,14 @@ impl Server {
                     .multiple(true)
         )
     }
+}
+
+#[derive(Debug, Default, Eq, PartialEq)]
+pub enum Mode {
+    Query,
+    Ingest,
+    #[default]
+    All,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]


### PR DESCRIPTION
Fixes #617.

### Description

Separate out the Ingestion and Querying functionality of the server based on either a cli option `--mode` or an environment variable `P_MODE`. 

Using a custom middleware to filter out non-accessible endpoints. 

##### Changes
1. Update CLI to accept `--mode` flag.
2. Configuring routes to properly filter out the endpoints based on the mode.
3. Addition of middleware that properly filters out the endpoints.


<hr>

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
