### PR TITLE
Allow Ingestion with Time Partition - Till 1 month older events

### DIFF
--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -75,38 +75,20 @@ fn get_file_bounds(
     file: &manifest::File,
     partition_column: String,
 ) -> (DateTime<Utc>, DateTime<Utc>) {
-    if partition_column == DEFAULT_TIMESTAMP_KEY {
-        match file
-            .columns()
-            .iter()
-            .find(|col| col.name == partition_column)
-            .unwrap()
-            .stats
-            .as_ref()
-            .unwrap()
-        {
-            column::TypedStatistics::Int(stats) => (
-                DateTime::from_timestamp_millis(stats.min).unwrap(),
-                DateTime::from_timestamp_millis(stats.max).unwrap(),
-            ),
-            _ => unreachable!(),
-        }
-    } else {
-        match file
-            .columns()
-            .iter()
-            .find(|col| col.name == partition_column)
-            .unwrap()
-            .stats
-            .as_ref()
-            .unwrap()
-        {
-            column::TypedStatistics::String(stats) => (
-                stats.min.parse::<DateTime<Utc>>().unwrap(),
-                stats.max.parse::<DateTime<Utc>>().unwrap(),
-            ),
-            _ => unreachable!(),
-        }
+    match file
+        .columns()
+        .iter()
+        .find(|col| col.name == partition_column)
+        .unwrap()
+        .stats
+        .as_ref()
+        .unwrap()
+    {
+        column::TypedStatistics::Int(stats) => (
+            DateTime::from_timestamp_millis(stats.min).unwrap(),
+            DateTime::from_timestamp_millis(stats.max).unwrap(),
+        ),
+        _ => unreachable!(),
     }
 }
 

--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -42,8 +42,11 @@ pub trait Snapshot {
 }
 
 pub trait ManifestFile {
+    #[allow(unused)]
     fn file_name(&self) -> &str;
+    #[allow(unused)]
     fn ingestion_size(&self) -> u64;
+    #[allow(unused)]
     fn file_size(&self) -> u64;
     fn num_rows(&self) -> u64;
     fn columns(&self) -> &[Column];

--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -23,6 +23,7 @@ use crate::handlers::http::base_path_without_preceding_slash;
 use crate::option::CONFIG;
 use crate::{
     catalog::manifest::Manifest,
+    event::DEFAULT_TIMESTAMP_KEY,
     query::PartialTimeFilter,
     storage::{object_storage::manifest_path, ObjectStorage, ObjectStorageError},
 };
@@ -70,21 +71,42 @@ impl ManifestFile for manifest::File {
     }
 }
 
-fn get_file_bounds(file: &manifest::File) -> (DateTime<Utc>, DateTime<Utc>) {
-    match file
-        .columns()
-        .iter()
-        .find(|col| col.name == "p_timestamp")
-        .unwrap()
-        .stats
-        .clone()
-        .unwrap()
-    {
-        column::TypedStatistics::Int(stats) => (
-            DateTime::from_timestamp_millis(stats.min).unwrap(),
-            DateTime::from_timestamp_millis(stats.max).unwrap(),
-        ),
-        _ => unreachable!(),
+fn get_file_bounds(
+    file: &manifest::File,
+    partition_column: String,
+) -> (DateTime<Utc>, DateTime<Utc>) {
+    if partition_column == DEFAULT_TIMESTAMP_KEY {
+        match file
+            .columns()
+            .iter()
+            .find(|col| col.name == partition_column)
+            .unwrap()
+            .stats
+            .as_ref()
+            .unwrap()
+        {
+            column::TypedStatistics::Int(stats) => (
+                DateTime::from_timestamp_millis(stats.min).unwrap(),
+                DateTime::from_timestamp_millis(stats.max).unwrap(),
+            ),
+            _ => unreachable!(),
+        }
+    } else {
+        match file
+            .columns()
+            .iter()
+            .find(|col| col.name == partition_column)
+            .unwrap()
+            .stats
+            .as_ref()
+            .unwrap()
+        {
+            column::TypedStatistics::String(stats) => (
+                stats.min.parse::<DateTime<Utc>>().unwrap(),
+                stats.max.parse::<DateTime<Utc>>().unwrap(),
+            ),
+            _ => unreachable!(),
+        }
     }
 }
 
@@ -95,8 +117,19 @@ pub async fn update_snapshot(
 ) -> Result<(), ObjectStorageError> {
     // get current snapshot
     let mut meta = storage.get_object_store_format(stream_name).await?;
+    let meta_clone = meta.clone();
     let manifests = &mut meta.snapshot.manifest_list;
-    let (lower_bound, _) = get_file_bounds(&change);
+    let time_partition: Option<String> = meta_clone.time_partition;
+    let lower_bound = match time_partition {
+        Some(time_partition) => {
+            let (lower_bound, _) = get_file_bounds(&change, time_partition);
+            lower_bound
+        }
+        None => {
+            let (lower_bound, _) = get_file_bounds(&change, DEFAULT_TIMESTAMP_KEY.to_string());
+            lower_bound
+        }
+    };
     let pos = manifests.iter().position(|item| {
         item.time_lower_bound <= lower_bound && lower_bound < item.time_upper_bound
     });
@@ -239,6 +272,7 @@ pub async fn get_first_event(
             // get current snapshot
             let mut meta = storage.get_object_store_format(stream_name).await?;
             let manifests = &mut meta.snapshot.manifest_list;
+            let time_partition = meta.time_partition;
             if manifests.is_empty() {
                 log::info!("No manifest found for stream {stream_name}");
                 return Err(ObjectStorageError::Custom("No manifest found".to_string()));
@@ -257,7 +291,17 @@ pub async fn get_first_event(
                 ));
             };
             if let Some(first_event) = manifest.files.first() {
-                let (lower_bound, _) = get_file_bounds(first_event);
+                let lower_bound = match time_partition {
+                    Some(time_partition) => {
+                        let (lower_bound, _) = get_file_bounds(first_event, time_partition);
+                        lower_bound
+                    }
+                    None => {
+                        let (lower_bound, _) =
+                            get_file_bounds(first_event, DEFAULT_TIMESTAMP_KEY.to_string());
+                        lower_bound
+                    }
+                };
                 first_event_at = lower_bound.with_timezone(&Local).to_rfc3339();
             }
         }

--- a/server/src/event.rs
+++ b/server/src/event.rs
@@ -29,6 +29,7 @@ use std::sync::Arc;
 use self::error::EventError;
 pub use self::writer::STREAM_WRITERS;
 use crate::metadata;
+use chrono::NaiveDateTime;
 
 pub const DEFAULT_TIMESTAMP_KEY: &str = "p_timestamp";
 pub const DEFAULT_TAGS_KEY: &str = "p_tags";
@@ -41,19 +42,25 @@ pub struct Event {
     pub origin_format: &'static str,
     pub origin_size: u64,
     pub is_first_event: bool,
+    pub parsed_timestamp: NaiveDateTime,
 }
 
 // Events holds the schema related to a each event for a single log stream
 impl Event {
     pub async fn process(self) -> Result<(), EventError> {
-        let key = get_schema_key(&self.rb.schema().fields);
+        let key = get_schema_key(&self.rb.schema().fields, self.parsed_timestamp);
         let num_rows = self.rb.num_rows() as u64;
 
         if self.is_first_event {
             commit_schema(&self.stream_name, self.rb.schema())?;
         }
 
-        Self::process_event(&self.stream_name, &key, self.rb.clone())?;
+        Self::process_event(
+            &self.stream_name,
+            &key,
+            self.rb.clone(),
+            self.parsed_timestamp,
+        )?;
 
         metadata::STREAM_INFO.update_stats(
             &self.stream_name,
@@ -80,20 +87,27 @@ impl Event {
         stream_name: &str,
         schema_key: &str,
         rb: RecordBatch,
+        parsed_timestamp: NaiveDateTime,
     ) -> Result<(), EventError> {
-        STREAM_WRITERS.append_to_local(stream_name, schema_key, rb)?;
+        STREAM_WRITERS.append_to_local(stream_name, schema_key, rb, parsed_timestamp)?;
         Ok(())
     }
 }
 
-pub fn get_schema_key(fields: &[Arc<Field>]) -> String {
+pub fn get_schema_key(fields: &[Arc<Field>], parsed_timestamp: NaiveDateTime) -> String {
     // Fields must be sorted
+    let parsed_timestamp = parsed_timestamp
+        .and_utc()
+        .format("%Y-%m-%d %H:%M")
+        .to_string();
     let mut hasher = xxhash_rust::xxh3::Xxh3::new();
     for field in fields.iter().sorted_by_key(|v| v.name()) {
+        // let field_name = field.name();
+        // hasher.update(format!("{field_name}.{parsed_timestamp}").as_bytes());
         hasher.update(field.name().as_bytes())
     }
     let hash = hasher.digest();
-    format!("{hash:x}")
+    format!("{hash:x}{parsed_timestamp}")
 }
 
 pub fn commit_schema(stream_name: &str, schema: Arc<Schema>) -> Result<(), EventError> {

--- a/server/src/event.rs
+++ b/server/src/event.rs
@@ -99,12 +99,11 @@ pub fn get_schema_key(fields: &[Arc<Field>], parsed_timestamp: NaiveDateTime) ->
     let parsed_timestamp = parsed_timestamp.and_utc().format("%Y%m%d%H%M").to_string();
     let mut hasher = xxhash_rust::xxh3::Xxh3::new();
     for field in fields.iter().sorted_by_key(|v| v.name()) {
-        // let field_name = field.name();
-        // hasher.update(format!("{field_name}.{parsed_timestamp}").as_bytes());
-        hasher.update(field.name().as_bytes())
+        let field_name = field.name();
+        hasher.update(format!("{field_name}.{parsed_timestamp}").as_bytes());
     }
     let hash = hasher.digest();
-    format!("{hash:x}{parsed_timestamp}")
+    format!("{hash:x}")
 }
 
 pub fn commit_schema(stream_name: &str, schema: Arc<Schema>) -> Result<(), EventError> {

--- a/server/src/event.rs
+++ b/server/src/event.rs
@@ -96,10 +96,7 @@ impl Event {
 
 pub fn get_schema_key(fields: &[Arc<Field>], parsed_timestamp: NaiveDateTime) -> String {
     // Fields must be sorted
-    let parsed_timestamp = parsed_timestamp
-        .and_utc()
-        .format("%Y-%m-%d %H:%M")
-        .to_string();
+    let parsed_timestamp = parsed_timestamp.and_utc().format("%Y%m%d%H%M").to_string();
     let mut hasher = xxhash_rust::xxh3::Xxh3::new();
     for field in fields.iter().sorted_by_key(|v| v.name()) {
         // let field_name = field.name();

--- a/server/src/event/format.rs
+++ b/server/src/event/format.rs
@@ -41,21 +41,16 @@ pub trait EventFormat: Sized {
     fn to_data(
         self,
         schema: HashMap<String, Arc<Field>>,
-        time_partition: Option<String>,
         static_schema_flag: Option<String>,
     ) -> Result<(Self::Data, EventSchema, bool, Tags, Metadata), AnyError>;
     fn decode(data: Self::Data, schema: Arc<Schema>) -> Result<RecordBatch, AnyError>;
     fn into_recordbatch(
         self,
         storage_schema: HashMap<String, Arc<Field>>,
-        time_partition: Option<String>,
         static_schema_flag: Option<String>,
     ) -> Result<(RecordBatch, bool), AnyError> {
-        let (data, mut schema, is_first, tags, metadata) = self.to_data(
-            storage_schema.clone(),
-            time_partition,
-            static_schema_flag.clone(),
-        )?;
+        let (data, mut schema, is_first, tags, metadata) =
+            self.to_data(storage_schema.clone(), static_schema_flag.clone())?;
 
         if get_field(&schema, DEFAULT_TAGS_KEY).is_some() {
             return Err(anyhow!("field {} is a reserved field", DEFAULT_TAGS_KEY));

--- a/server/src/event/format/json.rs
+++ b/server/src/event/format/json.rs
@@ -45,10 +45,9 @@ impl EventFormat for Event {
     fn to_data(
         self,
         schema: HashMap<String, Arc<Field>>,
-        time_partition: Option<String>,
         static_schema_flag: Option<String>,
     ) -> Result<(Self::Data, Vec<Arc<Field>>, bool, Tags, Metadata), anyhow::Error> {
-        let data = flatten_json_body(self.data, time_partition)?;
+        let data = flatten_json_body(self.data, None, false)?;
         let stream_schema = schema;
 
         // incoming event may be a single json or a json array

--- a/server/src/event/writer.rs
+++ b/server/src/event/writer.rs
@@ -25,11 +25,11 @@ use std::{
     sync::{Arc, Mutex, RwLock},
 };
 
-use crate::utils;
-
 use self::{errors::StreamWriterError, file_writer::FileWriter, mem_writer::MemWriter};
+use crate::utils;
 use arrow_array::{RecordBatch, TimestampMillisecondArray};
 use arrow_schema::Schema;
+use chrono::NaiveDateTime;
 use chrono::Utc;
 use derive_more::{Deref, DerefMut};
 use once_cell::sync::Lazy;
@@ -48,6 +48,7 @@ impl Writer {
         stream_name: &str,
         schema_key: &str,
         rb: RecordBatch,
+        parsed_timestamp: NaiveDateTime,
     ) -> Result<(), StreamWriterError> {
         let rb = utils::arrow::replace_columns(
             rb.schema(),
@@ -56,7 +57,8 @@ impl Writer {
             &[Arc::new(get_timestamp_array(rb.num_rows()))],
         );
 
-        self.disk.push(stream_name, schema_key, &rb)?;
+        self.disk
+            .push(stream_name, schema_key, &rb, parsed_timestamp)?;
         self.mem.push(schema_key, rb);
         Ok(())
     }
@@ -72,15 +74,18 @@ impl WriterTable {
         stream_name: &str,
         schema_key: &str,
         record: RecordBatch,
+        parsed_timestamp: NaiveDateTime,
     ) -> Result<(), StreamWriterError> {
         let hashmap_guard = self.read().unwrap();
 
         match hashmap_guard.get(stream_name) {
             Some(stream_writer) => {
-                stream_writer
-                    .lock()
-                    .unwrap()
-                    .push(stream_name, schema_key, record)?;
+                stream_writer.lock().unwrap().push(
+                    stream_name,
+                    schema_key,
+                    record,
+                    parsed_timestamp,
+                )?;
             }
             None => {
                 drop(hashmap_guard);
@@ -88,13 +93,15 @@ impl WriterTable {
                 // check for race condition
                 // if map contains entry then just
                 if let Some(writer) = map.get(stream_name) {
-                    writer
-                        .lock()
-                        .unwrap()
-                        .push(stream_name, schema_key, record)?;
+                    writer.lock().unwrap().push(
+                        stream_name,
+                        schema_key,
+                        record,
+                        parsed_timestamp,
+                    )?;
                 } else {
                     let mut writer = Writer::default();
-                    writer.push(stream_name, schema_key, record)?;
+                    writer.push(stream_name, schema_key, record, parsed_timestamp)?;
                     map.insert(stream_name.to_owned(), Mutex::new(writer));
                 }
             }

--- a/server/src/handlers/http/ingest.rs
+++ b/server/src/handlers/http/ingest.rs
@@ -115,7 +115,7 @@ async fn push_logs(stream_name: String, req: HttpRequest, body: Bytes) -> Result
             req,
             body_val,
             static_schema_flag,
-            time_partition,
+            time_partition.clone(),
         )?;
         event::Event {
             rb,
@@ -124,6 +124,7 @@ async fn push_logs(stream_name: String, req: HttpRequest, body: Bytes) -> Result
             origin_size: size as u64,
             is_first_event,
             parsed_timestamp,
+            time_partition,
         }
         .process()
         .await?;
@@ -154,6 +155,7 @@ async fn push_logs(stream_name: String, req: HttpRequest, body: Bytes) -> Result
                 origin_size: value.to_string().into_bytes().len() as u64,
                 is_first_event,
                 parsed_timestamp,
+                time_partition: time_partition.clone(),
             }
             .process()
             .await?;

--- a/server/src/handlers/http/ingest.rs
+++ b/server/src/handlers/http/ingest.rs
@@ -31,9 +31,11 @@ use crate::metadata::{self, STREAM_INFO};
 use crate::option::{Mode, CONFIG};
 use crate::storage::{LogStream, ObjectStorageError};
 use crate::utils::header_parsing::{collect_labelled_headers, ParseHeaderError};
+use crate::utils::json::convert_array_to_object;
 use actix_web::{http::header::ContentType, HttpRequest, HttpResponse};
 use arrow_schema::{Field, Schema};
 use bytes::Bytes;
+use chrono::{DateTime, Utc};
 use http::StatusCode;
 use serde_json::Value;
 use std::collections::{BTreeMap, HashMap};
@@ -95,58 +97,117 @@ pub async fn post_event(req: HttpRequest, body: Bytes) -> Result<HttpResponse, P
 }
 
 async fn push_logs(stream_name: String, req: HttpRequest, body: Bytes) -> Result<(), PostError> {
-    let (size, rb, is_first_event) = {
-        let hash_map = STREAM_INFO.read().unwrap();
-        let schema = hash_map
-            .get(&stream_name)
-            .ok_or(PostError::StreamNotFound(stream_name.clone()))?
-            .schema
-            .clone();
-        let time_partition = hash_map
-            .get(&stream_name)
-            .ok_or(PostError::StreamNotFound(stream_name.clone()))?
-            .time_partition
-            .clone();
-        let static_schema_flag = hash_map
-            .get(&stream_name)
-            .ok_or(PostError::StreamNotFound(stream_name.clone()))?
-            .static_schema_flag
-            .clone();
+    let glob_storage = CONFIG.storage().get_object_store();
+    let object_store_format = glob_storage
+        .get_object_store_format(&stream_name)
+        .await
+        .map_err(|_err| PostError::StreamNotFound(stream_name.clone()))?;
 
-        into_event_batch(req, body, schema, time_partition, static_schema_flag)?
-    };
+    let time_partition = object_store_format.time_partition;
+    let static_schema_flag = object_store_format.static_schema_flag;
+    let body_val: Value = serde_json::from_slice(&body)?;
+    let size: usize = body.len();
+    let mut parsed_timestamp = Utc::now().naive_utc();
+    if time_partition.is_none() {
+        let stream = stream_name.clone();
+        let (rb, is_first_event) =
+            get_stream_schema(stream.clone(), req, body_val, static_schema_flag)?;
+        event::Event {
+            rb,
+            stream_name: stream,
+            origin_format: "json",
+            origin_size: size as u64,
+            is_first_event,
+            parsed_timestamp,
+        }
+        .process()
+        .await?;
+    } else {
+        let data = convert_array_to_object(body_val.clone(), time_partition.clone())?;
+        for value in data {
+            let body_timestamp = value.get(&time_partition.clone().unwrap().to_string());
+            if body_timestamp.is_some() {
+                if body_timestamp
+                    .unwrap()
+                    .to_owned()
+                    .as_str()
+                    .unwrap()
+                    .parse::<DateTime<Utc>>()
+                    .is_ok()
+                {
+                    parsed_timestamp = body_timestamp
+                        .unwrap()
+                        .to_owned()
+                        .as_str()
+                        .unwrap()
+                        .parse::<DateTime<Utc>>()
+                        .unwrap()
+                        .naive_utc();
 
-    event::Event {
-        rb,
-        stream_name,
-        origin_format: "json",
-        origin_size: size as u64,
-        is_first_event,
+                    let (rb, is_first_event) = get_stream_schema(
+                        stream_name.clone(),
+                        req.clone(),
+                        value,
+                        static_schema_flag.clone(),
+                    )?;
+                    event::Event {
+                        rb,
+                        stream_name: stream_name.clone(),
+                        origin_format: "json",
+                        origin_size: size as u64,
+                        is_first_event,
+                        parsed_timestamp,
+                    }
+                    .process()
+                    .await?;
+                } else {
+                    return Err(PostError::Invalid(anyhow::Error::msg(format!(
+                        "field {} is not in the correct datetime format",
+                        body_timestamp.unwrap().to_owned().as_str().unwrap()
+                    ))));
+                }
+            } else {
+                return Err(PostError::Invalid(anyhow::Error::msg(format!(
+                    "ingestion failed as field {} is not part of the log",
+                    time_partition.unwrap()
+                ))));
+            }
+        }
     }
-    .process()
-    .await?;
 
     Ok(())
 }
 
+fn get_stream_schema(
+    stream_name: String,
+    req: HttpRequest,
+    body: Value,
+    static_schema_flag: Option<String>,
+) -> Result<(arrow_array::RecordBatch, bool), PostError> {
+    let hash_map = STREAM_INFO.read().unwrap();
+    let schema = hash_map
+        .get(&stream_name)
+        .ok_or(PostError::StreamNotFound(stream_name))?
+        .schema
+        .clone();
+    into_event_batch(req, body, schema, static_schema_flag)
+}
+
 fn into_event_batch(
     req: HttpRequest,
-    body: Bytes,
+    body: Value,
     schema: HashMap<String, Arc<Field>>,
-    time_partition: Option<String>,
     static_schema_flag: Option<String>,
-) -> Result<(usize, arrow_array::RecordBatch, bool), PostError> {
+) -> Result<(arrow_array::RecordBatch, bool), PostError> {
     let tags = collect_labelled_headers(&req, PREFIX_TAGS, SEPARATOR)?;
     let metadata = collect_labelled_headers(&req, PREFIX_META, SEPARATOR)?;
-    let size = body.len();
-    let body: Value = serde_json::from_slice(&body)?;
     let event = format::json::Event {
         data: body,
         tags,
         metadata,
     };
-    let (rb, is_first) = event.into_recordbatch(schema, time_partition, static_schema_flag)?;
-    Ok((size, rb, is_first))
+    let (rb, is_first) = event.into_recordbatch(schema, static_schema_flag)?;
+    Ok((rb, is_first))
 }
 
 // Check if the stream exists and create a new stream if doesn't exist
@@ -249,7 +310,6 @@ mod tests {
         types::Int64Type, ArrayRef, Float64Array, Int64Array, ListArray, StringArray,
     };
     use arrow_schema::{DataType, Field};
-    use bytes::Bytes;
     use serde_json::json;
 
     use crate::{
@@ -296,16 +356,8 @@ mod tests {
             .append_header((PREFIX_META.to_string() + "C", "meta1"))
             .to_http_request();
 
-        let (size, rb, _) = into_event_batch(
-            req,
-            Bytes::from(serde_json::to_vec(&json).unwrap()),
-            HashMap::default(),
-            None,
-            None,
-        )
-        .unwrap();
+        let (rb, _) = into_event_batch(req, json, HashMap::default(), None).unwrap();
 
-        assert_eq!(size, 28);
         assert_eq!(rb.num_rows(), 1);
         assert_eq!(rb.num_columns(), 6);
         assert_eq!(
@@ -344,14 +396,7 @@ mod tests {
 
         let req = TestRequest::default().to_http_request();
 
-        let (_, rb, _) = into_event_batch(
-            req,
-            Bytes::from(serde_json::to_vec(&json).unwrap()),
-            HashMap::default(),
-            None,
-            None,
-        )
-        .unwrap();
+        let (rb, _) = into_event_batch(req, json, HashMap::default(), None).unwrap();
 
         assert_eq!(rb.num_rows(), 1);
         assert_eq!(rb.num_columns(), 6);
@@ -383,14 +428,7 @@ mod tests {
 
         let req = TestRequest::default().to_http_request();
 
-        let (_, rb, _) = into_event_batch(
-            req,
-            Bytes::from(serde_json::to_vec(&json).unwrap()),
-            schema,
-            None,
-            None,
-        )
-        .unwrap();
+        let (rb, _) = into_event_batch(req, json, schema, None).unwrap();
 
         assert_eq!(rb.num_rows(), 1);
         assert_eq!(rb.num_columns(), 5);
@@ -422,14 +460,7 @@ mod tests {
 
         let req = TestRequest::default().to_http_request();
 
-        assert!(into_event_batch(
-            req,
-            Bytes::from(serde_json::to_vec(&json).unwrap()),
-            schema,
-            None,
-            None
-        )
-        .is_err());
+        assert!(into_event_batch(req, json, schema, None,).is_err());
     }
 
     #[test]
@@ -447,14 +478,7 @@ mod tests {
 
         let req = TestRequest::default().to_http_request();
 
-        let (_, rb, _) = into_event_batch(
-            req,
-            Bytes::from(serde_json::to_vec(&json).unwrap()),
-            schema,
-            None,
-            None,
-        )
-        .unwrap();
+        let (rb, _) = into_event_batch(req, json, schema, None).unwrap();
 
         assert_eq!(rb.num_rows(), 1);
         assert_eq!(rb.num_columns(), 3);
@@ -466,14 +490,7 @@ mod tests {
 
         let req = TestRequest::default().to_http_request();
 
-        assert!(into_event_batch(
-            req,
-            Bytes::from(serde_json::to_vec(&json).unwrap()),
-            HashMap::default(),
-            None,
-            None
-        )
-        .is_err())
+        assert!(into_event_batch(req, json, HashMap::default(), None,).is_err())
     }
 
     #[test]
@@ -496,14 +513,7 @@ mod tests {
 
         let req = TestRequest::default().to_http_request();
 
-        let (_, rb, _) = into_event_batch(
-            req,
-            Bytes::from(serde_json::to_vec(&json).unwrap()),
-            HashMap::default(),
-            None,
-            None,
-        )
-        .unwrap();
+        let (rb, _) = into_event_batch(req, json, HashMap::default(), None).unwrap();
 
         assert_eq!(rb.num_rows(), 3);
         assert_eq!(rb.num_columns(), 6);
@@ -551,14 +561,7 @@ mod tests {
 
         let req = TestRequest::default().to_http_request();
 
-        let (_, rb, _) = into_event_batch(
-            req,
-            Bytes::from(serde_json::to_vec(&json).unwrap()),
-            HashMap::default(),
-            None,
-            None,
-        )
-        .unwrap();
+        let (rb, _) = into_event_batch(req, json, HashMap::default(), None).unwrap();
 
         assert_eq!(rb.num_rows(), 3);
         assert_eq!(rb.num_columns(), 6);
@@ -606,14 +609,7 @@ mod tests {
         );
         let req = TestRequest::default().to_http_request();
 
-        let (_, rb, _) = into_event_batch(
-            req,
-            Bytes::from(serde_json::to_vec(&json).unwrap()),
-            schema,
-            None,
-            None,
-        )
-        .unwrap();
+        let (rb, _) = into_event_batch(req, json, schema, None).unwrap();
 
         assert_eq!(rb.num_rows(), 3);
         assert_eq!(rb.num_columns(), 6);
@@ -662,14 +658,7 @@ mod tests {
             .into_iter(),
         );
 
-        assert!(into_event_batch(
-            req,
-            Bytes::from(serde_json::to_vec(&json).unwrap()),
-            schema,
-            None,
-            None
-        )
-        .is_err());
+        assert!(into_event_batch(req, json, schema, None,).is_err());
     }
 
     #[test]
@@ -697,14 +686,7 @@ mod tests {
 
         let req = TestRequest::default().to_http_request();
 
-        let (_, rb, _) = into_event_batch(
-            req,
-            Bytes::from(serde_json::to_vec(&json).unwrap()),
-            HashMap::default(),
-            None,
-            None,
-        )
-        .unwrap();
+        let (rb, _) = into_event_batch(req, json, HashMap::default(), None).unwrap();
 
         assert_eq!(rb.num_rows(), 4);
         assert_eq!(rb.num_columns(), 7);

--- a/server/src/handlers/http/logstream.rs
+++ b/server/src/handlers/http/logstream.rs
@@ -216,7 +216,8 @@ pub async fn put_stream(req: HttpRequest, body: Bytes) -> Result<impl Responder,
     if !body.is_empty() && static_schema_flag == "true" {
         let static_schema: StaticSchema = serde_json::from_slice(&body)?;
 
-        let parsed_schema = convert_static_schema_to_arrow_schema(static_schema.clone());
+        let parsed_schema =
+            convert_static_schema_to_arrow_schema(static_schema.clone(), time_partition);
         if let Ok(parsed_schema) = parsed_schema {
             schema = parsed_schema;
         } else {
@@ -224,23 +225,6 @@ pub async fn put_stream(req: HttpRequest, body: Bytes) -> Result<impl Responder,
                 msg: format!("unable to commit static schema, logstream {stream_name} not created"),
                 status: StatusCode::BAD_REQUEST,
             });
-        }
-        if !time_partition.is_empty() {
-            let mut time_partition_exists: bool = false;
-            for field_name in &static_schema.get_fields() {
-                if field_name == time_partition {
-                    time_partition_exists = true;
-                    break;
-                }
-            }
-            if !time_partition_exists {
-                return Err(StreamError::Custom {
-                    msg: format!(
-                        "time partition field {time_partition} does not exist in the schema for static schema logstream {stream_name}"
-                    ),
-                    status: StatusCode::BAD_REQUEST,
-                });
-            }
         }
     } else if body.is_empty() && static_schema_flag == "true" {
         return Err(StreamError::Custom {

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -18,7 +18,7 @@
 
 use clap::error::ErrorKind;
 use clap::{command, Args, Command, FromArgMatches};
-
+use core::fmt;
 use once_cell::sync::Lazy;
 use parquet::basic::{BrotliLevel, GzipLevel, ZstdLevel};
 use std::env;
@@ -234,9 +234,9 @@ impl Mode {
     }
 }
 
-impl ToString for Mode {
-    fn to_string(&self) -> String {
-        self.to_str().to_string()
+impl fmt::Display for Mode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_str())
     }
 }
 

--- a/server/src/query.rs
+++ b/server/src/query.rs
@@ -229,13 +229,13 @@ fn transform(
                     Some(time_partition) => {
                         _start_time_filter =
                             PartialTimeFilter::Low(std::ops::Bound::Included(start_time))
-                                .binary_expr_timestamp_partition_key(Expr::Column(Column::new(
+                                .binary_expr(Expr::Column(Column::new(
                                     Some(table.table_name.to_owned_reference()),
                                     time_partition.clone(),
                                 )));
                         _end_time_filter =
                             PartialTimeFilter::High(std::ops::Bound::Excluded(end_time))
-                                .binary_expr_timestamp_partition_key(Expr::Column(Column::new(
+                                .binary_expr(Expr::Column(Column::new(
                                     Some(table.table_name.to_owned_reference()),
                                     time_partition,
                                 )));
@@ -243,13 +243,13 @@ fn transform(
                     None => {
                         _start_time_filter =
                             PartialTimeFilter::Low(std::ops::Bound::Included(start_time))
-                                .binary_expr_default_timestamp_key(Expr::Column(Column::new(
+                                .binary_expr(Expr::Column(Column::new(
                                     Some(table.table_name.to_owned_reference()),
                                     event::DEFAULT_TIMESTAMP_KEY,
                                 )));
                         _end_time_filter =
                             PartialTimeFilter::High(std::ops::Bound::Excluded(end_time))
-                                .binary_expr_default_timestamp_key(Expr::Column(Column::new(
+                                .binary_expr(Expr::Column(Column::new(
                                     Some(table.table_name.to_owned_reference()),
                                     event::DEFAULT_TIMESTAMP_KEY,
                                 )));

--- a/server/src/query/stream_schema_provider.rs
+++ b/server/src/query/stream_schema_provider.rs
@@ -551,7 +551,7 @@ impl PartialTimeFilter {
         Some(value)
     }
 
-    pub fn binary_expr_default_timestamp_key(&self, left: Expr) -> Expr {
+    pub fn binary_expr(&self, left: Expr) -> Expr {
         let (op, right) = match self {
             PartialTimeFilter::Low(Bound::Excluded(time)) => {
                 (Operator::Gt, time.and_utc().timestamp_millis())
@@ -576,26 +576,6 @@ impl PartialTimeFilter {
                 Some(right),
                 None,
             ))),
-        ))
-    }
-
-    pub fn binary_expr_timestamp_partition_key(&self, left: Expr) -> Expr {
-        let (op, right) = match self {
-            PartialTimeFilter::Low(Bound::Excluded(time)) => (Operator::Gt, time),
-            PartialTimeFilter::Low(Bound::Included(time)) => (Operator::GtEq, time),
-            PartialTimeFilter::High(Bound::Excluded(time)) => (Operator::Lt, time),
-            PartialTimeFilter::High(Bound::Included(time)) => (Operator::LtEq, time),
-            PartialTimeFilter::Eq(time) => (Operator::Eq, time),
-            _ => unimplemented!(),
-        };
-
-        Expr::BinaryExpr(BinaryExpr::new(
-            Box::new(left),
-            op,
-            Box::new(Expr::Literal(ScalarValue::Utf8(Some(format!(
-                "{:?}",
-                right
-            ))))),
         ))
     }
 }

--- a/server/src/static_schema.rs
+++ b/server/src/static_schema.rs
@@ -6,15 +6,32 @@ use std::str;
 
 use arrow_schema::{DataType, Field, Schema, TimeUnit};
 use std::{collections::HashMap, sync::Arc};
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StaticSchema {
     fields: Vec<SchemaFields>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+impl StaticSchema {
+    pub fn get_fields(&self) -> Vec<String> {
+        let fields = self
+            .fields
+            .iter()
+            .map(|field| field.clone().get_field_name())
+            .collect();
+        fields
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SchemaFields {
     name: String,
     data_type: String,
+}
+
+impl SchemaFields {
+    pub fn get_field_name(self) -> String {
+        self.name
+    }
 }
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -293,6 +293,7 @@ pub trait ObjectStorage: Sync + 'static {
     }
 
     /// for future use
+    #[allow(dead_code)]
     async fn get_stats_for_first_time(
         &self,
         stream_name: &str,

--- a/server/src/utils/json.rs
+++ b/server/src/utils/json.rs
@@ -24,8 +24,22 @@ pub mod flatten;
 pub fn flatten_json_body(
     body: serde_json::Value,
     time_partition: Option<String>,
+    validation_required: bool,
 ) -> Result<Value, anyhow::Error> {
-    flatten::flatten(body, "_", time_partition)
+    flatten::flatten(body, "_", time_partition, validation_required)
+}
+
+pub fn convert_array_to_object(
+    body: Value,
+    time_partition: Option<String>,
+) -> Result<Vec<Value>, anyhow::Error> {
+    let data = flatten_json_body(body, time_partition, true)?;
+    let value_arr = match data {
+        Value::Array(arr) => arr,
+        value @ Value::Object(_) => vec![value],
+        _ => unreachable!("flatten would have failed beforehand"),
+    };
+    Ok(value_arr)
 }
 
 pub fn convert_to_string(value: &Value) -> Value {


### PR DESCRIPTION
update in the time partition logic
to check if time partition field value is not less than a month old
then partition based on time partition field
also, if static schema is provided
check if static schema has time partition field at the time of log creation
update the data type of time partition field to timestamp when persisting schema
this improves query performance of count(*)