### PR TITLE
Fix: OAuth User to Role Mapping Fix

### DIFF
--- a/server/src/rbac/user.rs
+++ b/server/src/rbac/user.rs
@@ -60,7 +60,7 @@ impl User {
     pub fn new_oauth(username: String, roles: HashSet<String>, user_info: UserInfo) -> Self {
         Self {
             ty: UserType::OAuth(OAuth {
-                userid: username,
+                userid: user_info.name.clone().unwrap_or(username),
                 user_info,
             }),
             roles,


### PR DESCRIPTION
1. default role not assigned to the oauth user if group does not exist
2. name used instead of id


<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #638 #686 

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
