### PR TITLE
fix: absolute url for windows

### DIFF
--- a/server/src/storage/localfs.rs
+++ b/server/src/storage/localfs.rs
@@ -212,7 +212,7 @@ impl ObjectStorage for LocalFS {
 
     fn absolute_url(&self, prefix: &RelativePath) -> object_store::path::Path {
         object_store::path::Path::parse(
-            format!("{}", self.root.join(prefix.as_str()).display()).trim_start_matches('/'),
+            format!("{}", self.root.join(RelativePath::new(prefix).as_str()).display()),
         )
         .unwrap()
     }

--- a/server/src/storage/localfs.rs
+++ b/server/src/storage/localfs.rs
@@ -211,7 +211,9 @@ impl ObjectStorage for LocalFS {
     }
 
     fn absolute_url(&self, prefix: &RelativePath) -> object_store::path::Path {
-        object_store::path::Path::parse(format!("{}", self.root.join(prefix.as_str()).display()).trim_start_matches(std::path::MAIN_SEPARATOR),
+        object_store::path::Path::parse(
+            format!("{}", self.root.join(prefix.as_str()).display())
+                .trim_start_matches(std::path::MAIN_SEPARATOR),
         )
         .unwrap()
     }

--- a/server/src/storage/localfs.rs
+++ b/server/src/storage/localfs.rs
@@ -211,9 +211,10 @@ impl ObjectStorage for LocalFS {
     }
 
     fn absolute_url(&self, prefix: &RelativePath) -> object_store::path::Path {
-        object_store::path::Path::parse(
-            format!("{}", self.root.join(RelativePath::new(prefix).as_str()).display()),
-        )
+        object_store::path::Path::parse(format!(
+            "{}",
+            self.root.join(RelativePath::new(prefix).as_str()).display()
+        ))
         .unwrap()
     }
 

--- a/server/src/storage/localfs.rs
+++ b/server/src/storage/localfs.rs
@@ -211,10 +211,8 @@ impl ObjectStorage for LocalFS {
     }
 
     fn absolute_url(&self, prefix: &RelativePath) -> object_store::path::Path {
-        object_store::path::Path::parse(format!(
-            "{}",
-            self.root.join(RelativePath::new(prefix).as_str()).display()
-        ))
+        object_store::path::Path::parse(format!("{}", self.root.join(prefix.as_str()).display()).trim_start_matches(std::path::MAIN_SEPARATOR),
+        )
         .unwrap()
     }
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes https://github.com/parseablehq/parseable/issues/650

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

Fixes #650. 

~Uses `RelativePath::new` function for platform independent relative paths.~

EDIT: Uses `std::path::MAIN_SEPARATOR` instead of hardcore `/` which handles slashes accordingly. 

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.
