### PR TITLE
fix for delete stream API for distributed

### DIFF
--- a/server/src/handlers/http/modal/ingest_server.rs
+++ b/server/src/handlers/http/modal/ingest_server.rs
@@ -158,6 +158,13 @@ impl IngestServer {
         web::scope("/logstream").service(
             web::scope("/{logstream}")
                 .service(
+                    web::resource("").route(
+                        web::delete()
+                            .to(logstream::delete)
+                            .authorize_for_stream(Action::DeleteStream),
+                    ),
+                )
+                .service(
                     // GET "/logstream/{logstream}/stats" ==> Get stats for given log stream
                     web::resource("/stats").route(
                         web::get()


### PR DESCRIPTION
change - querier deletes the stream folder from the storage 
then calls delete stream API for each ingester
ingester deletes the stream from its local map

Fixes #763 .

