### PR TITLE
Ingestion partition change

### DIFF
--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -81,7 +81,7 @@ fn get_file_bounds(
             .find(|col| col.name == partition_column)
             .unwrap()
             .stats
-            .clone()
+            .as_ref()
             .unwrap()
         {
             column::TypedStatistics::Int(stats) => (
@@ -101,7 +101,7 @@ fn get_file_bounds(
             .find(|col| col.name == partition_column)
             .unwrap()
             .stats
-            .clone()
+            .as_ref()
             .unwrap()
         {
             column::TypedStatistics::String(stats) => (

--- a/server/src/catalog/manifest.rs
+++ b/server/src/catalog/manifest.rs
@@ -112,7 +112,6 @@ pub fn create_from_parquet_file(
     let columns = column_statistics(row_groups);
     manifest_file.columns = columns.into_values().collect();
     let mut sort_orders = sort_order(row_groups);
-
     if let Some(last_sort_order) = sort_orders.pop() {
         if sort_orders
             .into_iter()
@@ -131,6 +130,7 @@ fn sort_order(
     let mut sort_orders = Vec::new();
     for row_group in row_groups {
         let sort_order = row_group.sorting_columns().unwrap();
+        println!("sort_order: {:?}", sort_order);
         let sort_order = sort_order
             .iter()
             .map(|sort_order| {
@@ -155,7 +155,8 @@ fn sort_order(
             })
             .collect_vec();
 
-        sort_orders.push(sort_order)
+        sort_orders.push(sort_order);
+        
     }
     sort_orders
 }

--- a/server/src/catalog/manifest.rs
+++ b/server/src/catalog/manifest.rs
@@ -130,7 +130,6 @@ fn sort_order(
     let mut sort_orders = Vec::new();
     for row_group in row_groups {
         let sort_order = row_group.sorting_columns().unwrap();
-        println!("sort_order: {:?}", sort_order);
         let sort_order = sort_order
             .iter()
             .map(|sort_order| {
@@ -156,7 +155,6 @@ fn sort_order(
             .collect_vec();
 
         sort_orders.push(sort_order);
-        
     }
     sort_orders
 }

--- a/server/src/event.rs
+++ b/server/src/event.rs
@@ -26,10 +26,10 @@ use itertools::Itertools;
 
 use std::sync::Arc;
 
-use crate::metadata;
-use chrono::NaiveDateTime;
 use self::error::EventError;
 pub use self::writer::STREAM_WRITERS;
+use crate::metadata;
+use chrono::NaiveDateTime;
 
 pub const DEFAULT_TIMESTAMP_KEY: &str = "p_timestamp";
 pub const DEFAULT_TAGS_KEY: &str = "p_tags";
@@ -55,7 +55,12 @@ impl Event {
             commit_schema(&self.stream_name, self.rb.schema())?;
         }
 
-        Self::process_event(&self.stream_name, &key, self.rb.clone(), self.parsed_timestamp)?;
+        Self::process_event(
+            &self.stream_name,
+            &key,
+            self.rb.clone(),
+            self.parsed_timestamp,
+        )?;
 
         metadata::STREAM_INFO.update_stats(
             &self.stream_name,

--- a/server/src/event/format.rs
+++ b/server/src/event/format.rs
@@ -53,14 +53,14 @@ pub trait EventFormat: Sized {
             return Err(anyhow!("field {} is a reserved field", DEFAULT_TAGS_KEY));
         };
 
-        if get_field(&schema, DEFAULT_TAGS_KEY).is_some() {
+        if get_field(&schema, DEFAULT_METADATA_KEY).is_some() {
             return Err(anyhow!(
                 "field {} is a reserved field",
                 DEFAULT_METADATA_KEY
             ));
         };
 
-        if get_field(&schema, DEFAULT_TAGS_KEY).is_some() {
+        if get_field(&schema, DEFAULT_TIMESTAMP_KEY).is_some() {
             return Err(anyhow!(
                 "field {} is a reserved field",
                 DEFAULT_TIMESTAMP_KEY

--- a/server/src/event/writer.rs
+++ b/server/src/event/writer.rs
@@ -30,7 +30,7 @@ use crate::utils;
 use self::{errors::StreamWriterError, file_writer::FileWriter, mem_writer::MemWriter};
 use arrow_array::{RecordBatch, TimestampMillisecondArray};
 use arrow_schema::Schema;
-use chrono::NaiveDateTime;
+use chrono::{NaiveDateTime, Utc};
 use derive_more::{Deref, DerefMut};
 use once_cell::sync::Lazy;
 
@@ -55,9 +55,9 @@ impl Writer {
             rb.schema(),
             &rb,
             &[0],
-            &[Arc::new(get_timestamp_array(rb.num_rows(), parsed_timestamp))],
+            &[Arc::new(get_timestamp_array(rb.num_rows()))],
         );
-
+        
         self.disk.push(stream_name, schema_key, &rb, parsed_timestamp)?;
         self.mem.push(schema_key, rb);
         Ok(())
@@ -138,10 +138,8 @@ impl WriterTable {
     }
 }
 
-fn get_timestamp_array(size: usize, parsed_timestamp: NaiveDateTime) -> TimestampMillisecondArray {
-    println!("parsed_timestamp: {:?}", parsed_timestamp);
-    println!("parsed_timestamp: {:?}", parsed_timestamp.timestamp_millis());
-    TimestampMillisecondArray::from_value(parsed_timestamp.timestamp_millis(), size)
+fn get_timestamp_array(size: usize) -> TimestampMillisecondArray {
+    TimestampMillisecondArray::from_value(Utc::now().timestamp_millis(), size)
     
 }
 

--- a/server/src/event/writer/file_writer.rs
+++ b/server/src/event/writer/file_writer.rs
@@ -17,13 +17,13 @@
  *
  */
 
+use arrow_array::RecordBatch;
+use arrow_ipc::writer::StreamWriter;
+use chrono::NaiveDateTime;
+use derive_more::{Deref, DerefMut};
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
 use std::path::PathBuf;
-use chrono::NaiveDateTime;
-use arrow_array::RecordBatch;
-use arrow_ipc::writer::StreamWriter;
-use derive_more::{Deref, DerefMut};
 
 use crate::storage::staging::StorageDir;
 
@@ -44,9 +44,10 @@ impl FileWriter {
         stream_name: &str,
         schema_key: &str,
         record: &RecordBatch,
-        parsed_timestamp: NaiveDateTime
+        parsed_timestamp: NaiveDateTime,
     ) -> Result<(), StreamWriterError> {
-        let (path, writer) = init_new_stream_writer_file(stream_name, schema_key, record, parsed_timestamp)?;
+        let (path, writer) =
+            init_new_stream_writer_file(stream_name, schema_key, record, parsed_timestamp)?;
         self.insert(
             schema_key.to_owned(),
             ArrowWriter {

--- a/server/src/handlers.rs
+++ b/server/src/handlers.rs
@@ -23,7 +23,9 @@ const PREFIX_TAGS: &str = "x-p-tag-";
 const PREFIX_META: &str = "x-p-meta-";
 const STREAM_NAME_HEADER_KEY: &str = "x-p-stream";
 const LOG_SOURCE_KEY: &str = "x-p-log-source";
-
+const TIME_PARTITION_KEY: &str = "x-p-time-partition";
+const TIME_PARTITION_FORMAT_KEY: &str = "x-p-time-partition-format";
+const TIME_PARTITION_TIMEZONE_KEY: &str = "x-p-time-partition-timezone";
 const AUTHORIZATION_KEY: &str = "authorization";
 const SEPARATOR: char = '^';
 

--- a/server/src/handlers.rs
+++ b/server/src/handlers.rs
@@ -24,8 +24,6 @@ const PREFIX_META: &str = "x-p-meta-";
 const STREAM_NAME_HEADER_KEY: &str = "x-p-stream";
 const LOG_SOURCE_KEY: &str = "x-p-log-source";
 const TIME_PARTITION_KEY: &str = "x-p-time-partition";
-const TIME_PARTITION_FORMAT_KEY: &str = "x-p-time-partition-format";
-const TIME_PARTITION_TIMEZONE_KEY: &str = "x-p-time-partition-timezone";
 const AUTHORIZATION_KEY: &str = "authorization";
 const SEPARATOR: char = '^';
 

--- a/server/src/handlers/http/ingest.rs
+++ b/server/src/handlers/http/ingest.rs
@@ -715,7 +715,7 @@ mod tests {
 
         let req = TestRequest::default().to_http_request();
 
-        let (_, rb,..) = into_event_batch(
+        let (_, rb, ..) = into_event_batch(
             req,
             Bytes::from(serde_json::to_vec(&json).unwrap()),
             HashMap::default(),

--- a/server/src/handlers/http/ingest.rs
+++ b/server/src/handlers/http/ingest.rs
@@ -183,7 +183,7 @@ pub async fn create_stream_if_not_exists(stream_name: &str) -> Result<(), PostEr
     if STREAM_INFO.stream_exists(stream_name) {
         return Ok(());
     }
-    super::logstream::create_stream(stream_name.to_string(), String::new()).await?;
+    super::logstream::create_stream(stream_name.to_string(), String::default()).await?;
     Ok(())
 }
 
@@ -282,7 +282,7 @@ mod tests {
             .append_header((PREFIX_META.to_string() + "C", "meta1"))
             .to_http_request();
 
-        let (size, rb, _, _) = into_event_batch(
+        let (size, rb, ..) = into_event_batch(
             req,
             Bytes::from(serde_json::to_vec(&json).unwrap()),
             HashMap::default(),
@@ -329,7 +329,7 @@ mod tests {
 
         let req = TestRequest::default().to_http_request();
 
-        let (_, rb, _, _) = into_event_batch(
+        let (_, rb, ..) = into_event_batch(
             req,
             Bytes::from(serde_json::to_vec(&json).unwrap()),
             HashMap::default(),
@@ -367,7 +367,7 @@ mod tests {
 
         let req = TestRequest::default().to_http_request();
 
-        let (_, rb, _, _) = into_event_batch(
+        let (_, rb, ..) = into_event_batch(
             req,
             Bytes::from(serde_json::to_vec(&json).unwrap()),
             schema,
@@ -429,7 +429,7 @@ mod tests {
 
         let req = TestRequest::default().to_http_request();
 
-        let (_, rb, _, _) = into_event_batch(
+        let (_, rb, ..) = into_event_batch(
             req,
             Bytes::from(serde_json::to_vec(&json).unwrap()),
             schema,
@@ -476,7 +476,7 @@ mod tests {
 
         let req = TestRequest::default().to_http_request();
 
-        let (_, rb, _, _) = into_event_batch(
+        let (_, rb, ..) = into_event_batch(
             req,
             Bytes::from(serde_json::to_vec(&json).unwrap()),
             HashMap::default(),
@@ -530,7 +530,7 @@ mod tests {
 
         let req = TestRequest::default().to_http_request();
 
-        let (_, rb, _, _) = into_event_batch(
+        let (_, rb, ..) = into_event_batch(
             req,
             Bytes::from(serde_json::to_vec(&json).unwrap()),
             HashMap::default(),
@@ -584,7 +584,7 @@ mod tests {
         );
         let req = TestRequest::default().to_http_request();
 
-        let (_, rb, _, _) = into_event_batch(
+        let (_, rb, ..) = into_event_batch(
             req,
             Bytes::from(serde_json::to_vec(&json).unwrap()),
             schema,
@@ -630,7 +630,7 @@ mod tests {
 
         let req = TestRequest::default().to_http_request();
 
-        let (_, rb, _, _) = into_event_batch(
+        let (_, rb, ..) = into_event_batch(
             req,
             Bytes::from(serde_json::to_vec(&json).unwrap()),
             HashMap::default(),
@@ -715,7 +715,7 @@ mod tests {
 
         let req = TestRequest::default().to_http_request();
 
-        let (_, rb, _, _) = into_event_batch(
+        let (_, rb,..) = into_event_batch(
             req,
             Bytes::from(serde_json::to_vec(&json).unwrap()),
             HashMap::default(),

--- a/server/src/handlers/http/logstream.rs
+++ b/server/src/handlers/http/logstream.rs
@@ -30,7 +30,7 @@ use crate::storage::retention::Retention;
 use crate::storage::{LogStream, StorageDir};
 use crate::{catalog, event, stats};
 use crate::{metadata, validator};
-use crate::handlers::{TIME_PARTITION_FORMAT_KEY, TIME_PARTITION_KEY, TIME_PARTITION_TIMEZONE_KEY};
+use crate::handlers::TIME_PARTITION_KEY;
 use self::error::{CreateStreamError, StreamError};
 
 pub async fn delete(req: HttpRequest) -> Result<impl Responder, StreamError> {
@@ -111,34 +111,13 @@ pub async fn get_alert(req: HttpRequest) -> Result<impl Responder, StreamError> 
 
 pub async fn put_stream(req: HttpRequest) -> Result<impl Responder, StreamError> {
     let mut time_partition: String = String::new();
-    let mut time_partition_format: String = String::new();
-    let mut time_partition_timezone: String = String::new();
     if let Some((_, time_partition_name)) = req
         .headers()
         .iter()
         .find(|&(key, _)| key == TIME_PARTITION_KEY)
     {
         time_partition = time_partition_name.to_str().unwrap().to_owned();
-        println!("time_partition: {:?}", time_partition);
-
-        if let Some((_, header_time_partition_format)) = req
-        .headers()
-        .iter()
-        .find(|&(key, _)| key == TIME_PARTITION_FORMAT_KEY){
-            time_partition_format = header_time_partition_format.to_str().unwrap().to_owned();
-            println!("time_partition_format: {:?}", time_partition_format);
-        }else {
-            return Err(StreamError::TimePartitionFormatMissing(time_partition));
-        }
-        if let Some((_, header_time_partition_timezone)) = req
-        .headers()
-        .iter()
-        .find(|&(key, _)| key == TIME_PARTITION_TIMEZONE_KEY){
-            time_partition_timezone = header_time_partition_timezone.to_str().unwrap().to_owned();
-            println!("time_partition_timezone: {:?}", time_partition_timezone);
-        }else {
-           // return Err(StreamError::TimePartitionTimeZoneMissing(time_partition));
-        }
+        
     }
     let stream_name: String = req.match_info().get("logstream").unwrap().parse().unwrap();
 
@@ -151,7 +130,7 @@ pub async fn put_stream(req: HttpRequest) -> Result<impl Responder, StreamError>
             status: StatusCode::BAD_REQUEST,
         });
     } else {
-        create_stream(stream_name, time_partition, time_partition_format, time_partition_timezone).await?;
+        create_stream(stream_name, time_partition).await?;
     }
 
     Ok(("log stream created", StatusCode::OK))
@@ -358,13 +337,13 @@ fn remove_id_from_alerts(value: &mut Value) {
     }
 }
 
-pub async fn create_stream(stream_name: String, time_partition: String, time_partition_format: String, time_partition_timezone: String) -> Result<(), CreateStreamError> {
+pub async fn create_stream(stream_name: String, time_partition: String) -> Result<(), CreateStreamError> {
     // fail to proceed if invalid stream name
     validator::stream_name(&stream_name)?;
 
     // Proceed to create log stream if it doesn't exist
     let storage = CONFIG.storage().get_object_store();
-    if let Err(err) = storage.create_stream(&stream_name, &time_partition, &time_partition_format, &time_partition_timezone).await {
+    if let Err(err) = storage.create_stream(&stream_name, &time_partition).await {
         return Err(CreateStreamError::Storage { stream_name, err });
     }
 
@@ -376,15 +355,8 @@ pub async fn create_stream(stream_name: String, time_partition: String, time_par
         .await;
     let stream_meta = stream_meta.unwrap();
     let created_at = stream_meta.created_at;
-    let mut time_partition: String = String::new(); // Initialize time_partition with an empty string
-    let mut time_partition_format: String = String::new();
-    let mut time_partition_timezone: String = String::new();
-    if stream_meta.time_partition.is_some() && stream_meta.time_partition_format.is_some() && stream_meta.time_partition_timezone.is_some(){
-        time_partition = stream_meta.time_partition.unwrap();
-        time_partition_format = stream_meta.time_partition_format.unwrap();
-        time_partition_timezone = stream_meta.time_partition_timezone.unwrap();
-    }
-    metadata::STREAM_INFO.add_stream(stream_name.to_string(), created_at, time_partition, time_partition_format, time_partition_timezone);
+    
+    metadata::STREAM_INFO.add_stream(stream_name.to_string(), created_at, time_partition);
 
     Ok(())
 }
@@ -444,10 +416,6 @@ pub mod error {
         InvalidRetentionConfig(serde_json::Error),
         #[error("{msg}")]
         Custom { msg: String, status: StatusCode },
-        #[error("X-P-Time-Partition-Format header is missing for \"{0}\" X-P-Time-Partition header")]
-        TimePartitionFormatMissing(String),
-        #[error("X-P-Time-Partition-TimeZone header is missing for \"{0}\" X-P-Time-Partition header")]
-        TimePartitionTimeZoneMissing(String),
     }
 
     impl actix_web::ResponseError for StreamError {
@@ -470,8 +438,6 @@ pub mod error {
                 StreamError::InvalidAlert(_) => StatusCode::BAD_REQUEST,
                 StreamError::InvalidAlertMessage(_, _) => StatusCode::BAD_REQUEST,
                 StreamError::InvalidRetentionConfig(_) => StatusCode::BAD_REQUEST,
-                StreamError::TimePartitionFormatMissing(_) => StatusCode::BAD_REQUEST,
-                StreamError::TimePartitionTimeZoneMissing(_) => StatusCode::BAD_REQUEST
             }
         }
 

--- a/server/src/handlers/http/logstream.rs
+++ b/server/src/handlers/http/logstream.rs
@@ -109,7 +109,7 @@ pub async fn get_alert(req: HttpRequest) -> Result<impl Responder, StreamError> 
 }
 
 pub async fn put_stream(req: HttpRequest) -> Result<impl Responder, StreamError> {
-    let mut time_partition: String = String::new();
+    let mut time_partition: String = String::default();
     if let Some((_, time_partition_name)) = req
         .headers()
         .iter()

--- a/server/src/handlers/http/query.rs
+++ b/server/src/handlers/http/query.rs
@@ -56,7 +56,7 @@ pub async fn query(req: HttpRequest, query_request: Query) -> Result<impl Respon
     let permissions = Users.get_permissions(&creds);
     let session_state = QUERY_SESSION.state();
     let mut query = into_query(&query_request, &session_state).await?;
-
+    println!("query: {:?}", query);
     // check authorization of this query if it references physical table;
     let table_name = query.table_name();
     if let Some(ref table) = table_name {
@@ -94,7 +94,7 @@ pub async fn query(req: HttpRequest, query_request: Query) -> Result<impl Respon
 
     let time = Instant::now();
 
-    let (records, fields) = query.execute().await?;
+    let (records, fields) = query.execute(table_name.clone().unwrap()).await?;
     let response = QueryResponse {
         records,
         fields,

--- a/server/src/handlers/http/query.rs
+++ b/server/src/handlers/http/query.rs
@@ -56,7 +56,6 @@ pub async fn query(req: HttpRequest, query_request: Query) -> Result<impl Respon
     let permissions = Users.get_permissions(&creds);
     let session_state = QUERY_SESSION.state();
     let mut query = into_query(&query_request, &session_state).await?;
-    println!("query: {:?}", query);
     // check authorization of this query if it references physical table;
     let table_name = query.table_name();
     if let Some(ref table) = table_name {

--- a/server/src/metadata.rs
+++ b/server/src/metadata.rs
@@ -47,8 +47,6 @@ pub struct LogStreamMetadata {
     pub created_at: String,
     pub first_event_at: Option<String>,
     pub time_partition: Option<String>,
-    pub time_partition_format: Option<String>,
-    pub time_partition_timezone: Option<String>
 }
 
 // It is very unlikely that panic will occur when dealing with metadata.
@@ -145,7 +143,7 @@ impl StreamInfo {
             })
     }
 
-    pub fn add_stream(&self, stream_name: String, created_at: String, time_partition: String, time_partition_format: String, time_partition_timezone: String) {
+    pub fn add_stream(&self, stream_name: String, created_at: String, time_partition: String) {
         let mut map = self.write().expect(LOCK_EXPECT);
         let metadata = LogStreamMetadata {
             created_at: if created_at.is_empty() {
@@ -157,16 +155,6 @@ impl StreamInfo {
                 None
             } else {
                 Some(time_partition.clone())
-            },
-            time_partition_format: if time_partition_format.is_empty() {
-                None
-            } else {
-                Some(time_partition_format.clone())
-            },
-            time_partition_timezone: if time_partition_timezone.is_empty() {
-                None
-            } else {
-                Some(time_partition_timezone.clone())
             },
             ..Default::default()
         };
@@ -204,8 +192,6 @@ impl StreamInfo {
                 created_at: meta.created_at,
                 first_event_at: meta.first_event_at,
                 time_partition: meta.time_partition,
-                time_partition_format: meta.time_partition_format,
-                time_partition_timezone: meta.time_partition_timezone
             };
 
             let mut map = self.write().expect(LOCK_EXPECT);

--- a/server/src/metadata.rs
+++ b/server/src/metadata.rs
@@ -149,12 +149,12 @@ impl StreamInfo {
             created_at: if created_at.is_empty() {
                 Local::now().to_rfc3339()
             } else {
-                created_at.clone()
+                created_at
             },
             time_partition: if time_partition.is_empty() {
                 None
             } else {
-                Some(time_partition.clone())
+                Some(time_partition)
             },
             ..Default::default()
         };

--- a/server/src/metadata.rs
+++ b/server/src/metadata.rs
@@ -46,6 +46,9 @@ pub struct LogStreamMetadata {
     pub cache_enabled: bool,
     pub created_at: String,
     pub first_event_at: Option<String>,
+    pub time_partition: Option<String>,
+    pub time_partition_format: Option<String>,
+    pub time_partition_timezone: Option<String>
 }
 
 // It is very unlikely that panic will occur when dealing with metadata.
@@ -142,13 +145,28 @@ impl StreamInfo {
             })
     }
 
-    pub fn add_stream(&self, stream_name: String, created_at: String) {
+    pub fn add_stream(&self, stream_name: String, created_at: String, time_partition: String, time_partition_format: String, time_partition_timezone: String) {
         let mut map = self.write().expect(LOCK_EXPECT);
         let metadata = LogStreamMetadata {
             created_at: if created_at.is_empty() {
                 Local::now().to_rfc3339()
             } else {
                 created_at.clone()
+            },
+            time_partition: if time_partition.is_empty() {
+                None
+            } else {
+                Some(time_partition.clone())
+            },
+            time_partition_format: if time_partition_format.is_empty() {
+                None
+            } else {
+                Some(time_partition_format.clone())
+            },
+            time_partition_timezone: if time_partition_timezone.is_empty() {
+                None
+            } else {
+                Some(time_partition_timezone.clone())
             },
             ..Default::default()
         };
@@ -185,6 +203,9 @@ impl StreamInfo {
                 cache_enabled: meta.cache_enabled,
                 created_at: meta.created_at,
                 first_event_at: meta.first_event_at,
+                time_partition: meta.time_partition,
+                time_partition_format: meta.time_partition_format,
+                time_partition_timezone: meta.time_partition_timezone
             };
 
             let mut map = self.write().expect(LOCK_EXPECT);

--- a/server/src/query/stream_schema_provider.rs
+++ b/server/src/query/stream_schema_provider.rs
@@ -287,8 +287,9 @@ impl TableProvider for StandardTableProvider {
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
         let mut memory_exec = None;
         let mut cache_exec = None;
-
+        println!("filters: {:?}", filters);
         let time_filters = extract_primary_filter(filters);
+        println!("time_filters: {:?}", time_filters);
         if time_filters.is_empty() {
             return Err(DataFusionError::Plan("potentially unbounded query on time range. Table scanning requires atleast one time bound".to_string()));
         }
@@ -314,10 +315,12 @@ impl TableProvider for StandardTableProvider {
         let glob_storage = CONFIG.storage().get_object_store();
 
         // Fetch snapshot
-        let snapshot = glob_storage
+        let object_store_format = glob_storage
             .get_snapshot(&self.stream)
             .await
             .map_err(|err| DataFusionError::Plan(err.to_string()))?;
+
+        let snapshot = object_store_format.snapshot;
 
         // Is query timerange is overlapping with older data.
         if is_overlapping_query(&snapshot.manifest_list, &time_filters) {
@@ -512,27 +515,27 @@ impl PartialTimeFilter {
     pub fn binary_expr(&self, left: Expr) -> Expr {
         let (op, right) = match self {
             PartialTimeFilter::Low(Bound::Excluded(time)) => {
-                (Operator::Gt, time.timestamp_millis())
+                (Operator::Gt, time)
             }
             PartialTimeFilter::Low(Bound::Included(time)) => {
-                (Operator::GtEq, time.timestamp_millis())
+                (Operator::GtEq, time)
             }
             PartialTimeFilter::High(Bound::Excluded(time)) => {
-                (Operator::Lt, time.timestamp_millis())
+                (Operator::Lt, time)
             }
             PartialTimeFilter::High(Bound::Included(time)) => {
-                (Operator::LtEq, time.timestamp_millis())
+                (Operator::LtEq, time)
             }
-            PartialTimeFilter::Eq(time) => (Operator::Eq, time.timestamp_millis()),
+            PartialTimeFilter::Eq(time) => (Operator::Eq, time),
             _ => unimplemented!(),
         };
+        
 
         Expr::BinaryExpr(BinaryExpr::new(
             Box::new(left),
             op,
-            Box::new(Expr::Literal(ScalarValue::TimestampMillisecond(
-                Some(right),
-                None,
+            Box::new(Expr::Literal(ScalarValue::Utf8(
+                Some(format!("{:?}", right)),
             ))),
         ))
     }
@@ -613,11 +616,18 @@ fn expr_in_boundary(filter: &Expr) -> bool {
 }
 
 fn extract_from_lit(expr: &Expr) -> Option<NaiveDateTime> {
+    println!("expr: {:?}", expr);
     if let Expr::Literal(value) = expr {
+        println!("value: {:?}", value);
         match value {
             ScalarValue::TimestampMillisecond(Some(value), _) => {
                 Some(NaiveDateTime::from_timestamp_millis(*value).unwrap())
+            },
+            ScalarValue::Utf8(Some(str_value)) => {
+                println!("str_value: {:?}", str_value);
+                Some(str_value.parse::<NaiveDateTime>().unwrap())
             }
+            
             _ => None,
         }
     } else {
@@ -626,13 +636,20 @@ fn extract_from_lit(expr: &Expr) -> Option<NaiveDateTime> {
 }
 
 fn extract_timestamp_bound(binexpr: &BinaryExpr) -> Option<(Operator, NaiveDateTime)> {
-    if matches!(&*binexpr.left, Expr::Column(Column { name, .. }) if name == DEFAULT_TIMESTAMP_KEY)
-    {
-        let time = extract_from_lit(&binexpr.right)?;
-        Some((binexpr.op, time))
-    } else {
-        None
-    }
+    println!("binexpr: {:?}", binexpr);
+    println!("binexpr.left: {:?}", binexpr.left);
+    println!("binexpr.right: {:?}", binexpr.right);
+
+    let time = extract_from_lit(&binexpr.right)?;
+    println!("time: {:?}", time);
+    Some((binexpr.op, time))
+    // if matches!(&*binexpr.left, Expr::Column(Column { name, .. }) if name == DEFAULT_TIMESTAMP_KEY)
+    // {
+    //     let time = extract_from_lit(&binexpr.right)?;
+    //     Some((binexpr.op, time))
+    // } else {
+    //     None
+    // }
 }
 
 async fn collect_manifest_files(

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -84,10 +84,6 @@ pub struct ObjectStoreFormat {
     pub retention: Option<Retention>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub time_partition: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub time_partition_format: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub time_partition_timezone: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -133,8 +129,6 @@ impl Default for ObjectStoreFormat {
             cache_enabled: false,
             retention: None,
             time_partition: None,
-            time_partition_format: None,
-            time_partition_timezone: None,
         }
     }
 }

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -82,6 +82,12 @@ pub struct ObjectStoreFormat {
     pub cache_enabled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retention: Option<Retention>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_partition: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_partition_format: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_partition_timezone: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -126,6 +132,9 @@ impl Default for ObjectStoreFormat {
             snapshot: Snapshot::default(),
             cache_enabled: false,
             retention: None,
+            time_partition: None,
+            time_partition_format: None,
+            time_partition_timezone: None,
         }
     }
 }

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -106,19 +106,33 @@ pub trait ObjectStorage: Sync + 'static {
         Ok(())
     }
 
-    async fn create_stream(&self, stream_name: &str) -> Result<(), ObjectStorageError> {
+    async fn create_stream(&self, stream_name: &str, time_partition: &str, time_partition_format: &str, time_partition_timezone: &str) -> Result<(), ObjectStorageError> {
         let mut format = ObjectStoreFormat::default();
         format.set_id(CONFIG.parseable.username.clone());
         let permission = Permisssion::new(CONFIG.parseable.username.clone());
         format.permissions = vec![permission];
-
+        if time_partition.is_empty() {
+            format.time_partition = None;
+        } else {
+            format.time_partition = Some(time_partition.to_string());
+        }
+        if time_partition_format.is_empty() {
+            format.time_partition_format = None;
+        } else {
+            format.time_partition_format = Some(time_partition_format.to_string());
+        }
+        if time_partition_timezone.is_empty() {
+            format.time_partition_timezone = None;
+        } else {
+            format.time_partition_timezone = Some(time_partition_timezone.to_string());
+        }
         let format_json = to_bytes(&format);
-
         self.put_object(&schema_path(stream_name), to_bytes(&Schema::empty()))
             .await?;
 
         self.put_object(&stream_json_path(stream_name), format_json)
             .await?;
+        
 
         Ok(())
     }

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -106,7 +106,11 @@ pub trait ObjectStorage: Sync + 'static {
         Ok(())
     }
 
-    async fn create_stream(&self, stream_name: &str, time_partition: &str) -> Result<(), ObjectStorageError> {
+    async fn create_stream(
+        &self,
+        stream_name: &str,
+        time_partition: &str,
+    ) -> Result<(), ObjectStorageError> {
         let mut format = ObjectStoreFormat::default();
         format.set_id(CONFIG.parseable.username.clone());
         let permission = Permisssion::new(CONFIG.parseable.username.clone());
@@ -116,14 +120,13 @@ pub trait ObjectStorage: Sync + 'static {
         } else {
             format.time_partition = Some(time_partition.to_string());
         }
-        
+
         let format_json = to_bytes(&format);
         self.put_object(&schema_path(stream_name), to_bytes(&Schema::empty()))
             .await?;
 
         self.put_object(&stream_json_path(stream_name), format_json)
             .await?;
-        
 
         Ok(())
     }
@@ -274,7 +277,6 @@ pub trait ObjectStorage: Sync + 'static {
         path: &RelativePath,
     ) -> Result<Option<Manifest>, ObjectStorageError> {
         let path = manifest_path(path.as_str());
-        println!("path: {:?}", path);
         match self.get_object(&path).await {
             Ok(bytes) => Ok(Some(
                 serde_json::from_slice(&bytes).expect("manifest is valid json"),
@@ -298,13 +300,13 @@ pub trait ObjectStorage: Sync + 'static {
         self.put_object(&path, to_bytes(&manifest)).await
     }
 
-    
-
-    async fn get_snapshot(&self, stream: &str) -> Result<ObjectStoreFormat, ObjectStorageError> {
+    async fn get_object_store_format(
+        &self,
+        stream: &str,
+    ) -> Result<ObjectStoreFormat, ObjectStorageError> {
         let path = stream_json_path(stream);
         let bytes = self.get_object(&path).await?;
-        Ok(serde_json::from_slice::<ObjectStoreFormat>(&bytes)
-            .expect("snapshot is valid json"))
+        Ok(serde_json::from_slice::<ObjectStoreFormat>(&bytes).expect("snapshot is valid json"))
     }
 
     async fn put_snapshot(
@@ -362,11 +364,10 @@ pub trait ObjectStorage: Sync + 'static {
                 let absolute_path = self
                     .absolute_url(RelativePath::from_path(&stream_relative_path).unwrap())
                     .to_string();
-                let manifest_file_path = get_stream_manifest_path(stream_relative_path);
                 let store = CONFIG.storage().get_object_store();
                 let manifest =
                     catalog::create_from_parquet_file(absolute_path.clone(), &file).unwrap();
-                catalog::update_snapshot(store, stream, manifest,&manifest_file_path).await?;
+                catalog::update_snapshot(store, stream, manifest).await?;
                 if cache_enabled && cache_manager.is_some() {
                     cache_updates
                         .entry(stream)
@@ -412,7 +413,6 @@ pub trait ObjectStorage: Sync + 'static {
     }
 }
 
-
 async fn commit_schema_to_storage(
     stream_name: &str,
     schema: Schema,
@@ -453,10 +453,4 @@ fn alert_json_path(stream_name: &str) -> RelativePathBuf {
 #[inline(always)]
 fn manifest_path(prefix: &str) -> RelativePathBuf {
     RelativePathBuf::from_iter([prefix, MANIFEST_FILE])
-}
-
-fn get_stream_manifest_path(stream_relative_path: String) -> String{
-    let v: Vec<&str> = stream_relative_path.split("/").collect();
-    let manifest_path = format!("{}/{}", v[0], v[1]);
-    manifest_path
 }

--- a/server/src/storage/staging.rs
+++ b/server/src/storage/staging.rs
@@ -65,15 +65,7 @@ impl StorageDir {
             + &utils::minute_to_prefix(time.minute(), OBJECT_STORE_DATA_GRANULARITY).unwrap();
         let local_uri = str::replace(&uri, "/", ".");
         let hostname = utils::hostname_unchecked();
-        if extention == PARQUET_FILE_EXTENSION {
-            let mut rng = rand::thread_rng();
-            let n: u64 = rng.gen();
-            format!("{local_uri}{hostname}{n}.{extention}")
-        }
-        else{
-            format!("{local_uri}{hostname}.{extention}")
-        }
-        
+        format!("{local_uri}{hostname}.{extention}")
     }
 
     fn filename_by_time(stream_hash: &str, time: NaiveDateTime) -> String {
@@ -88,9 +80,15 @@ impl StorageDir {
         Self::filename_by_time(stream_hash, parsed_timestamp)
     }
 
-    pub fn path_by_current_time(&self, stream_hash: &str, parsed_timestamp: NaiveDateTime) -> PathBuf {
-        self.data_path
-            .join(Self::filename_by_current_time(stream_hash, parsed_timestamp))
+    pub fn path_by_current_time(
+        &self,
+        stream_hash: &str,
+        parsed_timestamp: NaiveDateTime,
+    ) -> PathBuf {
+        self.data_path.join(Self::filename_by_current_time(
+            stream_hash,
+            parsed_timestamp,
+        ))
     }
 
     pub fn arrow_files(&self) -> Vec<PathBuf> {
@@ -166,11 +164,11 @@ impl StorageDir {
     fn arrow_path_to_parquet(path: &Path) -> PathBuf {
         let file_stem = path.file_stem().unwrap().to_str().unwrap();
         let mut rng = rand::thread_rng();
-        let n: u64 = rng.gen();
+        let random_number: u64 = rng.gen();
         let (_, filename) = file_stem.split_once('.').unwrap();
-        let filename_with_random = format!("{}.{}.{}",filename, n, "arrows");
+        let filename_with_random_number = format!("{}.{}.{}", filename, random_number, "arrows");
         let mut parquet_path = path.to_owned();
-        parquet_path.set_file_name(filename_with_random);
+        parquet_path.set_file_name(filename_with_random_number);
         parquet_path.set_extension("parquet");
         parquet_path
     }

--- a/server/src/storage/staging.rs
+++ b/server/src/storage/staging.rs
@@ -26,7 +26,7 @@ use std::{
 };
 
 use arrow_schema::{ArrowError, Schema};
-use chrono::{NaiveDateTime, Timelike, Utc};
+use chrono::{NaiveDateTime, Timelike};
 use parquet::{
     arrow::ArrowWriter,
     basic::Encoding,
@@ -76,14 +76,13 @@ impl StorageDir {
         )
     }
 
-    fn filename_by_current_time(stream_hash: &str) -> String {
-        let datetime = Utc::now();
-        Self::filename_by_time(stream_hash, datetime.naive_utc())
+    fn filename_by_current_time(stream_hash: &str, parsed_timestamp: NaiveDateTime) -> String {
+        Self::filename_by_time(stream_hash, parsed_timestamp)
     }
 
-    pub fn path_by_current_time(&self, stream_hash: &str) -> PathBuf {
+    pub fn path_by_current_time(&self, stream_hash: &str, parsed_timestamp: NaiveDateTime) -> PathBuf {
         self.data_path
-            .join(Self::filename_by_current_time(stream_hash))
+            .join(Self::filename_by_current_time(stream_hash, parsed_timestamp))
     }
 
     pub fn arrow_files(&self) -> Vec<PathBuf> {

--- a/server/src/utils/json.rs
+++ b/server/src/utils/json.rs
@@ -25,6 +25,16 @@ pub fn flatten_json_body(body: serde_json::Value) -> Result<Value, anyhow::Error
     flatten::flatten(body, "_")
 }
 
+pub fn convert_array_to_object(body: Value) -> Result<Vec<Value>, anyhow::Error> {
+    let data = flatten_json_body(body)?;
+    let value_arr = match data {
+        Value::Array(arr) => arr,
+        value @ Value::Object(_) => vec![value],
+        _ => unreachable!("flatten would have failed beforehand"),
+    };
+    Ok(value_arr)
+}
+
 pub fn convert_to_string(value: &Value) -> Value {
     match value {
         Value::Null => Value::String("null".to_owned()),


### PR DESCRIPTION
add custom header X-P-Time-Partition (optional) at stream creation api -- to allow ingestion/query using timestamp column from the log data instead of server time / p_timestamp

store the time_partition field name in stream.json and in memory STREAM_INFO

in ingest api - check if timestamp column name exists in the log data, if no, throw exception
also, check if timestamp value can be parsed into datetime, if no, throw exception

arrow file name gets the date, hr, mm from the timestamp field (if defined in stream) else file name gets the date, hr, mm from the server time

parquet file name gets a random number attached to it -- this is because a lot of log data can have same date, hr, mm value of the timestamp field and with this random number, parquet will not get overwritten

in the console, query from and to date will be matched against the value of the timestamp column of the log data (if defined in the stream), else from and to date will be matched against the p_timestamp column