### PR TITLE
fix: bug in v3 migration function

### DIFF
--- a/server/src/metadata.rs
+++ b/server/src/metadata.rs
@@ -168,7 +168,7 @@ impl StreamInfo {
 
         for stream in storage.list_streams().await? {
             let alerts = storage.get_alerts(&stream.name).await?;
-            let schema = storage.get_schema_for_the_first_time(&stream.name).await?;
+            let schema = storage.get_schema_on_server_start(&stream.name).await?;
             let meta = storage.get_stream_metadata(&stream.name).await?;
 
             let schema = update_schema_from_staging(&stream.name, schema);

--- a/server/src/migration/metadata_migration.rs
+++ b/server/src/migration/metadata_migration.rs
@@ -109,7 +109,7 @@ pub fn update_v3(mut storage_metadata: JsonValue) -> JsonValue {
     let metadata = storage_metadata.as_object_mut().unwrap();
     let sm = metadata.get("server_mode");
 
-    if sm.is_none() {
+    if sm.is_none() || sm.unwrap().as_str().unwrap() == "All" {
         metadata.insert(
             "server_mode".to_string(),
             JsonValue::String(CONFIG.parseable.mode.to_string()),

--- a/server/src/query/filter_optimizer.rs
+++ b/server/src/query/filter_optimizer.rs
@@ -26,7 +26,7 @@ use datafusion::{
     scalar::ScalarValue,
 };
 
-/// Rewrites logical plan for source using projection and filter  
+/// Rewrites logical plan for source using projection and filter
 pub struct FilterOptimizerRule {
     pub column: String,
     pub literals: Vec<String>,
@@ -117,9 +117,8 @@ impl FilterOptimizerRule {
             Expr::Column(Column::from_name(&self.column)).like(lit(format!("%{}%", literal)))
         });
 
-        let Some(mut filter_expr) = patterns.next() else {
-            return None;
-        };
+        let mut filter_expr = patterns.next()?;
+
         for expr in patterns {
             filter_expr = or(filter_expr, expr)
         }

--- a/server/src/rbac/map.rs
+++ b/server/src/rbac/map.rs
@@ -159,9 +159,7 @@ impl Sessions {
 
     // remove a specific session
     pub fn remove_session(&mut self, key: &SessionKey) -> Option<String> {
-        let Some((user, _)) = self.active_sessions.remove(key) else {
-            return None;
-        };
+        let (user, _) = self.active_sessions.remove(key)?;
 
         if let Some(items) = self.user_sessions.get_mut(&user) {
             items.retain(|(session, _)| session != key);


### PR DESCRIPTION
### Description

If a migration is run in standalone mode. Then the server is switched to distributed mode. The metadata file does not reflect the server mode properly, keeping the value as `"All"` rather than updating to `"Query"`
When Migrated from Standalone Mode stats of the newly created ingest server need to default initalized

<hr>

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.
