### PR TITLE
fix for time partition limit

### DIFF
--- a/server/src/event/format/json.rs
+++ b/server/src/event/format/json.rs
@@ -48,7 +48,7 @@ impl EventFormat for Event {
         static_schema_flag: Option<String>,
         time_partition: Option<String>,
     ) -> Result<(Self::Data, Vec<Arc<Field>>, bool, Tags, Metadata), anyhow::Error> {
-        let data = flatten_json_body(self.data, None, false)?;
+        let data = flatten_json_body(self.data, None, None, false)?;
         let stream_schema = schema;
 
         // incoming event may be a single json or a json array

--- a/server/src/handlers.rs
+++ b/server/src/handlers.rs
@@ -24,6 +24,7 @@ const PREFIX_META: &str = "x-p-meta-";
 const STREAM_NAME_HEADER_KEY: &str = "x-p-stream";
 const LOG_SOURCE_KEY: &str = "x-p-log-source";
 const TIME_PARTITION_KEY: &str = "x-p-time-partition";
+const TIME_PARTITION_LIMIT_KEY: &str = "x-p-time-partition-limit";
 const STATIC_SCHEMA_FLAG: &str = "x-p-static-schema-flag";
 const AUTHORIZATION_KEY: &str = "authorization";
 const SEPARATOR: char = '^';

--- a/server/src/metadata.rs
+++ b/server/src/metadata.rs
@@ -24,12 +24,11 @@ use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
+use self::error::stream_info::{CheckAlertError, LoadError, MetadataError};
 use crate::alerts::Alerts;
 use crate::metrics::{EVENTS_INGESTED, EVENTS_INGESTED_SIZE};
 use crate::storage::{LogStream, ObjectStorage, StorageDir};
 use crate::utils::arrow::MergedRecordReader;
-
-use self::error::stream_info::{CheckAlertError, LoadError, MetadataError};
 use derive_more::{Deref, DerefMut};
 
 // TODO: make return type be of 'static lifetime instead of cloning
@@ -47,6 +46,7 @@ pub struct LogStreamMetadata {
     pub created_at: String,
     pub first_event_at: Option<String>,
     pub time_partition: Option<String>,
+    pub time_partition_limit: Option<String>,
     pub static_schema_flag: Option<String>,
 }
 
@@ -166,6 +166,7 @@ impl StreamInfo {
         stream_name: String,
         created_at: String,
         time_partition: String,
+        time_partition_limit: String,
         static_schema_flag: String,
         static_schema: HashMap<String, Arc<Field>>,
     ) {
@@ -180,6 +181,11 @@ impl StreamInfo {
                 None
             } else {
                 Some(time_partition)
+            },
+            time_partition_limit: if time_partition_limit.is_empty() {
+                None
+            } else {
+                Some(time_partition_limit)
             },
             static_schema_flag: if static_schema_flag != "true" {
                 None
@@ -237,6 +243,7 @@ impl StreamInfo {
             created_at: meta.created_at,
             first_event_at: meta.first_event_at,
             time_partition: meta.time_partition,
+            time_partition_limit: meta.time_partition_limit,
             static_schema_flag: meta.static_schema_flag,
         };
 

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -30,15 +30,14 @@ mod s3;
 pub mod staging;
 mod store_metadata;
 
+use self::retention::Retention;
+pub use self::staging::StorageDir;
 pub use localfs::FSConfig;
 pub use object_storage::{ObjectStorage, ObjectStorageProvider};
 pub use s3::S3Config;
 pub use store_metadata::{
     put_remote_metadata, put_staging_metadata, resolve_parseable_metadata, StorageMetadata,
 };
-
-use self::retention::Retention;
-pub use self::staging::StorageDir;
 
 // metadata file names in a Stream prefix
 pub const STREAM_METADATA_FILE_NAME: &str = ".stream.json";
@@ -94,6 +93,8 @@ pub struct ObjectStoreFormat {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub time_partition: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_partition_limit: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub static_schema_flag: Option<String>,
 }
 
@@ -108,6 +109,8 @@ pub struct StreamInfo {
     pub cache_enabled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub time_partition: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_partition_limit: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub static_schema_flag: Option<String>,
 }
@@ -155,6 +158,7 @@ impl Default for ObjectStoreFormat {
             cache_enabled: false,
             retention: None,
             time_partition: None,
+            time_partition_limit: None,
             static_schema_flag: None,
         }
     }

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -127,6 +127,7 @@ pub trait ObjectStorage: Sync + 'static {
         &self,
         stream_name: &str,
         time_partition: &str,
+        time_partition_limit: &str,
         static_schema_flag: &str,
         schema: Arc<Schema>,
     ) -> Result<(), ObjectStorageError> {
@@ -138,6 +139,11 @@ pub trait ObjectStorage: Sync + 'static {
             format.time_partition = None;
         } else {
             format.time_partition = Some(time_partition.to_string());
+        }
+        if time_partition_limit.is_empty() {
+            format.time_partition_limit = None;
+        } else {
+            format.time_partition_limit = Some(time_partition_limit.to_string());
         }
         if static_schema_flag != "true" {
             format.static_schema_flag = None;

--- a/server/src/utils/json.rs
+++ b/server/src/utils/json.rs
@@ -24,16 +24,24 @@ pub mod flatten;
 pub fn flatten_json_body(
     body: serde_json::Value,
     time_partition: Option<String>,
+    time_partition_limit: Option<String>,
     validation_required: bool,
 ) -> Result<Value, anyhow::Error> {
-    flatten::flatten(body, "_", time_partition, validation_required)
+    flatten::flatten(
+        body,
+        "_",
+        time_partition,
+        time_partition_limit,
+        validation_required,
+    )
 }
 
 pub fn convert_array_to_object(
     body: Value,
     time_partition: Option<String>,
+    time_partition_limit: Option<String>,
 ) -> Result<Vec<Value>, anyhow::Error> {
-    let data = flatten_json_body(body, time_partition, true)?;
+    let data = flatten_json_body(body, time_partition, time_partition_limit, true)?;
     let value_arr = match data {
         Value::Array(arr) => arr,
         value @ Value::Object(_) => vec![value],


### PR DESCRIPTION
additional header to be provided
X-P-Time-Partition-Limit with a value of unsigned integer 
with ending 'd' eg. 90d for 90 days
if not provided, default constraint of 30 days will be applied using this, 
user can ingest logs older than 30 days as well

Fixes #752

