### PR TITLE
fix for #651: removed use of env var P_STORAGE_UPLOAD_INTERVAL

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -50,6 +50,7 @@ mod validator;
 use option::CONFIG;
 
 use crate::localcache::LocalCacheManager;
+pub const STORAGE_UPLOAD_INTERVAL: u32 = 60;
 
 #[actix_web::main]
 async fn main() -> anyhow::Result<()> {
@@ -129,7 +130,7 @@ fn object_store_sync() -> (JoinHandle<()>, oneshot::Receiver<()>, oneshot::Sende
             rt.block_on(async {
                 let mut scheduler = AsyncScheduler::new();
                 scheduler
-                    .every((CONFIG.parseable.upload_interval as u32).seconds())
+                    .every(STORAGE_UPLOAD_INTERVAL.seconds())
                     // Extra time interval is added so that this schedular does not race with local sync.
                     .plus(5u32.seconds())
                     .run(|| async {

--- a/server/src/storage/staging.rs
+++ b/server/src/storage/staging.rs
@@ -134,16 +134,12 @@ impl StorageDir {
                 .ends_with(&hot_filename)
         });
 
-        //check if arrow files is not empty, fetch the parquet file path from last file from sorted arrow file list
-        if !(arrow_files.is_empty()) {
-            arrow_files.sort();
-            let key = Self::arrow_path_to_parquet(arrow_files.last().unwrap());
-            for arrow_file_path in arrow_files {
-                grouped_arrow_file
-                    .entry(key.clone())
-                    .or_default()
-                    .push(arrow_file_path);
-            }
+        for arrow_file_path in arrow_files {
+            let key = Self::arrow_path_to_parquet(&arrow_file_path);
+            grouped_arrow_file
+                .entry(key)
+                .or_default()
+                .push(arrow_file_path);
         }
 
         grouped_arrow_file


### PR DESCRIPTION
fix for #651: removed use of env var P_STORAGE_UPLOAD_INTERVAL
added const of 60 secs to be used for local to storage sync

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes: #651 

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
