### PR TITLE
allow type casting in static schema

### DIFF
--- a/server/src/event/format.rs
+++ b/server/src/event/format.rs
@@ -42,6 +42,7 @@ pub trait EventFormat: Sized {
         self,
         schema: HashMap<String, Arc<Field>>,
         time_partition: Option<String>,
+        static_schema_flag: Option<String>,
     ) -> Result<(Self::Data, EventSchema, bool, Tags, Metadata), AnyError>;
     fn decode(data: Self::Data, schema: Arc<Schema>) -> Result<RecordBatch, AnyError>;
     fn into_recordbatch(
@@ -50,8 +51,11 @@ pub trait EventFormat: Sized {
         time_partition: Option<String>,
         static_schema_flag: Option<String>,
     ) -> Result<(RecordBatch, bool), AnyError> {
-        let (data, mut schema, is_first, tags, metadata) =
-            self.to_data(storage_schema.clone(), time_partition)?;
+        let (data, mut schema, is_first, tags, metadata) = self.to_data(
+            storage_schema.clone(),
+            time_partition,
+            static_schema_flag.clone(),
+        )?;
 
         if get_field(&schema, DEFAULT_TAGS_KEY).is_some() {
             return Err(anyhow!("field {} is a reserved field", DEFAULT_TAGS_KEY));

--- a/server/src/event/format/json.rs
+++ b/server/src/event/format/json.rs
@@ -46,6 +46,7 @@ impl EventFormat for Event {
         self,
         schema: HashMap<String, Arc<Field>>,
         time_partition: Option<String>,
+        static_schema_flag: Option<String>,
     ) -> Result<(Self::Data, Vec<Arc<Field>>, bool, Tags, Metadata), anyhow::Error> {
         let data = flatten_json_body(self.data, time_partition)?;
         let stream_schema = schema;
@@ -91,9 +92,10 @@ impl EventFormat for Event {
             },
         };
 
-        if value_arr
-            .iter()
-            .any(|value| fields_mismatch(&schema, value))
+        if static_schema_flag.is_none()
+            && value_arr
+                .iter()
+                .any(|value| fields_mismatch(&schema, value))
         {
             return Err(anyhow!(
                 "Could not process this event due to mismatch in datatype"


### PR DESCRIPTION
if field defined as float,
below values (examples) can be accepted -
100,-100.45, 100.23, "200.45"

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #639 .

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
