### PR TITLE
Modify init_scheduler

### DIFF
--- a/server/src/handlers/http/logstream.rs
+++ b/server/src/handlers/http/logstream.rs
@@ -26,7 +26,7 @@ use serde_json::Value;
 use crate::alerts::Alerts;
 use crate::metadata::STREAM_INFO;
 use crate::option::CONFIG;
-use crate::storage::retention::{self, Retention};
+use crate::storage::retention::Retention;
 use crate::storage::{LogStream, StorageDir};
 use crate::{event, stats};
 use crate::{metadata, validator};
@@ -218,8 +218,6 @@ pub async fn put_retention(
         .get_object_store()
         .put_retention(&stream_name, &retention)
         .await?;
-
-    retention::init_scheduler(&stream_name, retention);
 
     Ok((
         format!("set retention configuration for log stream {stream_name}"),

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -76,7 +76,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // track all parquet files already in the data directory
-    storage::retention::load_retention_from_global().await;
+    storage::retention::load_retention_from_global();
     // load data from stats back to prometheus metrics
     metrics::load_from_stats_from_storage().await;
 


### PR DESCRIPTION
Fixes #636 

### Description
Earlier, separate scheduler was initialized for each stream on load time or whenever retention period is set. Now, a single scheduler is initialized which checks retention config of all the streams and performs the retention cleanup.
