### PR TITLE
fix: modified populate_via_listing function to push first prefix entr…

### DIFF
--- a/server/src/query/listing_table_builder.rs
+++ b/server/src/query/listing_table_builder.rs
@@ -112,8 +112,8 @@ impl ListingTableBuilder {
                 let hour_prefix = &prefix[0..prefix.rfind("minute").expect("minute exists")];
                 minute_resolve
                     .entry(hour_prefix.to_owned())
-                    .and_modify(|list| list.push(prefix))
-                    .or_default();
+                    .or_insert(Vec::new())
+                    .push(prefix);
             } else {
                 all_resolve.push(prefix)
             }


### PR DESCRIPTION
…y while creating minute_resolve hashmap (#692)

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #692 

### Description

modified populate_via_listing function to push first prefix entry while creating minute_resolve hashmap

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
