### PR TITLE
Multiple Fixes for Distributed Deployments

### DIFF
--- a/server/src/handlers/http/logstream.rs
+++ b/server/src/handlers/http/logstream.rs
@@ -338,6 +338,16 @@ pub async fn put_retention(
 
 pub async fn get_cache_enabled(req: HttpRequest) -> Result<impl Responder, StreamError> {
     let stream_name: String = req.match_info().get("logstream").unwrap().parse().unwrap();
+
+    match CONFIG.parseable.mode {
+        Mode::Ingest | Mode::All => {
+            if CONFIG.parseable.local_cache_path.is_none() {
+                return Err(StreamError::CacheNotEnabled(stream_name));
+            }
+        }
+        _ => {}
+    }
+
     let cache_enabled = STREAM_INFO.cache_enabled(&stream_name)?;
     Ok((web::Json(cache_enabled), StatusCode::OK))
 }

--- a/server/src/query/stream_schema_provider.rs
+++ b/server/src/query/stream_schema_provider.rs
@@ -328,10 +328,9 @@ impl TableProvider for StandardTableProvider {
             let obs = glob_storage
                 .get_objects(
                     Some(&path),
-                    Box::new(|file_name| file_name.starts_with(".ingestor")),
+                    Box::new(|file_name| file_name.ends_with("manifest.json")),
                 )
                 .await;
-
             if let Ok(obs) = obs {
                 for ob in obs {
                     if let Ok(object_store_format) =

--- a/server/src/storage/staging.rs
+++ b/server/src/storage/staging.rs
@@ -247,10 +247,16 @@ pub fn convert_disk_files_to_parquet(
         writer.close()?;
 
         for file in files {
-            if fs::remove_file(file).is_err() {
+            let file_size = file.metadata().unwrap().len();
+            let file_type = file.extension().unwrap().to_str().unwrap();
+
+            if fs::remove_file(file.clone()).is_err() {
                 log::error!("Failed to delete file. Unstable state");
                 process::abort()
             }
+            metrics::STORAGE_SIZE
+                .with_label_values(&["staging", stream, file_type])
+                .sub(file_size as i64);
         }
     }
 


### PR DESCRIPTION
- to subtract the size of the arrow file removed from staging from staging size metrics
- to return error in case global cache is not set - /GET cache returns true/false but does not even check if global cache was enabled
change done is to return error if global cache is not set, if set return true/false
- query fix for migration from standalone to distributed deployments - query was not working for the manifest listed dates but was working when from date was given a day before the manifest listed date
change done is to add querier manifest.json also while checking for all manifests related to the time filter
- fix for edge case when ingestor was down/unreachable at the timeout of retention activity and ingestor's stream.json did not get updated now when ingestion happens from ingestor, local to storage sync fails with error - Manifest found in snapshot but not in object-storage change done is to create the manifest but not update the snapshot because snapshot already has the manifest entry
