### PR TITLE
Removed Time Partition Logic from Ingestion Flow

### DIFF
--- a/server/src/event.rs
+++ b/server/src/event.rs
@@ -29,7 +29,6 @@ use std::sync::Arc;
 use self::error::EventError;
 pub use self::writer::STREAM_WRITERS;
 use crate::metadata;
-use chrono::NaiveDateTime;
 
 pub const DEFAULT_TIMESTAMP_KEY: &str = "p_timestamp";
 pub const DEFAULT_TAGS_KEY: &str = "p_tags";
@@ -42,7 +41,6 @@ pub struct Event {
     pub origin_format: &'static str,
     pub origin_size: u64,
     pub is_first_event: bool,
-    pub parsed_timestamp: NaiveDateTime,
 }
 
 // Events holds the schema related to a each event for a single log stream
@@ -55,12 +53,7 @@ impl Event {
             commit_schema(&self.stream_name, self.rb.schema())?;
         }
 
-        Self::process_event(
-            &self.stream_name,
-            &key,
-            self.rb.clone(),
-            self.parsed_timestamp,
-        )?;
+        Self::process_event(&self.stream_name, &key, self.rb.clone())?;
 
         metadata::STREAM_INFO.update_stats(
             &self.stream_name,
@@ -87,9 +80,8 @@ impl Event {
         stream_name: &str,
         schema_key: &str,
         rb: RecordBatch,
-        parsed_timestamp: NaiveDateTime,
     ) -> Result<(), EventError> {
-        STREAM_WRITERS.append_to_local(stream_name, schema_key, rb, parsed_timestamp)?;
+        STREAM_WRITERS.append_to_local(stream_name, schema_key, rb)?;
         Ok(())
     }
 }

--- a/server/src/event/writer/file_writer.rs
+++ b/server/src/event/writer/file_writer.rs
@@ -19,7 +19,6 @@
 
 use arrow_array::RecordBatch;
 use arrow_ipc::writer::StreamWriter;
-use chrono::NaiveDateTime;
 use derive_more::{Deref, DerefMut};
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
@@ -44,17 +43,27 @@ impl FileWriter {
         stream_name: &str,
         schema_key: &str,
         record: &RecordBatch,
-        parsed_timestamp: NaiveDateTime,
     ) -> Result<(), StreamWriterError> {
-        let (path, writer) =
-            init_new_stream_writer_file(stream_name, schema_key, record, parsed_timestamp)?;
-        self.insert(
-            schema_key.to_owned(),
-            ArrowWriter {
-                file_path: path,
-                writer,
-            },
-        );
+        match self.get_mut(schema_key) {
+            Some(writer) => {
+                writer
+                    .writer
+                    .write(record)
+                    .map_err(StreamWriterError::Writer)?;
+            }
+            // entry is not present thus we create it
+            None => {
+                // this requires mutable borrow of the map so we drop this read lock and wait for write lock
+                let (path, writer) = init_new_stream_writer_file(stream_name, schema_key, record)?;
+                self.insert(
+                    schema_key.to_owned(),
+                    ArrowWriter {
+                        file_path: path,
+                        writer,
+                    },
+                );
+            }
+        };
 
         Ok(())
     }
@@ -70,10 +79,9 @@ fn init_new_stream_writer_file(
     stream_name: &str,
     schema_key: &str,
     record: &RecordBatch,
-    parsed_timestamp: NaiveDateTime,
 ) -> Result<(PathBuf, StreamWriter<std::fs::File>), StreamWriterError> {
     let dir = StorageDir::new(stream_name);
-    let path = dir.path_by_current_time(schema_key, parsed_timestamp);
+    let path = dir.path_by_current_time(schema_key);
     std::fs::create_dir_all(dir.data_path)?;
 
     let file = OpenOptions::new().create(true).append(true).open(&path)?;

--- a/server/src/handlers.rs
+++ b/server/src/handlers.rs
@@ -23,7 +23,6 @@ const PREFIX_TAGS: &str = "x-p-tag-";
 const PREFIX_META: &str = "x-p-meta-";
 const STREAM_NAME_HEADER_KEY: &str = "x-p-stream";
 const LOG_SOURCE_KEY: &str = "x-p-log-source";
-const TIME_PARTITION_KEY: &str = "x-p-time-partition";
 const AUTHORIZATION_KEY: &str = "authorization";
 const SEPARATOR: char = '^';
 

--- a/server/src/handlers/http/logstream.rs
+++ b/server/src/handlers/http/logstream.rs
@@ -25,7 +25,6 @@ use serde_json::Value;
 
 use self::error::{CreateStreamError, StreamError};
 use crate::alerts::Alerts;
-use crate::handlers::TIME_PARTITION_KEY;
 use crate::metadata::STREAM_INFO;
 use crate::option::CONFIG;
 use crate::storage::{retention::Retention, LogStream, StorageDir};
@@ -109,15 +108,6 @@ pub async fn get_alert(req: HttpRequest) -> Result<impl Responder, StreamError> 
 }
 
 pub async fn put_stream(req: HttpRequest) -> Result<impl Responder, StreamError> {
-    let time_partition = if let Some((_, time_partition_name)) = req
-        .headers()
-        .iter()
-        .find(|&(key, _)| key == TIME_PARTITION_KEY)
-    {
-        time_partition_name.to_str().unwrap()
-    } else {
-        ""
-    };
     let stream_name: String = req.match_info().get("logstream").unwrap().parse().unwrap();
 
     if metadata::STREAM_INFO.stream_exists(&stream_name) {
@@ -129,7 +119,7 @@ pub async fn put_stream(req: HttpRequest) -> Result<impl Responder, StreamError>
             status: StatusCode::BAD_REQUEST,
         });
     } else {
-        create_stream(stream_name, time_partition).await?;
+        create_stream(stream_name).await?;
     }
 
     Ok(("log stream created", StatusCode::OK))
@@ -336,16 +326,13 @@ fn remove_id_from_alerts(value: &mut Value) {
     }
 }
 
-pub async fn create_stream(
-    stream_name: String,
-    time_partition: &str,
-) -> Result<(), CreateStreamError> {
+pub async fn create_stream(stream_name: String) -> Result<(), CreateStreamError> {
     // fail to proceed if invalid stream name
     validator::stream_name(&stream_name)?;
 
     // Proceed to create log stream if it doesn't exist
     let storage = CONFIG.storage().get_object_store();
-    if let Err(err) = storage.create_stream(&stream_name, time_partition).await {
+    if let Err(err) = storage.create_stream(&stream_name).await {
         return Err(CreateStreamError::Storage { stream_name, err });
     }
 
@@ -357,11 +344,7 @@ pub async fn create_stream(
     let stream_meta = stream_meta.unwrap();
     let created_at = stream_meta.created_at;
 
-    metadata::STREAM_INFO.add_stream(
-        stream_name.to_string(),
-        created_at,
-        time_partition.to_string(),
-    );
+    metadata::STREAM_INFO.add_stream(stream_name.to_string(), created_at);
 
     Ok(())
 }

--- a/server/src/metadata.rs
+++ b/server/src/metadata.rs
@@ -92,13 +92,6 @@ impl StreamInfo {
             .map(|metadata| metadata.cache_enabled)
     }
 
-    pub fn get_time_partition(&self, stream_name: &str) -> Result<Option<String>, MetadataError> {
-        let map = self.read().expect(LOCK_EXPECT);
-        map.get(stream_name)
-            .ok_or(MetadataError::StreamMetaNotFound(stream_name.to_string()))
-            .map(|metadata| metadata.time_partition.clone())
-    }
-
     pub fn set_stream_cache(&self, stream_name: &str, enable: bool) -> Result<(), MetadataError> {
         let mut map = self.write().expect(LOCK_EXPECT);
         let stream = map
@@ -150,18 +143,13 @@ impl StreamInfo {
             })
     }
 
-    pub fn add_stream(&self, stream_name: String, created_at: String, time_partition: String) {
+    pub fn add_stream(&self, stream_name: String, created_at: String) {
         let mut map = self.write().expect(LOCK_EXPECT);
         let metadata = LogStreamMetadata {
             created_at: if created_at.is_empty() {
                 Local::now().to_rfc3339()
             } else {
                 created_at
-            },
-            time_partition: if time_partition.is_empty() {
-                None
-            } else {
-                Some(time_partition)
             },
             ..Default::default()
         };

--- a/server/src/query.rs
+++ b/server/src/query.rs
@@ -38,12 +38,12 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use sysinfo::{System, SystemExt};
 
-use crate::event;
-use crate::option::CONFIG;
-use crate::storage::{ObjectStorageProvider, StorageDir};
 use self::error::ExecuteError;
 use self::stream_schema_provider::GlobalSchemaProvider;
 pub use self::stream_schema_provider::PartialTimeFilter;
+use crate::event;
+use crate::option::CONFIG;
+use crate::storage::{ObjectStorageProvider, StorageDir};
 
 pub static QUERY_SESSION: Lazy<SessionContext> =
     Lazy::new(|| Query::create_session_context(CONFIG.storage()));

--- a/server/src/query.rs
+++ b/server/src/query.rs
@@ -41,11 +41,9 @@ use sysinfo::{System, SystemExt};
 use crate::event;
 use crate::option::CONFIG;
 use crate::storage::{ObjectStorageProvider, StorageDir};
-
 use self::error::ExecuteError;
 use self::stream_schema_provider::GlobalSchemaProvider;
 pub use self::stream_schema_provider::PartialTimeFilter;
-use crate::metadata::STREAM_INFO;
 
 pub static QUERY_SESSION: Lazy<SessionContext> =
     Lazy::new(|| Query::create_session_context(CONFIG.storage()));
@@ -107,8 +105,12 @@ impl Query {
         &self,
         stream_name: String,
     ) -> Result<(Vec<RecordBatch>, Vec<String>), ExecuteError> {
+        let store = CONFIG.storage().get_object_store();
+        let object_store_format = store.get_object_store_format(&stream_name).await?;
+        let time_partition = object_store_format.time_partition;
+
         let df = QUERY_SESSION
-            .execute_logical_plan(self.final_logical_plan(stream_name))
+            .execute_logical_plan(self.final_logical_plan(&time_partition))
             .await?;
 
         let fields = df
@@ -124,7 +126,7 @@ impl Query {
     }
 
     /// return logical plan with all time filters applied through
-    fn final_logical_plan(&self, stream_name: String) -> LogicalPlan {
+    fn final_logical_plan(&self, time_partition: &Option<String>) -> LogicalPlan {
         let filters = self.filter_tag.clone().and_then(tag_filter);
         // see https://github.com/apache/arrow-datafusion/pull/8400
         // this can be eliminated in later version of datafusion but with slight caveat
@@ -138,7 +140,7 @@ impl Query {
                     self.start.naive_utc(),
                     self.end.naive_utc(),
                     filters,
-                    stream_name,
+                    time_partition,
                 );
                 LogicalPlan::Explain(Explain {
                     verbose: plan.verbose,
@@ -155,7 +157,7 @@ impl Query {
                 self.start.naive_utc(),
                 self.end.naive_utc(),
                 filters,
-                stream_name,
+                time_partition,
             ),
         }
     }
@@ -207,22 +209,12 @@ fn transform(
     start_time: NaiveDateTime,
     end_time: NaiveDateTime,
     filters: Option<Expr>,
-    stream_name: String,
+    time_partition: &Option<String>,
 ) -> LogicalPlan {
     plan.transform(&|plan| match plan {
         LogicalPlan::TableScan(table) => {
-            let hash_map = STREAM_INFO.read().unwrap();
-            let time_partition = hash_map
-                .get(&stream_name)
-                .ok_or(DataFusionError::Execution(format!(
-                    "stream not found {}",
-                    stream_name.clone()
-                )))?
-                .time_partition
-                .clone();
-
             let mut new_filters = vec![];
-            if !table_contains_any_time_filters(&table, &time_partition) {
+            if !table_contains_any_time_filters(&table, time_partition) {
                 let mut _start_time_filter: Expr;
                 let mut _end_time_filter: Expr;
                 match time_partition {
@@ -292,7 +284,7 @@ fn table_contains_any_time_filters(
             }
         })
         .any(|expr| {
-            matches!(&*expr.left, Expr::Column(Column { name, .. }) 
+            matches!(&*expr.left, Expr::Column(Column { name, .. })
             if ((time_partition.is_some() && name == time_partition.as_ref().unwrap()) || 
             (!time_partition.is_some() && name == event::DEFAULT_TIMESTAMP_KEY)))
         })

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -106,21 +106,11 @@ pub trait ObjectStorage: Sync + 'static {
         Ok(())
     }
 
-    async fn create_stream(
-        &self,
-        stream_name: &str,
-        time_partition: &str,
-    ) -> Result<(), ObjectStorageError> {
+    async fn create_stream(&self, stream_name: &str) -> Result<(), ObjectStorageError> {
         let mut format = ObjectStoreFormat::default();
         format.set_id(CONFIG.parseable.username.clone());
         let permission = Permisssion::new(CONFIG.parseable.username.clone());
         format.permissions = vec![permission];
-        if time_partition.is_empty() {
-            format.time_partition = None;
-        } else {
-            format.time_partition = Some(time_partition.to_string());
-        }
-
         let format_json = to_bytes(&format);
         self.put_object(&schema_path(stream_name), to_bytes(&Schema::empty()))
             .await?;
@@ -335,11 +325,8 @@ pub trait ObjectStorage: Sync + 'static {
             let cache_enabled = STREAM_INFO
                 .cache_enabled(stream)
                 .map_err(|err| ObjectStorageError::UnhandledError(Box::new(err)))?;
-            let time_partition = STREAM_INFO
-                .get_time_partition(stream)
-                .map_err(|err| ObjectStorageError::UnhandledError(Box::new(err)))?;
             let dir = StorageDir::new(stream);
-            let schema = convert_disk_files_to_parquet(stream, &dir, time_partition)
+            let schema = convert_disk_files_to_parquet(stream, &dir)
                 .map_err(|err| ObjectStorageError::UnhandledError(Box::new(err)))?;
 
             if let Some(schema) = schema {

--- a/server/src/storage/staging.rs
+++ b/server/src/storage/staging.rs
@@ -26,7 +26,7 @@ use std::{
 };
 
 use arrow_schema::{ArrowError, Schema};
-use chrono::{NaiveDateTime, Timelike};
+use chrono::{NaiveDateTime, Timelike, Utc};
 use parquet::{
     arrow::ArrowWriter,
     basic::Encoding,
@@ -43,7 +43,6 @@ use crate::{
     storage::OBJECT_STORE_DATA_GRANULARITY,
     utils::{self, arrow::merged_reader::MergedReverseRecordReader},
 };
-use rand::distributions::DistString;
 const ARROW_FILE_EXTENSION: &str = "data.arrows";
 const PARQUET_FILE_EXTENSION: &str = "data.parquet";
 
@@ -76,19 +75,14 @@ impl StorageDir {
         )
     }
 
-    fn filename_by_current_time(stream_hash: &str, parsed_timestamp: NaiveDateTime) -> String {
-        Self::filename_by_time(stream_hash, parsed_timestamp)
+    fn filename_by_current_time(stream_hash: &str) -> String {
+        let datetime = Utc::now();
+        Self::filename_by_time(stream_hash, datetime.naive_utc())
     }
 
-    pub fn path_by_current_time(
-        &self,
-        stream_hash: &str,
-        parsed_timestamp: NaiveDateTime,
-    ) -> PathBuf {
-        self.data_path.join(Self::filename_by_current_time(
-            stream_hash,
-            parsed_timestamp,
-        ))
+    pub fn path_by_current_time(&self, stream_hash: &str) -> PathBuf {
+        self.data_path
+            .join(Self::filename_by_current_time(stream_hash))
     }
 
     pub fn arrow_files(&self) -> Vec<PathBuf> {
@@ -162,13 +156,10 @@ impl StorageDir {
     }
 
     fn arrow_path_to_parquet(path: &Path) -> PathBuf {
-        let file_stem = path.file_stem().unwrap().to_str().unwrap();
-        let random_string =
-            rand::distributions::Alphanumeric.sample_string(&mut rand::thread_rng(), 20);
-        let (_, filename) = file_stem.split_once('.').unwrap();
-        let filename_with_random_number = format!("{}.{}.{}", filename, random_string, "arrows");
+        let filename = path.file_name().unwrap().to_str().unwrap();
+        let (_, filename) = filename.split_once('.').unwrap();
         let mut parquet_path = path.to_owned();
-        parquet_path.set_file_name(filename_with_random_number);
+        parquet_path.set_file_name(filename);
         parquet_path.set_extension("parquet");
         parquet_path
     }
@@ -185,7 +176,6 @@ pub fn to_parquet_path(stream_name: &str, time: NaiveDateTime) -> PathBuf {
 pub fn convert_disk_files_to_parquet(
     stream: &str,
     dir: &StorageDir,
-    time_partition: Option<String>,
 ) -> Result<Option<Schema>, MoveDataError> {
     let mut schemas = Vec::new();
 
@@ -210,15 +200,10 @@ pub fn convert_disk_files_to_parquet(
         }
 
         let record_reader = MergedReverseRecordReader::try_new(&files).unwrap();
-        let merged_schema = record_reader.merged_schema();
-        let mut index_time_partition: usize = 0;
-        if let Some(time_partition) = time_partition.as_ref() {
-            index_time_partition = merged_schema.index_of(time_partition).unwrap();
-        }
 
         let parquet_file = fs::File::create(&parquet_path).map_err(|_| MoveDataError::Create)?;
-        let props = parquet_writer_props(time_partition.clone(), index_time_partition).build();
-
+        let props = parquet_writer_props().build();
+        let merged_schema = record_reader.merged_schema();
         schemas.push(merged_schema.clone());
         let schema = Arc::new(merged_schema);
         let mut writer = ArrowWriter::try_new(parquet_file, schema.clone(), Some(props))?;
@@ -244,39 +229,19 @@ pub fn convert_disk_files_to_parquet(
     }
 }
 
-fn parquet_writer_props(
-    time_partition: Option<String>,
-    index_time_partition: usize,
-) -> WriterPropertiesBuilder {
-    let index_time_partition: i32 = index_time_partition as i32;
-
-    if let Some(time_partition) = time_partition {
-        WriterProperties::builder()
-            .set_max_row_group_size(CONFIG.parseable.row_group_size)
-            .set_compression(CONFIG.parseable.parquet_compression.into())
-            .set_column_encoding(
-                ColumnPath::new(vec![time_partition]),
-                Encoding::DELTA_BYTE_ARRAY,
-            )
-            .set_sorting_columns(Some(vec![SortingColumn {
-                column_idx: index_time_partition,
-                descending: true,
-                nulls_first: true,
-            }]))
-    } else {
-        WriterProperties::builder()
-            .set_max_row_group_size(CONFIG.parseable.row_group_size)
-            .set_compression(CONFIG.parseable.parquet_compression.into())
-            .set_column_encoding(
-                ColumnPath::new(vec![DEFAULT_TIMESTAMP_KEY.to_string()]),
-                Encoding::DELTA_BINARY_PACKED,
-            )
-            .set_sorting_columns(Some(vec![SortingColumn {
-                column_idx: index_time_partition,
-                descending: true,
-                nulls_first: true,
-            }]))
-    }
+fn parquet_writer_props() -> WriterPropertiesBuilder {
+    WriterProperties::builder()
+        .set_max_row_group_size(CONFIG.parseable.row_group_size)
+        .set_compression(CONFIG.parseable.parquet_compression.into())
+        .set_column_encoding(
+            ColumnPath::new(vec![DEFAULT_TIMESTAMP_KEY.to_string()]),
+            Encoding::DELTA_BINARY_PACKED,
+        )
+        .set_sorting_columns(Some(vec![SortingColumn {
+            column_idx: 0,
+            descending: true,
+            nulls_first: true,
+        }]))
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/server/src/utils/json.rs
+++ b/server/src/utils/json.rs
@@ -25,16 +25,6 @@ pub fn flatten_json_body(body: serde_json::Value) -> Result<Value, anyhow::Error
     flatten::flatten(body, "_")
 }
 
-pub fn convert_array_to_object(body: Value) -> Result<Vec<Value>, anyhow::Error> {
-    let data = flatten_json_body(body)?;
-    let value_arr = match data {
-        Value::Array(arr) => arr,
-        value @ Value::Object(_) => vec![value],
-        _ => unreachable!("flatten would have failed beforehand"),
-    };
-    Ok(value_arr)
-}
-
 pub fn convert_to_string(value: &Value) -> Value {
     match value {
         Value::Null => Value::String("null".to_owned()),


### PR DESCRIPTION
1. removed the use of X-P-Time-Partition header in log stream creation API

2. removed the logic that partitions the ingested log based on the X-P-Time-Partition header value of which was stored in stream.json
3. Query still uses the logic to make query compatible with the external tool that ingests based on time partition
