### PR TITLE
Impl Ingest Server

### DIFF
--- a/server/src/handlers/http.rs
+++ b/server/src/handlers/http.rs
@@ -32,9 +32,6 @@ pub(crate) mod query;
 pub(crate) mod rbac;
 pub(crate) mod role;
 
-// this needs to be removed from here. It is in modal->mod.rs
-// include!(concat!(env!("OUT_DIR"), "/generated.rs"));
-
 pub const MAX_EVENT_PAYLOAD_SIZE: usize = 10485760;
 pub const API_BASE_PATH: &str = "/api";
 pub const API_VERSION: &str = "v1";

--- a/server/src/handlers/http/modal/ingest_server.rs
+++ b/server/src/handlers/http/modal/ingest_server.rs
@@ -104,7 +104,6 @@ impl ParseableServer for IngestServer {
         self.initialize().await
     }
 
-    #[allow(unused)]
     fn validate(&self) -> anyhow::Result<()> {
         if CONFIG.get_storage_mode_string() == "Local drive" {
             return Err(anyhow::Error::msg(
@@ -229,7 +228,7 @@ impl IngestServer {
             DEFAULT_VERSION.to_string(),
             store.get_bucket_name(),
             &CONFIG.parseable.username,
-            &CONFIG.parseable.password, // is this secure?
+            &CONFIG.parseable.password,
         );
 
         let resource = serde_json::to_string(&resource)

--- a/server/src/handlers/http/modal/ingest_server.rs
+++ b/server/src/handlers/http/modal/ingest_server.rs
@@ -120,6 +120,7 @@ impl IngestServer {
             .service(
                 // Base path "{url}/api/v1"
                 web::scope(&base_path())
+                    .service(Server::get_query_factory())
                     .service(Server::get_ingest_factory())
                     .service(Self::logstream_api()),
             )

--- a/server/src/handlers/http/modal/ingest_server.rs
+++ b/server/src/handlers/http/modal/ingest_server.rs
@@ -20,6 +20,7 @@ use crate::analytics;
 use crate::banner;
 use crate::handlers::http::logstream;
 use crate::handlers::http::middleware::RouteExt;
+use crate::handlers::http::MAX_EVENT_PAYLOAD_SIZE;
 use crate::localcache::LocalCacheManager;
 use crate::metadata;
 use crate::metrics;
@@ -63,8 +64,8 @@ impl ParseableServer for IngestServer {
         prometheus: PrometheusMetrics,
         _oidc_client: Option<crate::oidc::OpenidConfig>,
     ) -> anyhow::Result<()> {
-        // set the ingestor metadata
-        self.set_ingestor_metadata().await?;
+        // set the ingester metadata
+        self.set_ingester_metadata().await?;
 
         // get the ssl stuff
         let ssl = get_ssl_acceptor(
@@ -122,7 +123,9 @@ impl IngestServer {
         config
             .service(
                 // Base path "{url}/api/v1"
-                web::scope(&base_path()).service(Server::get_ingest_factory()),
+                web::scope(&base_path())
+                    .service(Server::get_ingest_factory())
+                    .service(Self::logstream_api()),
             )
             .service(Server::get_liveness_factory())
             .service(Server::get_readiness_factory())
@@ -151,7 +154,7 @@ impl IngestServer {
     }
 
     #[inline(always)]
-    fn get_ingestor_address(&self) -> SocketAddr {
+    fn get_ingester_address(&self) -> SocketAddr {
         // this might cause an issue down the line
         // best is to make the Cli Struct better, but thats a chore
         (CONFIG.parseable.address.clone())
@@ -159,23 +162,60 @@ impl IngestServer {
             .unwrap()
     }
 
-    // create the ingestor metadata and put the .ingestor.json file in the object store
-    async fn set_ingestor_metadata(&self) -> anyhow::Result<()> {
+    fn logstream_api() -> Scope {
+        web::scope("/logstream")
+            .service(
+                // GET "/logstream" ==> Get list of all Log Streams on the server
+                web::resource("")
+                    .route(web::get().to(logstream::list).authorize(Action::ListStream)),
+            )
+            .service(
+                web::scope("/{logstream}")
+                    .service(
+                        web::resource("")
+                            // PUT "/logstream/{logstream}" ==> Create log stream
+                            .route(
+                                web::put()
+                                    .to(logstream::put_stream)
+                                    .authorize_for_stream(Action::CreateStream),
+                            )
+                            // DELETE "/logstream/{logstream}" ==> Delete log stream
+                            .route(
+                                web::delete()
+                                    .to(logstream::delete)
+                                    .authorize_for_stream(Action::DeleteStream),
+                            )
+                            .app_data(web::PayloadConfig::default().limit(MAX_EVENT_PAYLOAD_SIZE)),
+                    )
+                    .service(
+                        // GET "/logstream/{logstream}/stats" ==> Get stats for given log stream
+                        web::resource("/stats").route(
+                            web::get()
+                                .to(logstream::get_stats)
+                                .authorize_for_stream(Action::GetStats),
+                        ),
+                    ),
+            )
+    }
+
+    // create the ingester metadata and put the .ingester.json file in the object store
+    async fn set_ingester_metadata(&self) -> anyhow::Result<()> {
         let store = CONFIG.storage().get_object_store();
 
         // remove ip adn go with the domain name
-        let sock = self.get_ingestor_address();
+        let sock = self.get_ingester_address();
         let path = RelativePathBuf::from(format!(
-            "ingestor.{}.{}.json",
+            "ingester.{}.{}.json",
             sock.ip(), // this might be wrong
             sock.port()
         ));
 
         if store.get_object(&path).await.is_ok() {
-            println!("Ingestor metadata already exists");
+            println!("Ingester metadata already exists");
             return Ok(());
         };
 
+        let scheme = CONFIG.parseable.get_scheme();
         let resource = IngesterMetadata::new(
             sock.port().to_string(),
             CONFIG
@@ -183,7 +223,7 @@ impl IngestServer {
                 .domain_address
                 .clone()
                 .unwrap_or_else(|| {
-                    Url::parse(&format!("http://{}:{}", sock.ip(), sock.port())).unwrap()
+                    Url::parse(&format!("{}://{}:{}", scheme, sock.ip(), sock.port())).unwrap()
                 })
                 .to_string(),
             DEFAULT_VERSION.to_string(),
@@ -203,7 +243,7 @@ impl IngestServer {
     }
 
     // check for querier state. Is it there, or was it there in the past
-    // this should happen before the set the ingestor metadata
+    // this should happen before the set the ingester metadata
     async fn check_querier_state(&self) -> anyhow::Result<(), ObjectStorageError> {
         // how do we check for querier state?
         // based on the work flow of the system, the querier will always need to start first

--- a/server/src/handlers/http/modal/ingest_server.rs
+++ b/server/src/handlers/http/modal/ingest_server.rs
@@ -31,8 +31,6 @@ use crate::storage::ObjectStorageError;
 use crate::storage::PARSEABLE_METADATA_FILE_NAME;
 use crate::sync;
 
-use std::net::SocketAddr;
-
 use super::server::Server;
 use super::ssl_acceptor::get_ssl_acceptor;
 use super::IngesterMetadata;
@@ -151,15 +149,6 @@ impl IngestServer {
         )
     }
 
-    #[inline(always)]
-    fn get_ingester_address(&self) -> SocketAddr {
-        // this might cause an issue down the line
-        // best is to make the Cli Struct better, but thats a chore
-        (CONFIG.parseable.address.clone())
-            .parse::<SocketAddr>()
-            .unwrap()
-    }
-
     fn logstream_api() -> Scope {
         web::scope("/logstream")
             .service(
@@ -201,7 +190,7 @@ impl IngestServer {
         let store = CONFIG.storage().get_object_store();
 
         // remove ip adn go with the domain name
-        let sock = self.get_ingester_address();
+        let sock = Server::get_server_address();
         let path = RelativePathBuf::from(format!(
             "ingester.{}.{}.json",
             sock.ip(), // this might be wrong

--- a/server/src/handlers/http/modal/ingest_server.rs
+++ b/server/src/handlers/http/modal/ingest_server.rs
@@ -100,7 +100,6 @@ impl ParseableServer for IngestServer {
 
     /// implement the init method will just invoke the initialize method
     async fn init(&self) -> anyhow::Result<()> {
-        // self.validate()?;
         self.initialize().await
     }
 

--- a/server/src/handlers/http/modal/query_server.rs
+++ b/server/src/handlers/http/modal/query_server.rs
@@ -58,8 +58,6 @@ impl ParseableServer for QueryServer {
 
         // on subsequent runs, the qurier should check if the ingester is up and running or not
         for ingester in data.iter() {
-            // dbg!(&ingester);
-
             if !Self::check_liveness(&ingester.domain_name).await {
                 eprintln!("Ingester at {} is not reachable", &ingester.domain_name);
             } else {

--- a/server/src/handlers/http/modal/query_server.rs
+++ b/server/src/handlers/http/modal/query_server.rs
@@ -108,7 +108,6 @@ impl ParseableServer for QueryServer {
 
     /// implementation of init should just invoke a call to initialize
     async fn init(&self) -> anyhow::Result<()> {
-        // self.validate()?;
         self.initialize().await
     }
 

--- a/server/src/handlers/http/modal/query_server.rs
+++ b/server/src/handlers/http/modal/query_server.rs
@@ -507,9 +507,9 @@ impl QueryServer {
                 None => Utc::now(),
             })
             .min()
-            .unwrap_or(Utc::now());
+            .unwrap_or_else(Utc::now);
 
-        let min_time = stats.iter().map(|x| x.time).min().unwrap_or(Utc::now());
+        let min_time = stats.iter().map(|x| x.time).min().unwrap_or_else(Utc::now);
 
         let cumulative_ingestion =
             stats

--- a/server/src/handlers/http/modal/query_server.rs
+++ b/server/src/handlers/http/modal/query_server.rs
@@ -112,7 +112,6 @@ impl ParseableServer for QueryServer {
         self.initialize().await
     }
 
-    #[allow(unused)]
     fn validate(&self) -> anyhow::Result<()> {
         if CONFIG.get_storage_mode_string() == "Local drive" {
             return Err(anyhow::anyhow!(

--- a/server/src/handlers/http/modal/server.rs
+++ b/server/src/handlers/http/modal/server.rs
@@ -32,6 +32,7 @@ use crate::migration;
 use crate::rbac;
 use crate::storage;
 use crate::sync;
+use std::net::SocketAddr;
 use std::{fs::File, io::BufReader, sync::Arc};
 
 use actix_web::web::resource;
@@ -463,5 +464,14 @@ impl Server {
                 }
             };
         }
+    }
+
+    #[inline(always)]
+    pub fn get_server_address() -> SocketAddr {
+        // this might cause an issue down the line
+        // best is to make the Cli Struct better, but thats a chore
+        (CONFIG.parseable.address.clone())
+            .parse::<SocketAddr>()
+            .unwrap()
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -68,6 +68,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     // MODE == Query / Ingest and storage = local-store
+    server.validate()?;
     server.init().await?;
 
     Ok(())

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -67,11 +67,7 @@ async fn main() -> anyhow::Result<()> {
         Mode::All => Arc::new(Server),
     };
 
-    // add logic for graceful shutdown if
     // MODE == Query / Ingest and storage = local-store
-    // option.rs ln: 161
-    // CONFIG.run_time_mode_validation()?;
-
     server.init().await?;
 
     Ok(())

--- a/server/src/migration.rs
+++ b/server/src/migration.rs
@@ -30,8 +30,8 @@ use serde::Serialize;
 use crate::{
     option::Config,
     storage::{
-        ObjectStorage, ObjectStorageError, PARSEABLE_METADATA_FILE_NAME, SCHEMA_FILE_NAME,
-        STREAM_METADATA_FILE_NAME,
+        object_storage::stream_json_path, ObjectStorage, ObjectStorageError,
+        PARSEABLE_METADATA_FILE_NAME, SCHEMA_FILE_NAME,
     },
 };
 
@@ -94,7 +94,8 @@ pub async fn run_migration(config: &Config) -> anyhow::Result<()> {
 }
 
 async fn migration_stream(stream: &str, storage: &dyn ObjectStorage) -> anyhow::Result<()> {
-    let path = RelativePathBuf::from_iter([stream, STREAM_METADATA_FILE_NAME]);
+    let path = stream_json_path(stream);
+
     let stream_metadata = storage.get_object(&path).await?;
     let stream_metadata: serde_json::Value =
         serde_json::from_slice(&stream_metadata).expect("stream.json is valid json");

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -157,18 +157,6 @@ impl Config {
         }
         "S3 bucket"
     }
-
-    #[allow(dead_code)]
-    pub fn run_time_mode_validation(&self) -> anyhow::Result<()> {
-        let check = (self.parseable.mode == Mode::Ingest || self.parseable.mode == Mode::Query)
-            && self.storage_name == "drive";
-
-        if check {
-            anyhow::bail!(format!("Cannot start the server in {} mode with local storage, please use S3 bucket for storage", self.parseable.mode.to_str()))
-        }
-
-        Ok(())
-    }
 }
 
 fn create_parseable_cli_command() -> Command {

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -24,7 +24,7 @@ use std::fmt::Debug;
 
 mod localfs;
 mod metrics_layer;
-mod object_storage;
+pub(crate) mod object_storage;
 pub mod retention;
 mod s3;
 pub mod staging;

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -203,10 +203,20 @@ pub trait ObjectStorage: Sync + 'static {
             Ok(data) => data,
             Err(_) => {
                 // ! this is hard coded for now
-                let bytes = self.get_object(&RelativePathBuf::from_iter([stream_name, STREAM_METADATA_FILE_NAME])).await?;
-                self.put_stream_manifest(stream_name, &serde_json::from_slice::<ObjectStoreFormat>(&bytes).expect("parseable config is valid json")).await?;
+                let bytes = self
+                    .get_object(&RelativePathBuf::from_iter([
+                        stream_name,
+                        STREAM_METADATA_FILE_NAME,
+                    ]))
+                    .await?;
+                self.put_stream_manifest(
+                    stream_name,
+                    &serde_json::from_slice::<ObjectStoreFormat>(&bytes)
+                        .expect("parseable config is valid json"),
+                )
+                .await?;
                 bytes
-            },
+            }
         };
 
         Ok(serde_json::from_slice(&stream_metadata).expect("parseable config is valid json"))

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -25,6 +25,7 @@ use super::{
     STREAM_METADATA_FILE_NAME,
 };
 
+use crate::option::Mode;
 use crate::utils::get_address;
 use crate::{
     alerts::Alerts,
@@ -435,8 +436,17 @@ fn schema_path(stream_name: &str) -> RelativePathBuf {
 }
 
 #[inline(always)]
-fn stream_json_path(stream_name: &str) -> RelativePathBuf {
-    RelativePathBuf::from_iter([stream_name, STREAM_METADATA_FILE_NAME])
+pub fn stream_json_path(stream_name: &str) -> RelativePathBuf {
+    match &CONFIG.parseable.mode {
+        Mode::Ingest => {
+            let (ip, port) = get_address();
+            let file_name = format!("ingester.{}.{}{}", ip, port, STREAM_METADATA_FILE_NAME);
+            RelativePathBuf::from_iter([stream_name, &file_name])
+        }
+        Mode::Query | Mode::All => {
+            RelativePathBuf::from_iter([stream_name, STREAM_METADATA_FILE_NAME])
+        }
+    }
 }
 
 #[inline(always)]

--- a/server/src/storage/s3.rs
+++ b/server/src/storage/s3.rs
@@ -39,9 +39,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crate::metrics::storage::{s3::REQUEST_RESPONSE_TIME, StorageMetrics};
-use crate::option::{Mode, CONFIG};
 use crate::storage::{LogStream, ObjectStorage, ObjectStorageError};
-use crate::utils::get_address;
 
 use super::metrics_layer::MetricLayer;
 use super::{ObjectStorageProvider, PARSEABLE_METADATA_FILE_NAME, STREAM_METADATA_FILE_NAME};
@@ -307,13 +305,8 @@ impl S3 {
 
         let stream_json_check = FuturesUnordered::new();
 
-        let file_name = match &CONFIG.parseable.mode {
-            Mode::Ingest => {
-                let (ip, port) = get_address();
-                format!("ingester.{}.{}{}", ip, port, STREAM_METADATA_FILE_NAME)
-            }
-            Mode::All | Mode::Query => STREAM_METADATA_FILE_NAME.to_string(),
-        };
+        // even in ingest mode, we should only look for the global stream metadata file
+        let file_name = STREAM_METADATA_FILE_NAME.to_string();
 
         for dir in &dirs {
             let key = format!("{}/{}", dir, file_name);


### PR DESCRIPTION
Fixes #656 

### Description

Implement Ingest Server

### Changes

1. Implemented Ingest Server
2. Ingest Server creates and handles it's own `manifest` files
3. Ingest Server creates a metadata file for the Query Server
4. Logstreams will not be created automatically when sending the request to the Ingest API for the first time ***Only in Distributed Setup***
	- User needs to create a logstream first from the console (Possible changes Needed in console)
5. Disallow Users to run Server in Distributed Setup with local storage

<hr>

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
