### PR TITLE
feat: allow historical ingestion with custom date column in log

### DIFF
--- a/server/src/event/format.rs
+++ b/server/src/event/format.rs
@@ -41,13 +41,15 @@ pub trait EventFormat: Sized {
     fn to_data(
         self,
         schema: HashMap<String, Arc<Field>>,
+        time_partition: Option<String>,
     ) -> Result<(Self::Data, EventSchema, bool, Tags, Metadata), AnyError>;
     fn decode(data: Self::Data, schema: Arc<Schema>) -> Result<RecordBatch, AnyError>;
     fn into_recordbatch(
         self,
         schema: HashMap<String, Arc<Field>>,
+        time_partition: Option<String>,
     ) -> Result<(RecordBatch, bool), AnyError> {
-        let (data, mut schema, is_first, tags, metadata) = self.to_data(schema)?;
+        let (data, mut schema, is_first, tags, metadata) = self.to_data(schema, time_partition)?;
 
         if get_field(&schema, DEFAULT_TAGS_KEY).is_some() {
             return Err(anyhow!("field {} is a reserved field", DEFAULT_TAGS_KEY));

--- a/server/src/event/format/json.rs
+++ b/server/src/event/format/json.rs
@@ -45,8 +45,9 @@ impl EventFormat for Event {
     fn to_data(
         self,
         schema: HashMap<String, Arc<Field>>,
+        time_partition: Option<String>,
     ) -> Result<(Self::Data, Vec<Arc<Field>>, bool, Tags, Metadata), anyhow::Error> {
-        let data = flatten_json_body(self.data)?;
+        let data = flatten_json_body(self.data, time_partition)?;
         let stream_schema = schema;
 
         // incoming event may be a single json or a json array

--- a/server/src/handlers.rs
+++ b/server/src/handlers.rs
@@ -23,6 +23,7 @@ const PREFIX_TAGS: &str = "x-p-tag-";
 const PREFIX_META: &str = "x-p-meta-";
 const STREAM_NAME_HEADER_KEY: &str = "x-p-stream";
 const LOG_SOURCE_KEY: &str = "x-p-log-source";
+const TIME_PARTITION_KEY: &str = "x-p-time-partition";
 const AUTHORIZATION_KEY: &str = "authorization";
 const SEPARATOR: char = '^';
 

--- a/server/src/metadata.rs
+++ b/server/src/metadata.rs
@@ -92,6 +92,13 @@ impl StreamInfo {
             .map(|metadata| metadata.cache_enabled)
     }
 
+    pub fn get_time_partition(&self, stream_name: &str) -> Result<Option<String>, MetadataError> {
+        let map = self.read().expect(LOCK_EXPECT);
+        map.get(stream_name)
+            .ok_or(MetadataError::StreamMetaNotFound(stream_name.to_string()))
+            .map(|metadata| metadata.time_partition.clone())
+    }
+
     pub fn set_stream_cache(&self, stream_name: &str, enable: bool) -> Result<(), MetadataError> {
         let mut map = self.write().expect(LOCK_EXPECT);
         let stream = map
@@ -143,13 +150,18 @@ impl StreamInfo {
             })
     }
 
-    pub fn add_stream(&self, stream_name: String, created_at: String) {
+    pub fn add_stream(&self, stream_name: String, created_at: String, time_partition: String) {
         let mut map = self.write().expect(LOCK_EXPECT);
         let metadata = LogStreamMetadata {
             created_at: if created_at.is_empty() {
                 Local::now().to_rfc3339()
             } else {
                 created_at
+            },
+            time_partition: if time_partition.is_empty() {
+                None
+            } else {
+                Some(time_partition)
             },
             ..Default::default()
         };

--- a/server/src/query/filter_optimizer.rs
+++ b/server/src/query/filter_optimizer.rs
@@ -116,10 +116,8 @@ impl FilterOptimizerRule {
         let mut patterns = self.literals.iter().map(|literal| {
             Expr::Column(Column::from_name(&self.column)).like(lit(format!("%{}%", literal)))
         });
-
-        let Some(mut filter_expr) = patterns.next() else {
-            return None;
-        };
+        
+        let mut filter_expr = patterns.next()?;
         for expr in patterns {
             filter_expr = or(filter_expr, expr)
         }

--- a/server/src/query/filter_optimizer.rs
+++ b/server/src/query/filter_optimizer.rs
@@ -116,7 +116,7 @@ impl FilterOptimizerRule {
         let mut patterns = self.literals.iter().map(|literal| {
             Expr::Column(Column::from_name(&self.column)).like(lit(format!("%{}%", literal)))
         });
-        
+
         let mut filter_expr = patterns.next()?;
         for expr in patterns {
             filter_expr = or(filter_expr, expr)

--- a/server/src/rbac/map.rs
+++ b/server/src/rbac/map.rs
@@ -159,9 +159,8 @@ impl Sessions {
 
     // remove a specific session
     pub fn remove_session(&mut self, key: &SessionKey) -> Option<String> {
-        let Some((user, _)) = self.active_sessions.remove(key) else {
-            return None;
-        };
+        
+        let (user, _) = self.active_sessions.remove(key)?;
 
         if let Some(items) = self.user_sessions.get_mut(&user) {
             items.retain(|(session, _)| session != key);

--- a/server/src/rbac/map.rs
+++ b/server/src/rbac/map.rs
@@ -159,7 +159,6 @@ impl Sessions {
 
     // remove a specific session
     pub fn remove_session(&mut self, key: &SessionKey) -> Option<String> {
-        
         let (user, _) = self.active_sessions.remove(key)?;
 
         if let Some(items) = self.user_sessions.get_mut(&user) {

--- a/server/src/utils/json.rs
+++ b/server/src/utils/json.rs
@@ -21,8 +21,11 @@ use serde_json::Value;
 
 pub mod flatten;
 
-pub fn flatten_json_body(body: serde_json::Value) -> Result<Value, anyhow::Error> {
-    flatten::flatten(body, "_")
+pub fn flatten_json_body(
+    body: serde_json::Value,
+    time_partition: Option<String>,
+) -> Result<Value, anyhow::Error> {
+    flatten::flatten(body, "_", time_partition)
 }
 
 pub fn convert_to_string(value: &Value) -> Value {


### PR DESCRIPTION
feat: allow historical ingestion only when date column provided in header x-p-time-partition and server time are within the same minute, no change for default ingestions