### PR TITLE
fix for staging size metrics not resetting to 0

### DIFF
--- a/server/src/storage/staging.rs
+++ b/server/src/storage/staging.rs
@@ -199,6 +199,12 @@ pub fn convert_disk_files_to_parquet(
     let staging_files = dir.arrow_files_grouped_exclude_time(time);
     if staging_files.is_empty() {
         metrics::STAGING_FILES.with_label_values(&[stream]).set(0);
+        metrics::STORAGE_SIZE
+            .with_label_values(&["staging", stream, "arrows"])
+            .set(0);
+        metrics::STORAGE_SIZE
+            .with_label_values(&["staging", stream, "parquet"])
+            .set(0);
     }
 
     for (parquet_path, files) in staging_files {


### PR DESCRIPTION
fix for staging size metrics not resetting to 0 even when local to storage sync is completed and no arrow/parquet file is left in staging folder
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
