### PR TITLE
Metadata files path migration

### DIFF
--- a/server/src/handlers/http/cluster/mod.rs
+++ b/server/src/handlers/http/cluster/mod.rs
@@ -27,6 +27,7 @@ use crate::option::CONFIG;
 
 use crate::metrics::prom_utils::Metrics;
 use crate::storage::ObjectStorageError;
+use crate::storage::PARSEABLE_ROOT_DIRECTORY;
 use actix_web::http::header;
 use actix_web::{HttpRequest, Responder};
 use http::StatusCode;
@@ -338,7 +339,7 @@ pub async fn get_cluster_metrics() -> Result<impl Responder, PostError> {
 pub async fn get_ingester_info() -> anyhow::Result<IngesterMetadataArr> {
     let store = CONFIG.storage().get_object_store();
 
-    let root_path = RelativePathBuf::from("");
+    let root_path = RelativePathBuf::from(PARSEABLE_ROOT_DIRECTORY);
     let arr = store
         .get_objects(Some(&root_path))
         .await?

--- a/server/src/handlers/http/modal/server.rs
+++ b/server/src/handlers/http/modal/server.rs
@@ -141,6 +141,13 @@ impl ParseableServer for Server {
     /// implementation of init should just invoke a call to initialize
     async fn init(&self) -> anyhow::Result<()> {
         self.validate()?;
+        migration::run_file_migration(&CONFIG).await?;
+        CONFIG.validate_storage().await?;
+        migration::run_metadata_migration(&CONFIG).await?;
+        let metadata = storage::resolve_parseable_metadata().await?;
+        banner::print(&CONFIG, &metadata).await;
+        rbac::map::init(&metadata);
+        metadata.set_global();
         self.initialize().await
     }
 
@@ -405,12 +412,6 @@ impl Server {
     }
 
     async fn initialize(&self) -> anyhow::Result<()> {
-        migration::run_metadata_migration(&CONFIG).await?;
-        let metadata = storage::resolve_parseable_metadata().await?;
-        banner::print(&CONFIG, &metadata).await;
-        rbac::map::init(&metadata);
-        metadata.set_global();
-
         if let Some(cache_manager) = LocalCacheManager::global() {
             cache_manager
                 .validate(CONFIG.parseable.local_cache_size)

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -56,7 +56,6 @@ pub const STORAGE_UPLOAD_INTERVAL: u32 = 60;
 #[actix_web::main]
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
-    CONFIG.validate_storage().await?;
 
     // these are empty ptrs so mem footprint should be minimal
     let server: Arc<dyn ParseableServer> = match CONFIG.parseable.mode {

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -26,7 +26,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::cli::Cli;
-use crate::storage::PARSEABLE_METADATA_FILE_NAME;
+use crate::storage::object_storage::parseable_json_path;
 use crate::storage::{FSConfig, ObjectStorageError, ObjectStorageProvider, S3Config};
 pub const MIN_CACHE_SIZE_BYTES: u64 = 1000u64.pow(3); // 1 GiB
 pub const JOIN_COMMUNITY: &str =
@@ -102,7 +102,7 @@ impl Config {
     // if the proper data directory is provided, or s3 bucket is provided etc
     pub async fn validate_storage(&self) -> Result<(), ObjectStorageError> {
         let obj_store = self.storage.get_object_store();
-        let rel_path = relative_path::RelativePathBuf::from(PARSEABLE_METADATA_FILE_NAME);
+        let rel_path = parseable_json_path();
 
         let has_parseable_json = obj_store.get_object(&rel_path).await.is_ok();
 

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -43,6 +43,7 @@ pub use self::staging::StorageDir;
 // metadata file names in a Stream prefix
 pub const STREAM_METADATA_FILE_NAME: &str = ".stream.json";
 pub const PARSEABLE_METADATA_FILE_NAME: &str = ".parseable.json";
+pub const STREAM_ROOT_DIRECTORY: &str = ".stream";
 pub const PARSEABLE_ROOT_DIRECTORY: &str = ".parseable";
 pub const SCHEMA_FILE_NAME: &str = ".schema";
 pub const ALERT_FILE_NAME: &str = ".alert.json";

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -43,6 +43,7 @@ pub use self::staging::StorageDir;
 // metadata file names in a Stream prefix
 pub const STREAM_METADATA_FILE_NAME: &str = ".stream.json";
 pub const PARSEABLE_METADATA_FILE_NAME: &str = ".parseable.json";
+pub const PARSEABLE_ROOT_DIRECTORY: &str = ".parseable";
 pub const SCHEMA_FILE_NAME: &str = ".schema";
 pub const ALERT_FILE_NAME: &str = ".alert.json";
 pub const MANIFEST_FILE: &str = "manifest.json";

--- a/server/src/storage/localfs.rs
+++ b/server/src/storage/localfs.rs
@@ -27,7 +27,7 @@ use bytes::Bytes;
 use datafusion::{datasource::listing::ListingTableUrl, execution::runtime_env::RuntimeConfig};
 use fs_extra::file::CopyOptions;
 use futures::{stream::FuturesUnordered, TryStreamExt};
-use relative_path::RelativePath;
+use relative_path::{RelativePath, RelativePathBuf};
 use tokio::fs::{self, DirEntry};
 use tokio_stream::wrappers::ReadDirStream;
 
@@ -36,7 +36,7 @@ use crate::option::validation;
 
 use super::{
     LogStream, ObjectStorage, ObjectStorageError, ObjectStorageProvider, PARSEABLE_ROOT_DIRECTORY,
-    STREAM_METADATA_FILE_NAME,
+    SCHEMA_FILE_NAME, STREAM_METADATA_FILE_NAME, STREAM_ROOT_DIRECTORY,
 };
 
 #[derive(Debug, Clone, clap::Args)]
@@ -114,6 +114,81 @@ impl ObjectStorage for LocalFS {
         res
     }
 
+    async fn get_ingester_meta_file_paths(
+        &self,
+    ) -> Result<Vec<RelativePathBuf>, ObjectStorageError> {
+        let time = Instant::now();
+
+        let mut path_arr = vec![];
+        let mut entries = fs::read_dir(&self.root).await?;
+
+        while let Some(entry) = entries.next_entry().await? {
+            let flag = entry
+                .path()
+                .file_name()
+                .unwrap_or_default()
+                .to_str()
+                .unwrap_or_default()
+                .contains("ingester");
+
+            if flag {
+                path_arr.push(
+                    RelativePathBuf::from_path(entry.path().file_name().unwrap())
+                        .map_err(ObjectStorageError::PathError)?,
+                );
+            }
+        }
+
+        let time = time.elapsed().as_secs_f64();
+        REQUEST_RESPONSE_TIME
+            .with_label_values(&["GET", "200"]) // this might not be the right status code
+            .observe(time);
+
+        Ok(path_arr)
+    }
+
+    async fn get_stream_file_paths(
+        &self,
+        stream_name: &str,
+    ) -> Result<Vec<RelativePathBuf>, ObjectStorageError> {
+        let time = Instant::now();
+        let mut path_arr = vec![];
+
+        // = data/stream_name
+        let stream_dir_path = self.path_in_root(&RelativePathBuf::from(stream_name));
+        let mut entries = fs::read_dir(&stream_dir_path).await?;
+
+        while let Some(entry) = entries.next_entry().await? {
+            let flag = entry
+                .path()
+                .file_name()
+                .unwrap_or_default()
+                .to_str()
+                .unwrap_or_default()
+                .contains("ingester");
+
+            if flag {
+                path_arr.push(RelativePathBuf::from_iter([
+                    stream_name,
+                    entry.path().file_name().unwrap().to_str().unwrap(),
+                ]));
+            }
+        }
+
+        path_arr.push(RelativePathBuf::from_iter([
+            stream_name,
+            STREAM_METADATA_FILE_NAME,
+        ]));
+        path_arr.push(RelativePathBuf::from_iter([stream_name, SCHEMA_FILE_NAME]));
+
+        let time = time.elapsed().as_secs_f64();
+        REQUEST_RESPONSE_TIME
+            .with_label_values(&["GET", "200"]) // this might not be the right status code
+            .observe(time);
+
+        Ok(path_arr)
+    }
+
     async fn get_objects(
         &self,
         base_path: Option<&RelativePath>,
@@ -183,6 +258,12 @@ impl ObjectStorage for LocalFS {
         Ok(())
     }
 
+    async fn delete_object(&self, path: &RelativePath) -> Result<(), ObjectStorageError> {
+        let path = self.path_in_root(path);
+        tokio::fs::remove_file(path).await?;
+        Ok(())
+    }
+
     async fn check(&self) -> Result<(), ObjectStorageError> {
         fs::create_dir_all(&self.root)
             .await
@@ -209,6 +290,26 @@ impl ObjectStorage for LocalFS {
         let entries = entries
             .into_iter()
             .map(|entry| dir_with_stream(entry, ignore_dir));
+
+        let logstream_dirs: Vec<Option<String>> =
+            FuturesUnordered::from_iter(entries).try_collect().await?;
+
+        let logstreams = logstream_dirs
+            .into_iter()
+            .flatten()
+            .map(|name| LogStream { name })
+            .collect();
+
+        Ok(logstreams)
+    }
+
+    async fn list_old_streams(&self) -> Result<Vec<LogStream>, ObjectStorageError> {
+        let ignore_dir = &["lost+found", PARSEABLE_ROOT_DIRECTORY];
+        let directories = ReadDirStream::new(fs::read_dir(&self.root).await?);
+        let entries: Vec<DirEntry> = directories.try_collect().await?;
+        let entries = entries
+            .into_iter()
+            .map(|entry| dir_with_old_stream(entry, ignore_dir));
 
         let logstream_dirs: Vec<Option<String>> =
             FuturesUnordered::from_iter(entries).try_collect().await?;
@@ -293,7 +394,7 @@ impl ObjectStorage for LocalFS {
     }
 }
 
-async fn dir_with_stream(
+async fn dir_with_old_stream(
     entry: DirEntry,
     ignore_dirs: &[&str],
 ) -> Result<Option<String>, ObjectStorageError> {
@@ -314,6 +415,42 @@ async fn dir_with_stream(
 
         // even in ingest mode, we should only look for the global stream metadata file
         let stream_json_path = path.join(STREAM_METADATA_FILE_NAME);
+
+        if stream_json_path.exists() {
+            Ok(Some(dir_name))
+        } else {
+            let err: Box<dyn std::error::Error + Send + Sync + 'static> =
+                format!("found {}", entry.path().display()).into();
+            Err(ObjectStorageError::UnhandledError(err))
+        }
+    } else {
+        Ok(None)
+    }
+}
+
+async fn dir_with_stream(
+    entry: DirEntry,
+    ignore_dirs: &[&str],
+) -> Result<Option<String>, ObjectStorageError> {
+    let dir_name = entry
+        .path()
+        .file_name()
+        .expect("valid path")
+        .to_str()
+        .expect("valid unicode")
+        .to_owned();
+
+    if ignore_dirs.contains(&dir_name.as_str()) {
+        return Ok(None);
+    }
+
+    if entry.file_type().await?.is_dir() {
+        let path = entry.path();
+
+        // even in ingest mode, we should only look for the global stream metadata file
+        let stream_json_path = path
+            .join(STREAM_ROOT_DIRECTORY)
+            .join(STREAM_METADATA_FILE_NAME);
 
         if stream_json_path.exists() {
             Ok(Some(dir_name))

--- a/server/src/storage/localfs.rs
+++ b/server/src/storage/localfs.rs
@@ -35,7 +35,8 @@ use crate::metrics::storage::{localfs::REQUEST_RESPONSE_TIME, StorageMetrics};
 use crate::option::validation;
 
 use super::{
-    LogStream, ObjectStorage, ObjectStorageError, ObjectStorageProvider, STREAM_METADATA_FILE_NAME,
+    LogStream, ObjectStorage, ObjectStorageError, ObjectStorageProvider, PARSEABLE_ROOT_DIRECTORY,
+    STREAM_METADATA_FILE_NAME,
 };
 
 #[derive(Debug, Clone, clap::Args)]
@@ -202,7 +203,7 @@ impl ObjectStorage for LocalFS {
     }
 
     async fn list_streams(&self) -> Result<Vec<LogStream>, ObjectStorageError> {
-        let ignore_dir = &["lost+found"];
+        let ignore_dir = &["lost+found", PARSEABLE_ROOT_DIRECTORY];
         let directories = ReadDirStream::new(fs::read_dir(&self.root).await?);
         let entries: Vec<DirEntry> = directories.try_collect().await?;
         let entries = entries

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -21,8 +21,8 @@ use super::{
     ObjectStoreFormat, Permisssion, StorageDir, StorageMetadata,
 };
 use super::{
-    ALERT_FILE_NAME, MANIFEST_FILE, PARSEABLE_METADATA_FILE_NAME, SCHEMA_FILE_NAME,
-    STREAM_METADATA_FILE_NAME,
+    ALERT_FILE_NAME, MANIFEST_FILE, PARSEABLE_METADATA_FILE_NAME, PARSEABLE_ROOT_DIRECTORY,
+    SCHEMA_FILE_NAME, STREAM_METADATA_FILE_NAME,
 };
 
 use crate::option::Mode;
@@ -508,9 +508,10 @@ pub fn stream_json_path(stream_name: &str) -> RelativePathBuf {
     }
 }
 
+/// path will be ".parseable/.parsable.json"
 #[inline(always)]
-fn parseable_json_path() -> RelativePathBuf {
-    RelativePathBuf::from(PARSEABLE_METADATA_FILE_NAME)
+pub fn parseable_json_path() -> RelativePathBuf {
+    RelativePathBuf::from_iter([PARSEABLE_ROOT_DIRECTORY, PARSEABLE_METADATA_FILE_NAME])
 }
 
 #[inline(always)]
@@ -523,4 +524,9 @@ fn manifest_path(prefix: &str) -> RelativePathBuf {
     let addr = get_address();
     let mainfest_file_name = format!("{}.{}.{}", addr.0, addr.1, MANIFEST_FILE);
     RelativePathBuf::from_iter([prefix, &mainfest_file_name])
+}
+
+#[inline(always)]
+pub fn ingester_metadata_path(ip: String, port: String) -> RelativePathBuf {
+    RelativePathBuf::from_iter([PARSEABLE_ROOT_DIRECTORY, &format!("ingester.{}.{}.json", ip, port)])
 }

--- a/server/src/storage/s3.rs
+++ b/server/src/storage/s3.rs
@@ -39,7 +39,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crate::metrics::storage::{s3::REQUEST_RESPONSE_TIME, StorageMetrics};
-use crate::storage::{LogStream, ObjectStorage, ObjectStorageError};
+use crate::storage::{LogStream, ObjectStorage, ObjectStorageError, PARSEABLE_ROOT_DIRECTORY};
 
 use super::metrics_layer::MetricLayer;
 use super::{ObjectStorageProvider, PARSEABLE_METADATA_FILE_NAME, STREAM_METADATA_FILE_NAME};
@@ -297,11 +297,13 @@ impl S3 {
         let common_prefixes = resp.common_prefixes;
 
         // return prefixes at the root level
-        let dirs: Vec<_> = common_prefixes
+        let mut dirs: Vec<_> = common_prefixes
             .iter()
             .filter_map(|path| path.parts().next())
             .map(|name| name.as_ref().to_string())
             .collect();
+        // filter out the root directory
+        dirs.retain(|x| x != PARSEABLE_ROOT_DIRECTORY);
 
         let stream_json_check = FuturesUnordered::new();
 

--- a/server/src/storage/store_metadata.rs
+++ b/server/src/storage/store_metadata.rs
@@ -33,7 +33,7 @@ use crate::{
     utils::uid,
 };
 
-use super::PARSEABLE_METADATA_FILE_NAME;
+use super::{object_storage::parseable_json_path, PARSEABLE_METADATA_FILE_NAME};
 
 // Expose some static variables for internal usage
 pub static STORAGE_METADATA: OnceCell<StaticStorageMetadata> = OnceCell::new();
@@ -237,7 +237,7 @@ fn standalone_when_distributed(remote_server_mode: Mode) -> Result<(), MetadataE
 }
 
 pub fn get_staging_metadata() -> io::Result<Option<StorageMetadata>> {
-    let path = CONFIG.staging_dir().join(PARSEABLE_METADATA_FILE_NAME);
+    let path = parseable_json_path().to_path(CONFIG.staging_dir());
     let bytes = match fs::read(path) {
         Ok(bytes) => bytes,
         Err(err) => match err.kind() {

--- a/server/src/storage/store_metadata.rs
+++ b/server/src/storage/store_metadata.rs
@@ -126,33 +126,39 @@ pub async fn resolve_parseable_metadata() -> Result<StorageMetadata, ObjectStora
             Err("Could not start the server because staging directory indicates stale data from previous deployment, please choose an empty staging directory and restart the server")
         }
         EnvChange::NewStaging(mut metadata) => {
-            create_dir_all(CONFIG.staging_dir())?;
-            metadata.staging = CONFIG.staging_dir().canonicalize()?;
-            // this flag is set to true so that metadata is copied to staging
-            overwrite_staging = true;
-            // overwrite remote in all and query mode
-            // because staging dir has changed.
-            match CONFIG.parseable.mode {
-                Mode::All => {
-                    standalone_when_distributed(Mode::from_string(&metadata.server_mode).expect("mode should be valid at here"))
-                        .map_err(|err| {
-                            ObjectStorageError::Custom(err.to_string())
-                        })?;
+            // if server is started in ingest mode,we need to make sure that query mode has been started
+            // i.e the metadata is updated to reflect the server mode = Query
+            if Mode::from_string(&metadata.server_mode).unwrap() == Mode::All && CONFIG.parseable.mode == Mode::Ingest {
+                Err("Starting Ingest Mode is not allowed, Since Query Server has not been started yet")
+            } else {
+                create_dir_all(CONFIG.staging_dir())?;
+                metadata.staging = CONFIG.staging_dir().canonicalize()?;
+                // this flag is set to true so that metadata is copied to staging
+                overwrite_staging = true;
+                // overwrite remote in all and query mode
+                // because staging dir has changed.
+                match CONFIG.parseable.mode {
+                    Mode::All => {
+                        standalone_when_distributed(Mode::from_string(&metadata.server_mode).expect("mode should be valid at here"))
+                            .map_err(|err| {
+                                ObjectStorageError::Custom(err.to_string())
+                            })?;
+                            overwrite_remote = true;
+                    },
+                    Mode::Query => {
                         overwrite_remote = true;
-                },
-                Mode::Query => {
-                    overwrite_remote = true;
-                    metadata.server_mode = CONFIG.parseable.mode.to_string();
-                    metadata.staging = CONFIG.staging_dir().to_path_buf();
-                },
-                Mode::Ingest => {
-                    // if ingest server is started fetch the metadata from remote
-                    // update the server mode for local metadata
-                    metadata.server_mode = CONFIG.parseable.mode.to_string();
-                    metadata.staging = CONFIG.staging_dir().to_path_buf();
-                },
+                        metadata.server_mode = CONFIG.parseable.mode.to_string();
+                        metadata.staging = CONFIG.staging_dir().to_path_buf();
+                    },
+                    Mode::Ingest => {
+                        // if ingest server is started fetch the metadata from remote
+                        // update the server mode for local metadata
+                        metadata.server_mode = CONFIG.parseable.mode.to_string();
+                        metadata.staging = CONFIG.staging_dir().to_path_buf();
+                    },
+                }
+                Ok(metadata)
             }
-            Ok(metadata)
         }
         EnvChange::CreateBoth => {
             create_dir_all(CONFIG.staging_dir())?;


### PR DESCRIPTION
### Description

1. Update the server initialization steps
2. Seperate out the logic to fetch directories with old streams and new streams
3. Update ObjectStorage Trait to refect the same
4. Fix the migration logic guard for Ingest Servers
5. Impl migration of server metadata files on Object Store
6. update the root path for the metadata files
  
<hr>

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.
