### PR TITLE
Fetch schema and stream from obj store

### DIFF
--- a/server/src/handlers/http/cluster/mod.rs
+++ b/server/src/handlers/http/cluster/mod.rs
@@ -117,7 +117,10 @@ pub async fn fetch_stats_from_ingesters(
     let obs = CONFIG
         .storage()
         .get_object_store()
-        .get_objects(Some(&path), ".ingester")
+        .get_objects(
+            Some(&path),
+            Box::new(|file_name| file_name.starts_with(".ingester")),
+        )
         .await?;
     let mut ingestion_size = 0u64;
     let mut storage_size = 0u64;
@@ -346,7 +349,10 @@ pub async fn get_ingester_info() -> anyhow::Result<IngesterMetadataArr> {
 
     let root_path = RelativePathBuf::from(PARSEABLE_ROOT_DIRECTORY);
     let arr = store
-        .get_objects(Some(&root_path), "ingester")
+        .get_objects(
+            Some(&root_path),
+            Box::new(|file_name| file_name.starts_with("ingester")),
+        )
         .await?
         .iter()
         // this unwrap will most definateley shoot me in the foot later

--- a/server/src/handlers/http/cluster/mod.rs
+++ b/server/src/handlers/http/cluster/mod.rs
@@ -49,6 +49,7 @@ use super::base_path_without_preceding_slash;
 use super::modal::IngesterMetadata;
 
 // forward the request to all ingesters to keep them in sync
+#[allow(dead_code)]
 pub async fn sync_streams_with_ingesters(
     stream_name: &str,
     time_partition: &str,
@@ -143,6 +144,7 @@ pub async fn fetch_stats_from_ingesters(
     Ok(vec![qs])
 }
 
+#[allow(dead_code)]
 async fn send_stream_sync_request(
     url: &str,
     ingester: IngesterMetadata,
@@ -186,6 +188,7 @@ async fn send_stream_sync_request(
 }
 
 /// send a rollback request to all ingesters
+#[allow(dead_code)]
 async fn send_stream_rollback_request(
     url: &str,
     ingester: IngesterMetadata,

--- a/server/src/handlers/http/logstream.rs
+++ b/server/src/handlers/http/logstream.rs
@@ -26,8 +26,8 @@ use crate::storage::{retention::Retention, LogStream, StorageDir, StreamInfo};
 use crate::{catalog, event, stats};
 use crate::{metadata, validator};
 
+use super::cluster::fetch_stats_from_ingesters;
 use super::cluster::utils::{merge_quried_stats, IngestionStats, QueriedStats, StorageStats};
-use super::cluster::{fetch_stats_from_ingesters, sync_streams_with_ingesters};
 use actix_web::http::StatusCode;
 use actix_web::{web, HttpRequest, Responder};
 use arrow_schema::{Field, Schema};
@@ -166,9 +166,6 @@ pub async fn put_stream(req: HttpRequest, body: Bytes) -> Result<impl Responder,
                 });
     }
 
-    if CONFIG.parseable.mode == Mode::Query {
-        sync_streams_with_ingesters(&stream_name, time_partition, static_schema_flag, body).await?;
-    }
     create_stream(stream_name, time_partition, static_schema_flag, schema).await?;
 
     Ok(("log stream created", StatusCode::OK))

--- a/server/src/handlers/http/modal/ingest_server.rs
+++ b/server/src/handlers/http/modal/ingest_server.rs
@@ -263,7 +263,10 @@ impl IngestServer {
         let store = CONFIG.storage().get_object_store();
         let base_path = RelativePathBuf::from("");
         let ingester_metadata = store
-            .get_objects(Some(&base_path), "ingester")
+            .get_objects(
+                Some(&base_path),
+                Box::new(|file_name| file_name.starts_with("ingester")),
+            )
             .await?
             .iter()
             // this unwrap will most definateley shoot me in the foot later

--- a/server/src/handlers/http/query.rs
+++ b/server/src/handlers/http/query.rs
@@ -74,6 +74,7 @@ pub async fn query(req: HttpRequest, query_request: Query) -> Result<impl Respon
 
     if CONFIG.parseable.mode == Mode::Query {
         if let Ok(new_schema) = fetch_schema(&table_name).await {
+            // commit schema merges the schema internally and updates the schema in storage.
             commit_schema_to_storage(&table_name, new_schema.clone())
                 .await
                 .map_err(QueryError::ObjectStorage)?;

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -42,7 +42,15 @@ pub struct Config {
 
 impl Config {
     fn new() -> Self {
-        let cli = create_parseable_cli_command().get_matches();
+        let cli = create_parseable_cli_command()
+            .name("Parseable")
+            .about("A Cloud Native, log analytics platform")
+            .before_help("Log Lake for the cloud-native world")
+            .arg_required_else_help(true)
+            .subcommand_required(true)
+            .color(clap::ColorChoice::Always)
+            .get_matches();
+
         match cli.subcommand() {
             Some(("local-store", m)) => {
                 let cli = match Cli::from_arg_matches(m) {
@@ -181,7 +189,8 @@ fn create_parseable_cli_command() -> Command {
         .next_line_help(false)
         .help_template(
             r#"
-{about} Join the community at https://logg.ing/community.
+{about}
+Join the community at https://logg.ing/community.
 
 {all-args}
         "#,

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -167,7 +167,7 @@ impl ObjectStoreFormat {
     }
 }
 
-#[derive(serde::Serialize)]
+#[derive(serde::Serialize, PartialEq)]
 pub struct LogStream {
     pub name: String,
 }

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -69,7 +69,7 @@ pub trait ObjectStorage: Sync + 'static {
     async fn get_objects(
         &self,
         base_path: Option<&RelativePath>,
-        starts_with_pattern: &str,
+        filter_fun: Box<dyn Fn(String) -> bool + Send>,
     ) -> Result<Vec<Bytes>, ObjectStorageError>;
     async fn put_object(
         &self,


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->
Schema now is fetched from the Object Store
And Stream Info for ingesters is no longer synced/updated at creation time, rather at ingest time, if stream info does not exists
Ingester Updates the stream info from store

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.
