### PR TITLE
impl query result caching

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -9,13 +9,14 @@ build = "build.rs"
 
 [dependencies]
 ### apache arrow/datafusion dependencies
+# arrow = "51.0.0"
 arrow-schema = { version = "51.0.0", features = ["serde"] }
 arrow-array = { version = "51.0.0" }
 arrow-json = "51.0.0"
 arrow-ipc = "51.0.0"
 arrow-select = "51.0.0"
 datafusion = "37.1.0"
-object_store = { version = "0.9.1", features = ["cloud", "aws"] }
+object_store = { version = "0.9.1", features = ["cloud", "aws"] }  # cannot update object_store as datafusion has not caught up
 parquet = "51.0.0"
 
 ### LiveTail server deps
@@ -74,11 +75,11 @@ relative-path = { version = "1.7", features = ["serde"] }
 reqwest = { version = "0.11.27", default_features = false, features = [
   "rustls-tls",
   "json",
-] }
-rustls = "0.22.4"
+] }         # cannot update cause rustls is not latest `see rustls`
+rustls = "0.22.4"       # cannot update to 0.23 actix has not caught up yet
 rustls-pemfile = "2.1.2"
 semver = "1.0"
-serde = { version = "1.0", features = ["rc"] }
+serde = { version = "1.0", features = ["rc", "derive"] }
 serde_json = "1.0"
 static-files = "0.2"
 sysinfo = "0.30.11"

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -89,6 +89,12 @@ pub struct Cli {
 
     /// public address for the parseable server ingestor
     pub ingestor_endpoint: String,
+
+    /// to query cached data
+    pub query_cache_path: Option<PathBuf>,
+
+    /// Size for local cache
+    pub query_cache_size: u64,
 }
 
 impl Cli {
@@ -99,6 +105,8 @@ impl Cli {
     pub const DOMAIN_URI: &'static str = "origin";
     pub const STAGING: &'static str = "local-staging-path";
     pub const CACHE: &'static str = "cache-path";
+    pub const QUERY_CACHE: &'static str = "query-cache-path";
+    pub const QUERY_CACHE_SIZE: &'static str = "query-cache-size";
     pub const CACHE_SIZE: &'static str = "cache-size";
     pub const USERNAME: &'static str = "username";
     pub const PASSWORD: &'static str = "password";
@@ -187,6 +195,25 @@ impl Cli {
                     .next_line_help(true),
             )
 
+             .arg(
+                Arg::new(Self::QUERY_CACHE)
+                    .long(Self::QUERY_CACHE)
+                    .env("P_QUERY_CACHE_DIR")
+                    .value_name("DIR")
+                    .value_parser(validation::canonicalize_path)
+                    .help("Local path on this device to be used for caching data")
+                    .next_line_help(true),
+            )
+             .arg(
+                Arg::new(Self::QUERY_CACHE_SIZE)
+                    .long(Self::QUERY_CACHE_SIZE)
+                    .env("P_QUERY_CACHE_SIZE")
+                    .value_name("size")
+                    .default_value("1GiB")
+                    .value_parser(validation::cache_size)
+                    .help("Maximum allowed cache size for all streams combined (In human readable format, e.g 1GiB, 2GiB, 100MB)")
+                    .next_line_help(true),
+            )
             .arg(
                 Arg::new(Self::USERNAME)
                     .long(Self::USERNAME)
@@ -358,6 +385,7 @@ impl FromArgMatches for Cli {
 
     fn update_from_arg_matches(&mut self, m: &clap::ArgMatches) -> Result<(), clap::Error> {
         self.local_cache_path = m.get_one::<PathBuf>(Self::CACHE).cloned();
+        self.query_cache_path = m.get_one::<PathBuf>(Self::QUERY_CACHE).cloned();
         self.tls_cert_path = m.get_one::<PathBuf>(Self::TLS_CERT).cloned();
         self.tls_key_path = m.get_one::<PathBuf>(Self::TLS_KEY).cloned();
         self.domain_address = m.get_one::<Url>(Self::DOMAIN_URI).cloned();
@@ -380,6 +408,10 @@ impl FromArgMatches for Cli {
             .get_one::<u64>(Self::CACHE_SIZE)
             .cloned()
             .expect("default value for cache size");
+        self.query_cache_size = m
+            .get_one(Self::QUERY_CACHE_SIZE)
+            .cloned()
+            .expect("default value for query cache size");
         self.username = m
             .get_one::<String>(Self::USERNAME)
             .cloned()

--- a/server/src/handlers/http/query.rs
+++ b/server/src/handlers/http/query.rs
@@ -199,20 +199,7 @@ async fn into_query(
         return Err(QueryError::EmptyEndTime);
     }
 
-    let start: DateTime<Utc>;
-    let end: DateTime<Utc>;
-
-    if query.end_time == "now" {
-        end = Utc::now();
-        start = end - chrono::Duration::from_std(humantime::parse_duration(&query.start_time)?)?;
-    } else {
-        start = DateTime::parse_from_rfc3339(&query.start_time)
-            .map_err(|_| QueryError::StartTimeParse)?
-            .into();
-        end = DateTime::parse_from_rfc3339(&query.end_time)
-            .map_err(|_| QueryError::EndTimeParse)?
-            .into();
-    };
+    let (start, end) = parse_human_time(&query.start_time, &query.end_time)?;
 
     if start.timestamp() > end.timestamp() {
         return Err(QueryError::StartTimeAfterEndTime);
@@ -224,6 +211,28 @@ async fn into_query(
         end,
         filter_tag: query.filter_tags.clone(),
     })
+}
+
+fn parse_human_time(
+    start_time: &str,
+    end_time: &str,
+) -> Result<(DateTime<Utc>, DateTime<Utc>), QueryError> {
+    let start: DateTime<Utc>;
+    let end: DateTime<Utc>;
+
+    if end_time == "now" {
+        end = Utc::now();
+        start = end - chrono::Duration::from_std(humantime::parse_duration(start_time)?)?;
+    } else {
+        start = DateTime::parse_from_rfc3339(start_time)
+            .map_err(|_| QueryError::StartTimeParse)?
+            .into();
+        end = DateTime::parse_from_rfc3339(end_time)
+            .map_err(|_| QueryError::EndTimeParse)?
+            .into();
+    };
+
+    Ok((start, end))
 }
 
 /// unused for now, might need it in the future

--- a/server/src/handlers/http/query.rs
+++ b/server/src/handlers/http/query.rs
@@ -289,6 +289,8 @@ pub enum QueryError {
     Execute(#[from] ExecuteError),
     #[error("ObjectStorage Error: {0}")]
     ObjectStorage(#[from] ObjectStorageError),
+    #[error("Cache Error: {0}")]
+    CacheError(#[from] CacheError),
     #[error("Evern Error: {0}")]
     EventError(#[from] EventError),
     #[error("Error: {0}")]

--- a/server/src/handlers/http/query.rs
+++ b/server/src/handlers/http/query.rs
@@ -34,11 +34,13 @@ use crate::event::error::EventError;
 use crate::handlers::http::fetch_schema;
 
 use crate::event::commit_schema;
+use crate::localcache::CacheError;
 use crate::metrics::QUERY_EXECUTE_TIME;
 use crate::option::{Mode, CONFIG};
 use crate::query::error::ExecuteError;
 use crate::query::Query as LogicalQuery;
 use crate::query::{TableScanVisitor, QUERY_SESSION};
+use crate::querycache::QueryCacheManager;
 use crate::rbac::role::{Action, Permission};
 use crate::rbac::Users;
 use crate::response::QueryResponse;
@@ -50,7 +52,7 @@ use crate::utils::actix::extract_session_key_from_req;
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Query {
-    query: String,
+    pub query: String,
     start_time: String,
     end_time: String,
     #[serde(default)]
@@ -72,6 +74,36 @@ pub async fn query(req: HttpRequest, query_request: Query) -> Result<impl Respon
     // create a visitor to extract the table name
     let mut visitor = TableScanVisitor::default();
     let _ = raw_logical_plan.visit(&mut visitor);
+    let stream = visitor.top();
+    let query_cache_manager = QueryCacheManager::global(CONFIG.parseable.query_cache_size)
+        .await
+        .unwrap_or(None);
+
+    if let Some(query_cache_manager) = query_cache_manager {
+        let mut query_cache = query_cache_manager.get_cache(stream).await?;
+
+        let (start, end) = parse_human_time(&query_request.start_time, &query_request.end_time)?;
+        let key = format!(
+            "{}-{}-{}",
+            start.to_rfc3339(),
+            end.to_rfc3339(),
+            query_request.query.clone()
+        );
+
+        let file_path = query_cache.get_file(key);
+        if let Some(file_path) = file_path {
+            let (records, fields) = query_cache.get_cached_records(&file_path).await?;
+            let response = QueryResponse {
+                records,
+                fields,
+                fill_null: query_request.send_null,
+                with_fields: query_request.fields,
+            }
+            .to_http()?;
+
+            return Ok(response);
+        }
+    };
 
     let tables = visitor.into_inner();
 
@@ -99,6 +131,19 @@ pub async fn query(req: HttpRequest, query_request: Query) -> Result<impl Respon
     let time = Instant::now();
 
     let (records, fields) = query.execute(table_name.clone()).await?;
+    // put the rbs to parquet
+    if let Some(query_cache_manager) = query_cache_manager {
+        query_cache_manager
+            .create_parquet_cache(
+                &table_name,
+                &records,
+                query.start.to_rfc3339(),
+                query.end.to_rfc3339(),
+                query_request.query,
+            )
+            .await?;
+    }
+
     let response = QueryResponse {
         records,
         fields,

--- a/server/src/localcache.rs
+++ b/server/src/localcache.rs
@@ -25,9 +25,10 @@ use human_size::{Byte, Gigibyte, SpecificSize};
 use itertools::{Either, Itertools};
 use object_store::{local::LocalFileSystem, ObjectStore};
 use once_cell::sync::OnceCell;
+use parquet::errors::ParquetError;
 use tokio::{fs, sync::Mutex};
 
-use crate::option::CONFIG;
+use crate::{metadata::error::stream_info::MetadataError, option::CONFIG};
 
 pub const STREAM_CACHE_FILENAME: &str = ".cache.json";
 pub const CACHE_META_FILENAME: &str = ".cache_meta.json";
@@ -256,4 +257,8 @@ pub enum CacheError {
     MoveError(#[from] fs_extra::error::Error),
     #[error("{0}")]
     ObjectStoreError(#[from] object_store::Error),
+    #[error("{0}")]
+    ParquetError(#[from] ParquetError),
+    #[error("{0}")]
+    MetadataError(#[from] MetadataError),
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -32,6 +32,7 @@ mod migration;
 mod oidc;
 mod option;
 mod query;
+mod querycache;
 mod rbac;
 mod response;
 mod static_schema;

--- a/server/src/migration.rs
+++ b/server/src/migration.rs
@@ -150,7 +150,7 @@ async fn migration_stream(stream: &str, storage: &dyn ObjectStorage) -> anyhow::
 }
 
 #[inline(always)]
-fn to_bytes(any: &(impl ?Sized + Serialize)) -> Bytes {
+pub fn to_bytes(any: &(impl ?Sized + Serialize)) -> Bytes {
     serde_json::to_vec(any)
         .map(|any| any.into())
         .expect("serialize cannot fail")

--- a/server/src/query.rs
+++ b/server/src/query.rs
@@ -186,6 +186,9 @@ impl TableScanVisitor {
     pub fn into_inner(self) -> Vec<String> {
         self.tables
     }
+    pub fn top(&self) -> &str {
+        self.tables[0].as_ref()
+    }
 }
 
 impl TreeNodeVisitor for TableScanVisitor {

--- a/server/src/querycache.rs
+++ b/server/src/querycache.rs
@@ -1,0 +1,338 @@
+use arrow_array::RecordBatch;
+use chrono::Utc;
+use futures::TryStreamExt;
+use futures_util::TryFutureExt;
+use hashlru::Cache;
+use human_size::{Byte, Gigibyte, SpecificSize};
+use itertools::Itertools;
+use object_store::{local::LocalFileSystem, ObjectStore};
+use once_cell::sync::OnceCell;
+use parquet::arrow::{AsyncArrowWriter, ParquetRecordBatchStreamBuilder};
+use std::path::{Path, PathBuf};
+use tokio::fs as AsyncFs;
+use tokio::{fs, sync::Mutex};
+
+use crate::metadata::STREAM_INFO;
+use crate::storage::staging::parquet_writer_props;
+use crate::{localcache::CacheError, option::CONFIG, utils::hostname_unchecked};
+
+pub const QUERY_CACHE_FILENAME: &str = ".cache.json";
+pub const QUERY_CACHE_META_FILENAME: &str = ".cache_meta.json";
+pub const CURRENT_QUERY_CACHE_VERSION: &str = "v1";
+
+#[derive(Default, Clone, serde::Deserialize, serde::Serialize, Debug, Hash, Eq, PartialEq)]
+pub struct CacheMetadata {
+    query: String,
+    pub start_time: String,
+    pub end_time: String,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct QueryCache {
+    version: String,
+    current_size: u64,
+
+    /// Mapping between storage path and cache path.
+    files: Cache<String, PathBuf>,
+}
+
+impl QueryCache {
+    fn new() -> Self {
+        Self {
+            version: CURRENT_QUERY_CACHE_VERSION.to_string(),
+            current_size: 0,
+            files: Cache::new(100),
+        }
+    }
+
+    pub fn get_file(&mut self, key: String) -> Option<PathBuf> {
+        self.files.get(&key).cloned()
+    }
+
+    // read the parquet
+    // return the recordbatches
+    pub async fn get_cached_records(
+        &self,
+        path: &PathBuf,
+    ) -> Result<(Vec<RecordBatch>, Vec<String>), CacheError> {
+        let file = AsyncFs::File::open(path).await?;
+        let builder = ParquetRecordBatchStreamBuilder::new(file).await?;
+        // Build a async parquet reader.
+        let stream = builder.build()?;
+
+        let records = stream.try_collect::<Vec<_>>().await?;
+        let fields = records.first().map_or_else(Vec::new, |record| {
+            record
+                .schema()
+                .fields()
+                .iter()
+                .map(|field| field.name())
+                .cloned()
+                .collect_vec()
+        });
+
+        Ok((records, fields))
+    }
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct QueryCacheMeta {
+    version: String,
+    size_capacity: u64,
+}
+
+impl QueryCacheMeta {
+    fn new() -> Self {
+        Self {
+            version: CURRENT_QUERY_CACHE_VERSION.to_string(),
+            size_capacity: 0,
+        }
+    }
+}
+
+pub struct QueryCacheManager {
+    filesystem: LocalFileSystem,
+    cache_path: PathBuf,
+    cache_capacity: u64,
+    semaphore: Mutex<()>,
+}
+
+impl QueryCacheManager {
+    pub fn gen_file_path(query_staging_path: &str, stream: &str) -> PathBuf {
+        PathBuf::from_iter([
+            query_staging_path,
+            stream,
+            &format!(
+                "{}.{}.parquet",
+                hostname_unchecked(),
+                Utc::now().to_rfc3339()
+            ),
+        ])
+    }
+    pub async fn global(config_capacity: u64) -> Result<Option<&'static Self>, CacheError> {
+        static INSTANCE: OnceCell<QueryCacheManager> = OnceCell::new();
+
+        let cache_path = CONFIG.parseable.query_cache_path.as_ref();
+
+        if cache_path.is_none() {
+            return Ok(None);
+        }
+
+        let cache_path = cache_path.unwrap();
+
+        let cache_manager = INSTANCE.get_or_init(|| {
+            let cache_path = cache_path.clone();
+            std::fs::create_dir_all(&cache_path).unwrap();
+            Self {
+                filesystem: LocalFileSystem::new(),
+                cache_path,
+                cache_capacity: CONFIG.parseable.query_cache_size,
+                semaphore: Mutex::new(()),
+            }
+        });
+
+        cache_manager.validate(config_capacity).await?;
+
+        Ok(Some(cache_manager))
+    }
+
+    async fn validate(&self, config_capacity: u64) -> Result<(), CacheError> {
+        fs::create_dir_all(&self.cache_path).await?;
+        let path = query_cache_meta_path(&self.cache_path)
+            .map_err(|err| CacheError::ObjectStoreError(err.into()))?;
+        let resp = self
+            .filesystem
+            .get(&path)
+            .and_then(|resp| resp.bytes())
+            .await;
+
+        let updated_cache = match resp {
+            Ok(bytes) => {
+                let mut meta: QueryCacheMeta = serde_json::from_slice(&bytes)?;
+                if meta.size_capacity != config_capacity {
+                    // log the change in cache size
+                    let configured_size_human: SpecificSize<Gigibyte> =
+                        SpecificSize::new(config_capacity as f64, Byte)
+                            .unwrap()
+                            .into();
+                    let current_size_human: SpecificSize<Gigibyte> =
+                        SpecificSize::new(meta.size_capacity as f64, Byte)
+                            .unwrap()
+                            .into();
+                    log::warn!(
+                        "Cache size is updated from {} to {}",
+                        current_size_human,
+                        configured_size_human
+                    );
+                    meta.size_capacity = config_capacity;
+                    Some(meta)
+                } else {
+                    None
+                }
+            }
+            Err(object_store::Error::NotFound { .. }) => {
+                let mut meta = QueryCacheMeta::new();
+                meta.size_capacity = config_capacity;
+                Some(meta)
+            }
+            Err(err) => return Err(err.into()),
+        };
+
+        if let Some(updated_cache) = updated_cache {
+            let result = self
+                .filesystem
+                .put(&path, serde_json::to_vec(&updated_cache)?.into())
+                .await?;
+            log::info!("Cache meta file updated: {:?}", result);
+        }
+
+        Ok(())
+    }
+
+    pub async fn get_cache(&self, stream: &str) -> Result<QueryCache, CacheError> {
+        let path = query_cache_file_path(&self.cache_path, stream).unwrap();
+        let res = self
+            .filesystem
+            .get(&path)
+            .and_then(|resp| resp.bytes())
+            .await;
+        let cache = match res {
+            Ok(bytes) => serde_json::from_slice(&bytes)?,
+            Err(object_store::Error::NotFound { .. }) => QueryCache::new(),
+            Err(err) => return Err(err.into()),
+        };
+        Ok(cache)
+    }
+
+    pub async fn put_cache(&self, stream: &str, cache: &QueryCache) -> Result<(), CacheError> {
+        let path = query_cache_file_path(&self.cache_path, stream).unwrap();
+        let bytes = serde_json::to_vec(cache)?.into();
+        let result = self.filesystem.put(&path, bytes).await?;
+        log::info!("Cache file updated: {:?}", result);
+        Ok(())
+    }
+
+    pub async fn move_to_cache(
+        &self,
+        stream: &str,
+        key: String,
+        staging_path: &Path,
+    ) -> Result<(), CacheError> {
+        let lock = self.semaphore.lock().await;
+        let mut cache_path = self.cache_path.join(stream);
+        fs::create_dir_all(&cache_path).await?;
+        cache_path.push(staging_path.file_name().unwrap());
+        // this needs to be the record batches parquet
+        // fs_extra::file::move_file(staging_path, &cache_path, &self.copy_options)?;
+        let file_size = std::fs::metadata(&cache_path)?.len();
+        let mut cache = self.get_cache(stream).await?;
+
+        while cache.current_size + file_size > self.cache_capacity {
+            if let Some((_, file_for_removal)) = cache.files.pop_lru() {
+                let lru_file_size = std::fs::metadata(&file_for_removal)?.len();
+                cache.current_size = cache.current_size.saturating_sub(lru_file_size);
+                log::info!("removing cache entry");
+                tokio::spawn(fs::remove_file(file_for_removal));
+            } else {
+                log::error!("Cache size too small");
+                break;
+            }
+        }
+
+        if cache.files.is_full() {
+            cache.files.resize(cache.files.capacity() * 2);
+        }
+        cache.files.push(key, cache_path);
+        cache.current_size += file_size;
+        self.put_cache(stream, &cache).await?;
+        drop(lock);
+        Ok(())
+    }
+
+    pub async fn create_parquet_cache(
+        &self,
+        table_name: &str,
+        records: &[RecordBatch],
+        start: String,
+        end: String,
+        query: String,
+    ) -> Result<(), CacheError> {
+        let parquet_path = Self::gen_file_path(
+            self.cache_path.to_str().expect("utf-8 compat path"),
+            table_name,
+        );
+        AsyncFs::create_dir_all(parquet_path.parent().expect("parent path exists")).await?;
+        let parquet_file = AsyncFs::File::create(&parquet_path).await?;
+        let time_partition = STREAM_INFO.get_time_partition(table_name)?;
+        let props = parquet_writer_props(time_partition.clone(), 0).build();
+
+        let mut arrow_writer = AsyncArrowWriter::try_new(
+            parquet_file,
+            STREAM_INFO.schema(table_name).expect("schema present"),
+            Some(props),
+        )?;
+
+        for record in records {
+            if let Err(e) = arrow_writer.write(record).await {
+                log::error!("Error While Writing to Query Cache: {}", e);
+            }
+        }
+
+        arrow_writer.close().await?;
+        self.move_to_cache(
+            table_name,
+            format!("{}-{}-{}", start, end, query),
+            &parquet_path,
+        )
+        .await
+        // match AsyncArrowWriter::try_new(
+        //     parquet_file,
+        //     STREAM_INFO.schema(&table_name).expect("schema present"),
+        //     Some(props),
+        // ) {
+        //     Ok(mut writer) => {
+        //         for record in records {
+        //             if let Err(e) = writer.write(record).await {
+        //                 log::error!("Error While Writing to Query Cache: {}", e);
+        //                 err_flag = true;
+        //             }
+        //         }
+        //
+        //         if let Err(e) = writer.close().await {
+        //             log::error!(
+        //                 "Unstable State: Async ArrowWriter Faild to close. Error: {}",
+        //                 e
+        //             );
+        //
+        //             err_flag = true;
+        //         }
+        //     }
+        //     Err(err) => {
+        //         log::error!("Failed to create an Async ArrowWriter. Reason: {}", err);
+        //         err_flag = true;
+        //     }
+        // }
+        //
+        // if err_flag {
+        //     log::error!("Failed to cache query result");
+        // } else {
+        //
+        // }
+    }
+}
+
+fn query_cache_file_path(
+    root: impl AsRef<std::path::Path>,
+    stream: &str,
+) -> Result<object_store::path::Path, object_store::path::Error> {
+    let mut path = root.as_ref().join(stream);
+    path.push(QUERY_CACHE_FILENAME);
+    object_store::path::Path::from_absolute_path(path)
+}
+
+fn query_cache_meta_path(
+    root: impl AsRef<std::path::Path>,
+) -> Result<object_store::path::Path, object_store::path::Error> {
+    let path = root.as_ref().join(QUERY_CACHE_META_FILENAME);
+    object_store::path::Path::from_absolute_path(path)
+}

--- a/server/src/storage/staging.rs
+++ b/server/src/storage/staging.rs
@@ -275,7 +275,7 @@ pub fn convert_disk_files_to_parquet(
     }
 }
 
-fn parquet_writer_props(
+pub fn parquet_writer_props(
     time_partition: Option<String>,
     index_time_partition: usize,
 ) -> WriterPropertiesBuilder {

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -271,7 +271,7 @@ pub fn get_ingestor_id() -> String {
     let result = format!("{:x}", hasher.finalize());
     let result = result.split_at(15).0.to_string();
     log::debug!("Ingestor ID: {}", &result);
-    result.to_string()
+    result
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Description

Implement Query Result Caching. The user needs to set the env vars `P_QUERY_CACHE_SIZE` and `P_QUERY_CACHE_DIR` to enable caching. Cache Size has a default value of 1GB.

<hr>

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.
