### PR TITLE
feat: static schema flag to stream-info API

### DIFF
--- a/server/src/handlers/http/logstream.rs
+++ b/server/src/handlers/http/logstream.rs
@@ -21,8 +21,8 @@ use crate::alerts::Alerts;
 use crate::handlers::{STATIC_SCHEMA_FLAG, TIME_PARTITION_KEY};
 use crate::metadata::STREAM_INFO;
 use crate::option::CONFIG;
+use crate::static_schema::{convert_static_schema_to_arrow_schema, StaticSchema};
 use crate::storage::{retention::Retention, LogStream, StorageDir, StreamInfo};
-use crate::static_schema::{StaticSchema, convert_static_schema_to_arrow_schema};
 use crate::{catalog, event, stats};
 use crate::{metadata, validator};
 use actix_web::http::StatusCode;
@@ -434,6 +434,7 @@ pub async fn get_stream_info(req: HttpRequest) -> Result<impl Responder, StreamE
         first_event_at: stream_meta.first_event_at.clone(),
         time_partition: stream_meta.time_partition.clone(),
         cache_enabled: stream_meta.cache_enabled,
+        static_schema_flag: stream_meta.static_schema_flag.clone(),
     };
 
     Ok((web::Json(stream_info), StatusCode::OK))

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -99,6 +99,8 @@ pub struct StreamInfo {
     pub cache_enabled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub time_partition: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub static_schema_flag: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
added static-schema-flag to stream info API

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
