### PR TITLE
fix: avoid removal of retention configuration while updating snapshot

### DIFF
--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -37,6 +37,7 @@ pub use store_metadata::{
     put_remote_metadata, put_staging_metadata, resolve_parseable_metadata, StorageMetadata,
 };
 
+use self::retention::Retention;
 pub use self::staging::StorageDir;
 
 /// local sync interval to move data.records to /tmp dir of that stream.
@@ -76,6 +77,8 @@ pub struct ObjectStoreFormat {
     pub snapshot: Snapshot,
     #[serde(default)]
     pub cache_enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retention: Option<Retention>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -118,6 +121,7 @@ impl Default for ObjectStoreFormat {
             stats: Stats::default(),
             snapshot: Snapshot::default(),
             cache_enabled: false,
+            retention: None,
         }
     }
 }


### PR DESCRIPTION
Fixes #654 

### Description
Added `retention` in `ObjectStoreFormat` struct so that update_snapshot gets the complete stream metadata information and don't override the retention configuration.