### PR TITLE
Revert "fix: avoid removal of retention configuration while updating snapshot"

### DIFF
--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -37,7 +37,6 @@ pub use store_metadata::{
     put_remote_metadata, put_staging_metadata, resolve_parseable_metadata, StorageMetadata,
 };
 
-use self::retention::Retention;
 pub use self::staging::StorageDir;
 
 /// local sync interval to move data.records to /tmp dir of that stream.
@@ -77,7 +76,6 @@ pub struct ObjectStoreFormat {
     pub snapshot: Snapshot,
     #[serde(default)]
     pub cache_enabled: bool,
-    pub retention: Retention,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -120,7 +118,6 @@ impl Default for ObjectStoreFormat {
             stats: Stats::default(),
             snapshot: Snapshot::default(),
             cache_enabled: false,
-            retention: Retention::new(),
         }
     }
 }

--- a/server/src/storage/retention.rs
+++ b/server/src/storage/retention.rs
@@ -134,12 +134,6 @@ struct TaskView {
     duration: String,
 }
 
-impl Retention {
-    pub fn new() -> Self {
-        Self { tasks: Vec::new() }
-    }
-}
-
 impl TryFrom<Vec<TaskView>> for Retention {
     type Error = String;
 


### PR DESCRIPTION
Reverts parseablehq/parseable#661 because with this change we're backward incompatible with older versions where `.stream.json` doesn't contain `retention` field. 

