### PR TITLE
rename P_NODE_URL to P_INGESTOR_URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 target
-data
-staging
+data*
+staging*
 limitcache
 examples
 cert.pem

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -87,8 +87,8 @@ pub struct Cli {
     /// Mode of operation
     pub mode: Mode,
 
-    /// public address for the parseable server
-    pub node_url: String,
+    /// public address for the parseable server ingestor
+    pub ingestor_url: String,
 }
 
 impl Cli {
@@ -115,7 +115,7 @@ impl Cli {
     pub const ROW_GROUP_SIZE: &'static str = "row-group-size";
     pub const PARQUET_COMPRESSION_ALGO: &'static str = "compression-algo";
     pub const MODE: &'static str = "mode";
-    pub const NODE_URL: &'static str = "node-url";
+    pub const INGESTOR_URL: &'static str = "ingestor-url";
     pub const DEFAULT_USERNAME: &'static str = "admin";
     pub const DEFAULT_PASSWORD: &'static str = "admin";
 
@@ -317,13 +317,13 @@ impl Cli {
                     .help("Mode of operation"),
             )
             .arg(
-            	Arg::new(Self::NODE_URL)
-             		.long(Self::NODE_URL)
-               		.env("P_NODE_URL")
+            	Arg::new(Self::INGESTOR_URL)
+             		.long(Self::INGESTOR_URL)
+               		.env("P_INGESTOR_URL")
                  	.value_name("URL")
                   	.required(false)
                     .value_parser(validation::socket_addr)
-                    .help("Node URL for Parseable server")
+                    .help("URL to connect to this specific ingestor. Default is the address of the server.")
             )
             .arg(
                 Arg::new(Self::PARQUET_COMPRESSION_ALGO)
@@ -368,8 +368,8 @@ impl FromArgMatches for Cli {
             .cloned()
             .expect("default value for address");
 
-        self.node_url = m
-            .get_one::<String>(Self::NODE_URL)
+        self.ingestor_url = m
+            .get_one::<String>(Self::INGESTOR_URL)
             .cloned()
             .unwrap_or_else(|| self.address.clone());
 

--- a/server/src/handlers/http/modal/server.rs
+++ b/server/src/handlers/http/modal/server.rs
@@ -480,7 +480,7 @@ impl Server {
     pub fn get_server_address() -> SocketAddr {
         // this might cause an issue down the line
         // best is to make the Cli Struct better, but thats a chore
-        (CONFIG.parseable.node_url.clone())
+        (CONFIG.parseable.ingestor_url.clone())
             .parse::<SocketAddr>()
             .unwrap()
     }

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -228,7 +228,7 @@ impl TimePeriod {
 
 #[inline(always)]
 pub fn get_address() -> (IpAddr, u16) {
-    let addr = CONFIG.parseable.node_url.parse::<SocketAddr>().unwrap();
+    let addr = CONFIG.parseable.ingestor_url.parse::<SocketAddr>().unwrap();
     (addr.ip(), addr.port())
 }
 


### PR DESCRIPTION
`P_INGESTOR_URL` is a better name for this env variable.