### PR TITLE
feat: Add cluster info api end point

### DIFF
--- a/server/src/handlers/http.rs
+++ b/server/src/handlers/http.rs
@@ -51,3 +51,7 @@ pub(crate) fn cross_origin_config() -> Cors {
         Cors::default().block_on_origin_mismatch(false)
     }
 }
+
+pub fn base_path_without_preceding_slash() -> String {
+    base_path().trim_start_matches('/').to_string()
+}

--- a/server/src/handlers/http/modal/query_server.rs
+++ b/server/src/handlers/http/modal/query_server.rs
@@ -17,9 +17,11 @@
  */
 
 use crate::handlers::http::logstream::error::StreamError;
+use crate::handlers::http::middleware::RouteExt;
 use crate::handlers::http::{
     base_path, base_path_without_preceding_slash, cross_origin_config, API_BASE_PATH, API_VERSION,
 };
+use crate::rbac::role::Action;
 use crate::{analytics, banner, metadata, metrics, migration, rbac, storage};
 use actix_web::http::header;
 use actix_web::web::ServiceConfig;
@@ -144,8 +146,13 @@ impl QueryServer {
     }
 
     fn get_cluster_info_web_scope() -> actix_web::Scope {
-        web::scope("/cluster")
-            .service(web::resource("/info").route(web::get().to(Self::get_cluster_info)))
+        web::scope("/cluster").service(
+            web::resource("/info").route(
+                web::get()
+                    .to(Self::get_cluster_info)
+                    .authorize(Action::ListCluster),
+            ),
+        )
     }
 
     // update the .query.json file and return the new IngesterMetadataArr

--- a/server/src/rbac/role.rs
+++ b/server/src/rbac/role.rs
@@ -44,6 +44,7 @@ pub enum Action {
     ListRole,
     GetAbout,
     QueryLLM,
+    ListCluster,
     All,
 }
 
@@ -108,6 +109,7 @@ impl RoleBuilder {
                 | Action::PutAlert
                 | Action::GetAlert
                 | Action::All => Permission::Stream(action, self.stream.clone().unwrap()),
+                Action::ListCluster => Permission::Unit(action),
             };
             perms.push(perm);
         }
@@ -215,6 +217,7 @@ pub mod model {
                 Action::GetAlert,
                 Action::GetAbout,
                 Action::QueryLLM,
+                Action::ListCluster,
             ],
             stream: None,
             tag: None,

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -451,7 +451,15 @@ fn to_bytes(any: &(impl ?Sized + serde::Serialize)) -> Bytes {
 
 #[inline(always)]
 fn schema_path(stream_name: &str) -> RelativePathBuf {
-    RelativePathBuf::from_iter([stream_name, SCHEMA_FILE_NAME])
+    match CONFIG.parseable.mode {
+        Mode::Ingest => {
+            let (ip, port) = get_address();
+            let file_name = format!(".ingester.{}.{}{}", ip, port, SCHEMA_FILE_NAME);
+
+            RelativePathBuf::from_iter([stream_name, &file_name])
+        }
+        Mode::All | Mode::Query => RelativePathBuf::from_iter([stream_name, SCHEMA_FILE_NAME]),
+    }
 }
 
 #[inline(always)]
@@ -459,7 +467,7 @@ pub fn stream_json_path(stream_name: &str) -> RelativePathBuf {
     match &CONFIG.parseable.mode {
         Mode::Ingest => {
             let (ip, port) = get_address();
-            let file_name = format!("ingester.{}.{}{}", ip, port, STREAM_METADATA_FILE_NAME);
+            let file_name = format!(".ingester.{}.{}{}", ip, port, STREAM_METADATA_FILE_NAME);
             RelativePathBuf::from_iter([stream_name, &file_name])
         }
         Mode::Query | Mode::All => {

--- a/server/src/storage/s3.rs
+++ b/server/src/storage/s3.rs
@@ -426,11 +426,7 @@ impl ObjectStorage for S3 {
         let mut res = vec![];
 
         while let Some(meta) = list_stream.next().await.transpose()? {
-            let ingester_file = meta
-                .location
-                .filename()
-                .unwrap_or_default()
-                .contains("ingester");
+            let ingester_file = meta.location.filename().unwrap().starts_with("ingester");
 
             if !ingester_file {
                 continue;


### PR DESCRIPTION
This PR contains the ingester side changes<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #698.

### Description

Add Endpoint on Query Server `/api/v1/cluster/info` to fetch the information and status of the ingest server

<hr>

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.
