### PR TITLE
Update Error Message

### DIFF
--- a/server/src/handlers/http/middleware.rs
+++ b/server/src/handlers/http/middleware.rs
@@ -307,7 +307,7 @@ where
                 if cond {
                     Box::pin(async {
                         Err(actix_web::error::ErrorUnauthorized(
-                            "Ingest API cannot be accessed in Query Mode",
+                            "Ingestion API cannot be accessed in Query Mode",
                         ))
                     })
                 } else {

--- a/server/src/handlers/http/middleware.rs
+++ b/server/src/handlers/http/middleware.rs
@@ -299,15 +299,23 @@ where
     fn call(&self, req: ServiceRequest) -> Self::Future {
         let path = req.path();
         let mode = &CONFIG.parseable.mode;
-
         // change error messages based on mode
         match mode {
             Mode::Query => {
-                let cond = path.split('/').any(|x| x == "ingest");
-                if cond {
+                // In Query mode, only allows /ingest endpoint, and /logstream endpoint with GET method
+                let base_cond = path.split('/').any(|x| x == "ingest");
+                let logstream_cond =
+                    !(path.split('/').any(|x| x == "logstream") && req.method() == "GET");
+                if base_cond {
                     Box::pin(async {
                         Err(actix_web::error::ErrorUnauthorized(
                             "Ingestion API cannot be accessed in Query Mode",
+                        ))
+                    })
+                } else if logstream_cond {
+                    Box::pin(async {
+                        Err(actix_web::error::ErrorUnauthorized(
+                            "Logstream cannot be changed in Query Mode",
                         ))
                     })
                 } else {


### PR DESCRIPTION
Fixes #641 

### Description

Previously in Query Mode, All logstream endpoints were allowed.
Now only GET requests are allowed

<hr>

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
