### PR TITLE
enhancement to allow custom partitions in ingestion

### DIFF
--- a/server/src/event.rs
+++ b/server/src/event.rs
@@ -57,7 +57,7 @@ impl Event {
         }
 
         if !self.custom_partition_values.is_empty() {
-            let mut custom_partition_key = String::new();
+            let mut custom_partition_key = String::default();
             for (k, v) in self.custom_partition_values.iter().sorted_by_key(|v| v.0) {
                 custom_partition_key = format!("{custom_partition_key}&{k}={v}");
             }

--- a/server/src/event.rs
+++ b/server/src/event.rs
@@ -23,13 +23,13 @@ mod writer;
 use arrow_array::RecordBatch;
 use arrow_schema::{Field, Fields, Schema};
 use itertools::Itertools;
-
 use std::sync::Arc;
 
 use self::error::EventError;
 pub use self::writer::STREAM_WRITERS;
 use crate::metadata;
 use chrono::NaiveDateTime;
+use std::collections::HashMap;
 
 pub const DEFAULT_TIMESTAMP_KEY: &str = "p_timestamp";
 pub const DEFAULT_TAGS_KEY: &str = "p_tags";
@@ -44,6 +44,7 @@ pub struct Event {
     pub is_first_event: bool,
     pub parsed_timestamp: NaiveDateTime,
     pub time_partition: Option<String>,
+    pub custom_partition_values: HashMap<String, String>,
 }
 
 // Events holds the schema related to a each event for a single log stream
@@ -53,6 +54,14 @@ impl Event {
         if self.time_partition.is_some() {
             let parsed_timestamp_to_min = self.parsed_timestamp.format("%Y%m%dT%H%M").to_string();
             key = format!("{key}{parsed_timestamp_to_min}");
+        }
+
+        if !self.custom_partition_values.is_empty() {
+            let mut custom_partition_key = String::new();
+            for (k, v) in self.custom_partition_values.iter().sorted_by_key(|v| v.0) {
+                custom_partition_key = format!("{custom_partition_key}&{k}={v}");
+            }
+            key = format!("{key}{custom_partition_key}");
         }
 
         let num_rows = self.rb.num_rows() as u64;
@@ -65,6 +74,7 @@ impl Event {
             &key,
             self.rb.clone(),
             self.parsed_timestamp,
+            self.custom_partition_values,
         )?;
 
         metadata::STREAM_INFO.update_stats(
@@ -93,8 +103,15 @@ impl Event {
         schema_key: &str,
         rb: RecordBatch,
         parsed_timestamp: NaiveDateTime,
+        custom_partition_values: HashMap<String, String>,
     ) -> Result<(), EventError> {
-        STREAM_WRITERS.append_to_local(stream_name, schema_key, rb, parsed_timestamp)?;
+        STREAM_WRITERS.append_to_local(
+            stream_name,
+            schema_key,
+            rb,
+            parsed_timestamp,
+            custom_partition_values,
+        )?;
         Ok(())
     }
 }

--- a/server/src/event/format/json.rs
+++ b/server/src/event/format/json.rs
@@ -48,7 +48,7 @@ impl EventFormat for Event {
         static_schema_flag: Option<String>,
         time_partition: Option<String>,
     ) -> Result<(Self::Data, Vec<Arc<Field>>, bool, Tags, Metadata), anyhow::Error> {
-        let data = flatten_json_body(self.data, None, None, false)?;
+        let data = flatten_json_body(self.data, None, None, None, false)?;
         let stream_schema = schema;
 
         // incoming event may be a single json or a json array

--- a/server/src/event/writer/file_writer.rs
+++ b/server/src/event/writer/file_writer.rs
@@ -44,6 +44,7 @@ impl FileWriter {
         schema_key: &str,
         record: &RecordBatch,
         parsed_timestamp: NaiveDateTime,
+        custom_partition_values: HashMap<String, String>,
     ) -> Result<(), StreamWriterError> {
         match self.get_mut(schema_key) {
             Some(writer) => {
@@ -55,8 +56,13 @@ impl FileWriter {
             // entry is not present thus we create it
             None => {
                 // this requires mutable borrow of the map so we drop this read lock and wait for write lock
-                let (path, writer) =
-                    init_new_stream_writer_file(stream_name, schema_key, record, parsed_timestamp)?;
+                let (path, writer) = init_new_stream_writer_file(
+                    stream_name,
+                    schema_key,
+                    record,
+                    parsed_timestamp,
+                    custom_partition_values,
+                )?;
                 self.insert(
                     schema_key.to_owned(),
                     ArrowWriter {
@@ -82,9 +88,10 @@ fn init_new_stream_writer_file(
     schema_key: &str,
     record: &RecordBatch,
     parsed_timestamp: NaiveDateTime,
+    custom_partition_values: HashMap<String, String>,
 ) -> Result<(PathBuf, StreamWriter<std::fs::File>), StreamWriterError> {
     let dir = StorageDir::new(stream_name);
-    let path = dir.path_by_current_time(schema_key, parsed_timestamp);
+    let path = dir.path_by_current_time(schema_key, parsed_timestamp, custom_partition_values);
     std::fs::create_dir_all(dir.data_path)?;
 
     let file = OpenOptions::new().create(true).append(true).open(&path)?;

--- a/server/src/handlers.rs
+++ b/server/src/handlers.rs
@@ -25,6 +25,7 @@ const STREAM_NAME_HEADER_KEY: &str = "x-p-stream";
 const LOG_SOURCE_KEY: &str = "x-p-log-source";
 const TIME_PARTITION_KEY: &str = "x-p-time-partition";
 const TIME_PARTITION_LIMIT_KEY: &str = "x-p-time-partition-limit";
+const CUSTOM_PARTITION_KEY: &str = "x-p-custom-partition";
 const STATIC_SCHEMA_FLAG: &str = "x-p-static-schema-flag";
 const AUTHORIZATION_KEY: &str = "authorization";
 const SEPARATOR: char = '^';

--- a/server/src/handlers/http/ingest.rs
+++ b/server/src/handlers/http/ingest.rs
@@ -35,7 +35,7 @@ use crate::utils::json::convert_array_to_object;
 use actix_web::{http::header::ContentType, HttpRequest, HttpResponse};
 use arrow_schema::{Field, Schema};
 use bytes::Bytes;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDateTime, Utc};
 use http::StatusCode;
 use serde_json::Value;
 use std::collections::{BTreeMap, HashMap};
@@ -110,72 +110,41 @@ async fn push_logs(stream_name: String, req: HttpRequest, body: Bytes) -> Result
     let body_val: Value = serde_json::from_slice(&body)?;
     let size: usize = body.len();
     let mut parsed_timestamp = Utc::now().naive_utc();
-    let mut custom_partition_values: HashMap<String, String> = HashMap::new();
-
     if time_partition.is_none() {
         if custom_partition.is_none() {
-            let stream = stream_name.clone();
-            let (rb, is_first_event) = get_stream_schema(
-                stream.clone(),
-                req,
-                body_val,
-                static_schema_flag,
-                time_partition.clone(),
-            )?;
-            event::Event {
-                rb: rb.clone(),
-                stream_name: stream,
-                origin_format: "json",
-                origin_size: size as u64,
-                is_first_event,
+            let size = size as u64;
+            create_process_record_batch(
+                stream_name.clone(),
+                req.clone(),
+                body_val.clone(),
+                static_schema_flag.clone(),
+                None,
                 parsed_timestamp,
-                time_partition,
-                custom_partition_values,
-            }
-            .process()
+                HashMap::new(),
+                size,
+            )
             .await?;
         } else {
-            let data = convert_array_to_object(
-                body_val.clone(),
-                time_partition.clone(),
-                time_partition_limit,
-                custom_partition.clone(),
-            )?;
+            let data =
+                convert_array_to_object(body_val.clone(), None, None, custom_partition.clone())?;
             let custom_partition = custom_partition.unwrap();
             let custom_partition_list = custom_partition.split(',').collect::<Vec<&str>>();
 
             for value in data {
-                for custom_partition_field in custom_partition_list.clone() {
-                    let custom_partition_value =
-                        value.get(custom_partition_field.trim()).unwrap().to_owned();
-                    let custom_partition_value = match custom_partition_value.clone() {
-                        e @ Value::Number(_) | e @ Value::Bool(_) => e.to_string(),
-                        Value::String(s) => s,
-                        _ => "".to_string(),
-                    };
-                    custom_partition_values.insert(
-                        custom_partition_field.trim().to_string(),
-                        custom_partition_value,
-                    );
-                }
-                let (rb, is_first_event) = get_stream_schema(
+                let custom_partition_values =
+                    get_custom_partition_values(&value, &custom_partition_list);
+
+                let size = value.to_string().into_bytes().len() as u64;
+                create_process_record_batch(
                     stream_name.clone(),
                     req.clone(),
                     value.clone(),
                     static_schema_flag.clone(),
-                    time_partition.clone(),
-                )?;
-                event::Event {
-                    rb,
-                    stream_name: stream_name.clone(),
-                    origin_format: "json",
-                    origin_size: value.to_string().into_bytes().len() as u64,
-                    is_first_event,
+                    None,
                     parsed_timestamp,
-                    time_partition: time_partition.clone(),
-                    custom_partition_values: custom_partition_values.clone(),
-                }
-                .process()
+                    custom_partition_values.clone(),
+                    size,
+                )
                 .await?;
             }
         }
@@ -184,37 +153,21 @@ async fn push_logs(stream_name: String, req: HttpRequest, body: Bytes) -> Result
             body_val.clone(),
             time_partition.clone(),
             time_partition_limit,
-            custom_partition.clone(),
+            None,
         )?;
         for value in data {
-            let body_timestamp = value.get(&time_partition.clone().unwrap().to_string());
-            parsed_timestamp = body_timestamp
-                .unwrap()
-                .to_owned()
-                .as_str()
-                .unwrap()
-                .parse::<DateTime<Utc>>()
-                .unwrap()
-                .naive_utc();
-
-            let (rb, is_first_event) = get_stream_schema(
+            parsed_timestamp = get_parsed_timestamp(&value, &time_partition);
+            let size = value.to_string().into_bytes().len() as u64;
+            create_process_record_batch(
                 stream_name.clone(),
                 req.clone(),
                 value.clone(),
                 static_schema_flag.clone(),
                 time_partition.clone(),
-            )?;
-            event::Event {
-                rb,
-                stream_name: stream_name.clone(),
-                origin_format: "json",
-                origin_size: value.to_string().into_bytes().len() as u64,
-                is_first_event,
                 parsed_timestamp,
-                time_partition: time_partition.clone(),
-                custom_partition_values: HashMap::new(),
-            }
-            .process()
+                HashMap::new(),
+                size,
+            )
             .await?;
         }
     } else {
@@ -228,50 +181,91 @@ async fn push_logs(stream_name: String, req: HttpRequest, body: Bytes) -> Result
         let custom_partition_list = custom_partition.split(',').collect::<Vec<&str>>();
 
         for value in data {
-            for custom_partition_field in custom_partition_list.clone() {
-                let custom_partition_value =
-                    value.get(custom_partition_field.trim()).unwrap().to_owned();
-                let custom_partition_value = match custom_partition_value.clone() {
-                    e @ Value::Number(_) | e @ Value::Bool(_) => e.to_string(),
-                    Value::String(s) => s,
-                    _ => "".to_string(),
-                };
-                custom_partition_values.insert(
-                    custom_partition_field.trim().to_string(),
-                    custom_partition_value,
-                );
-            }
-            let body_timestamp = value.get(&time_partition.clone().unwrap().to_string());
-            parsed_timestamp = body_timestamp
-                .unwrap()
-                .to_owned()
-                .as_str()
-                .unwrap()
-                .parse::<DateTime<Utc>>()
-                .unwrap()
-                .naive_utc();
+            let custom_partition_values =
+                get_custom_partition_values(&value, &custom_partition_list);
 
-            let (rb, is_first_event) = get_stream_schema(
+            parsed_timestamp = get_parsed_timestamp(&value, &time_partition);
+            let size = value.to_string().into_bytes().len() as u64;
+            create_process_record_batch(
                 stream_name.clone(),
                 req.clone(),
                 value.clone(),
                 static_schema_flag.clone(),
                 time_partition.clone(),
-            )?;
-            event::Event {
-                rb,
-                stream_name: stream_name.clone(),
-                origin_format: "json",
-                origin_size: value.to_string().into_bytes().len() as u64,
-                is_first_event,
                 parsed_timestamp,
-                time_partition: time_partition.clone(),
-                custom_partition_values: custom_partition_values.clone(),
-            }
-            .process()
+                custom_partition_values.clone(),
+                size,
+            )
             .await?;
         }
     }
+
+    Ok(())
+}
+
+fn get_parsed_timestamp(body: &Value, time_partition: &Option<String>) -> NaiveDateTime {
+    let body_timestamp = body.get(&time_partition.clone().unwrap().to_string());
+    let parsed_timestamp = body_timestamp
+        .unwrap()
+        .to_owned()
+        .as_str()
+        .unwrap()
+        .parse::<DateTime<Utc>>()
+        .unwrap()
+        .naive_utc();
+    parsed_timestamp
+}
+
+fn get_custom_partition_values(
+    body: &Value,
+    custom_partition_list: &[&str],
+) -> HashMap<String, String> {
+    let mut custom_partition_values: HashMap<String, String> = HashMap::new();
+    for custom_partition_field in custom_partition_list {
+        let custom_partition_value = body.get(custom_partition_field.trim()).unwrap().to_owned();
+        let custom_partition_value = match custom_partition_value.clone() {
+            e @ Value::Number(_) | e @ Value::Bool(_) => e.to_string(),
+            Value::String(s) => s,
+            _ => "".to_string(),
+        };
+        custom_partition_values.insert(
+            custom_partition_field.trim().to_string(),
+            custom_partition_value,
+        );
+    }
+    custom_partition_values
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn create_process_record_batch(
+    stream_name: String,
+    req: HttpRequest,
+    value: Value,
+    static_schema_flag: Option<String>,
+    time_partition: Option<String>,
+    parsed_timestamp: NaiveDateTime,
+    custom_partition_values: HashMap<String, String>,
+    origin_size: u64,
+) -> Result<(), PostError> {
+    let (rb, is_first_event) = get_stream_schema(
+        stream_name.clone(),
+        req.clone(),
+        value.clone(),
+        static_schema_flag.clone(),
+        time_partition.clone(),
+    )?;
+    event::Event {
+        rb,
+        stream_name: stream_name.clone(),
+        origin_format: "json",
+        origin_size,
+        is_first_event,
+        parsed_timestamp,
+        time_partition: time_partition.clone(),
+        custom_partition_values: custom_partition_values.clone(),
+    }
+    .process()
+    .await?;
 
     Ok(())
 }

--- a/server/src/handlers/http/ingest.rs
+++ b/server/src/handlers/http/ingest.rs
@@ -106,36 +106,103 @@ async fn push_logs(stream_name: String, req: HttpRequest, body: Bytes) -> Result
     let time_partition = object_store_format.time_partition;
     let time_partition_limit = object_store_format.time_partition_limit;
     let static_schema_flag = object_store_format.static_schema_flag;
+    let custom_partition = object_store_format.custom_partition;
     let body_val: Value = serde_json::from_slice(&body)?;
     let size: usize = body.len();
     let mut parsed_timestamp = Utc::now().naive_utc();
+    let mut custom_partition_values: HashMap<String, String> = HashMap::new();
+
     if time_partition.is_none() {
-        let stream = stream_name.clone();
-        let (rb, is_first_event) = get_stream_schema(
-            stream.clone(),
-            req,
-            body_val,
-            static_schema_flag,
-            time_partition.clone(),
-        )?;
-        event::Event {
-            rb,
-            stream_name: stream,
-            origin_format: "json",
-            origin_size: size as u64,
-            is_first_event,
-            parsed_timestamp,
-            time_partition,
+        if custom_partition.is_none() {
+            let stream = stream_name.clone();
+            let (rb, is_first_event) = get_stream_schema(
+                stream.clone(),
+                req,
+                body_val,
+                static_schema_flag,
+                time_partition.clone(),
+            )?;
+            event::Event {
+                rb: rb.clone(),
+                stream_name: stream,
+                origin_format: "json",
+                origin_size: size as u64,
+                is_first_event,
+                parsed_timestamp,
+                time_partition,
+                custom_partition_values,
+            }
+            .process()
+            .await?;
+        } else {
+            let data = convert_array_to_object(
+                body_val.clone(),
+                time_partition.clone(),
+                time_partition_limit,
+                custom_partition.clone(),
+            )?;
+            let custom_partition = custom_partition.unwrap();
+            let custom_partition_list = custom_partition.split(',').collect::<Vec<&str>>();
+
+            for value in data {
+                for custom_partition_field in custom_partition_list.clone() {
+                    let custom_partition_value =
+                        value.get(custom_partition_field.trim()).unwrap().to_owned();
+                    let custom_partition_value = match custom_partition_value.clone() {
+                        e @ Value::Number(_) | e @ Value::Bool(_) => e.to_string(),
+                        Value::String(s) => s,
+                        _ => "".to_string(),
+                    };
+                    custom_partition_values.insert(
+                        custom_partition_field.trim().to_string(),
+                        custom_partition_value,
+                    );
+                }
+                let (rb, is_first_event) = get_stream_schema(
+                    stream_name.clone(),
+                    req.clone(),
+                    value.clone(),
+                    static_schema_flag.clone(),
+                    time_partition.clone(),
+                )?;
+                event::Event {
+                    rb,
+                    stream_name: stream_name.clone(),
+                    origin_format: "json",
+                    origin_size: value.to_string().into_bytes().len() as u64,
+                    is_first_event,
+                    parsed_timestamp,
+                    time_partition: time_partition.clone(),
+                    custom_partition_values: custom_partition_values.clone(),
+                }
+                .process()
+                .await?;
+            }
         }
-        .process()
-        .await?;
     } else {
         let data = convert_array_to_object(
             body_val.clone(),
             time_partition.clone(),
             time_partition_limit,
+            custom_partition.clone(),
         )?;
+        let custom_partition = custom_partition.unwrap();
+        let custom_partition_list = custom_partition.split(',').collect::<Vec<&str>>();
+
         for value in data {
+            for custom_partition_field in custom_partition_list.clone() {
+                let custom_partition_value =
+                    value.get(custom_partition_field.trim()).unwrap().to_owned();
+                let custom_partition_value = match custom_partition_value.clone() {
+                    e @ Value::Number(_) | e @ Value::Bool(_) => e.to_string(),
+                    Value::String(s) => s,
+                    _ => "".to_string(),
+                };
+                custom_partition_values.insert(
+                    custom_partition_field.trim().to_string(),
+                    custom_partition_value,
+                );
+            }
             let body_timestamp = value.get(&time_partition.clone().unwrap().to_string());
             parsed_timestamp = body_timestamp
                 .unwrap()
@@ -161,6 +228,7 @@ async fn push_logs(stream_name: String, req: HttpRequest, body: Bytes) -> Result
                 is_first_event,
                 parsed_timestamp,
                 time_partition: time_partition.clone(),
+                custom_partition_values: custom_partition_values.clone(),
             }
             .process()
             .await?;
@@ -213,6 +281,7 @@ pub async fn create_stream_if_not_exists(stream_name: &str) -> Result<(), PostEr
         Mode::All | Mode::Query => {
             super::logstream::create_stream(
                 stream_name.to_string(),
+                "",
                 "",
                 "",
                 "",

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -95,6 +95,8 @@ pub struct ObjectStoreFormat {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub time_partition_limit: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub custom_partition: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub static_schema_flag: Option<String>,
 }
 
@@ -111,6 +113,8 @@ pub struct StreamInfo {
     pub time_partition: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub time_partition_limit: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub custom_partition: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub static_schema_flag: Option<String>,
 }
@@ -159,6 +163,7 @@ impl Default for ObjectStoreFormat {
             retention: None,
             time_partition: None,
             time_partition_limit: None,
+            custom_partition: None,
             static_schema_flag: None,
         }
     }

--- a/server/src/storage/staging.rs
+++ b/server/src/storage/staging.rs
@@ -38,7 +38,8 @@ use crate::{
 };
 use arrow_schema::{ArrowError, Schema};
 use base64::Engine;
-use chrono::{NaiveDateTime, Timelike};
+use chrono::{NaiveDateTime, Timelike, Utc};
+use itertools::Itertools;
 use parquet::{
     arrow::ArrowWriter,
     basic::Encoding,
@@ -64,10 +65,17 @@ impl StorageDir {
         Self { data_path }
     }
 
-    pub fn file_time_suffix(time: NaiveDateTime, extention: &str) -> String {
-        let uri = utils::date_to_prefix(time.date())
+    pub fn file_time_suffix(
+        time: NaiveDateTime,
+        custom_partition_values: HashMap<String, String>,
+        extention: &str,
+    ) -> String {
+        let mut uri = utils::date_to_prefix(time.date())
             + &utils::hour_to_prefix(time.hour())
             + &utils::minute_to_prefix(time.minute(), OBJECT_STORE_DATA_GRANULARITY).unwrap();
+        if !custom_partition_values.is_empty() {
+            uri = uri + &utils::custom_partition_to_prefix(custom_partition_values);
+        }
         let local_uri = str::replace(&uri, "/", ".");
         let hostname = hostname_unchecked();
         if CONFIG.parseable.mode == Mode::Ingest {
@@ -78,27 +86,37 @@ impl StorageDir {
         }
     }
 
-    fn filename_by_time(stream_hash: &str, time: NaiveDateTime) -> String {
+    fn filename_by_time(
+        stream_hash: &str,
+        time: NaiveDateTime,
+        custom_partition_values: HashMap<String, String>,
+    ) -> String {
         format!(
             "{}.{}",
             stream_hash,
-            Self::file_time_suffix(time, ARROW_FILE_EXTENSION)
+            Self::file_time_suffix(time, custom_partition_values, ARROW_FILE_EXTENSION)
         )
     }
 
-    fn filename_by_current_time(stream_hash: &str, parsed_timestamp: NaiveDateTime) -> String {
-        Self::filename_by_time(stream_hash, parsed_timestamp)
+    fn filename_by_current_time(
+        stream_hash: &str,
+        parsed_timestamp: NaiveDateTime,
+        custom_partition_values: HashMap<String, String>,
+    ) -> String {
+        Self::filename_by_time(stream_hash, parsed_timestamp, custom_partition_values)
     }
 
     pub fn path_by_current_time(
         &self,
         stream_hash: &str,
         parsed_timestamp: NaiveDateTime,
+        custom_partition_values: HashMap<String, String>,
     ) -> PathBuf {
-        self.data_path.join(Self::filename_by_current_time(
-            stream_hash,
-            parsed_timestamp,
-        ))
+        let server_time_in_min = Utc::now().format("%Y%m%dT%H%M").to_string();
+        let mut filename =
+            Self::filename_by_current_time(stream_hash, parsed_timestamp, custom_partition_values);
+        filename = format!("{}{}", server_time_in_min, filename);
+        self.data_path.join(filename)
     }
 
     pub fn arrow_files(&self) -> Vec<PathBuf> {
@@ -106,10 +124,11 @@ impl StorageDir {
             return vec![];
         };
 
-        let paths: Vec<PathBuf> = dir
+        let paths = dir
             .flatten()
             .map(|file| file.path())
             .filter(|file| file.extension().map_or(false, |ext| ext.eq("arrows")))
+            .sorted_by_key(|f| f.metadata().unwrap().modified().unwrap())
             .collect();
 
         paths
@@ -135,20 +154,16 @@ impl StorageDir {
         &self,
         exclude: NaiveDateTime,
     ) -> HashMap<PathBuf, Vec<PathBuf>> {
-        let hot_filename = StorageDir::file_time_suffix(exclude, ARROW_FILE_EXTENSION);
-        // hashmap <time, vec[paths]> but exclude where hot filename matches
         let mut grouped_arrow_file: HashMap<PathBuf, Vec<PathBuf>> = HashMap::new();
         let mut arrow_files = self.arrow_files();
-
         arrow_files.retain(|path| {
             !path
                 .file_name()
                 .unwrap()
                 .to_str()
                 .unwrap()
-                .ends_with(&hot_filename)
+                .starts_with(&exclude.format("%Y%m%dT%H%M").to_string())
         });
-
         for arrow_file_path in arrow_files {
             let key = Self::arrow_path_to_parquet(&arrow_file_path);
             grouped_arrow_file
@@ -156,7 +171,6 @@ impl StorageDir {
                 .or_default()
                 .push(arrow_file_path);
         }
-
         grouped_arrow_file
     }
 
@@ -176,6 +190,7 @@ impl StorageDir {
         let (_, filename) = filename.split_once('.').unwrap();
         let filename = filename.rsplit_once('.').expect("contains the delim `.`");
         let filename = format!("{}.{}", filename.0, filename.1);
+
         let random_string =
             rand::distributions::Alphanumeric.sample_string(&mut rand::thread_rng(), 15);
         let filename_with_random_number = format!("{}.{}.{}", filename, random_string, "arrows");
@@ -186,7 +201,6 @@ impl StorageDir {
                 let (_, filename) = file_stem.split_once('.').unwrap();
                 let filename_with_random_number = format!("{}.{}.{}", filename, random_number, "arrows");
         */
-
         let mut parquet_path = path.to_owned();
         parquet_path.set_file_name(filename_with_random_number);
         parquet_path.set_extension("parquet");
@@ -197,7 +211,7 @@ impl StorageDir {
 #[allow(unused)]
 pub fn to_parquet_path(stream_name: &str, time: NaiveDateTime) -> PathBuf {
     let data_path = CONFIG.parseable.local_stream_data_path(stream_name);
-    let dir = StorageDir::file_time_suffix(time, PARQUET_FILE_EXTENSION);
+    let dir = StorageDir::file_time_suffix(time, HashMap::new(), PARQUET_FILE_EXTENSION);
 
     data_path.join(dir)
 }
@@ -206,6 +220,7 @@ pub fn convert_disk_files_to_parquet(
     stream: &str,
     dir: &StorageDir,
     time_partition: Option<String>,
+    custom_partition: Option<String>,
 ) -> Result<Option<Schema>, MoveDataError> {
     let mut schemas = Vec::new();
 
@@ -241,8 +256,20 @@ pub fn convert_disk_files_to_parquet(
         if let Some(time_partition) = time_partition.as_ref() {
             index_time_partition = merged_schema.index_of(time_partition).unwrap();
         }
+        let mut custom_partition_fields: HashMap<String, usize> = HashMap::new();
+        if let Some(custom_partition) = custom_partition.as_ref() {
+            for custom_partition_field in custom_partition.split(',') {
+                let index = merged_schema.index_of(custom_partition_field).unwrap();
+                custom_partition_fields.insert(custom_partition_field.to_string(), index);
+            }
+        }
         let parquet_file = fs::File::create(&parquet_path).map_err(|_| MoveDataError::Create)?;
-        let props = parquet_writer_props(time_partition.clone(), index_time_partition).build();
+        let props = parquet_writer_props(
+            time_partition.clone(),
+            index_time_partition,
+            custom_partition_fields,
+        )
+        .build();
 
         schemas.push(merged_schema.clone());
         let schema = Arc::new(merged_schema);
@@ -278,36 +305,41 @@ pub fn convert_disk_files_to_parquet(
 fn parquet_writer_props(
     time_partition: Option<String>,
     index_time_partition: usize,
+    custom_partition_fields: HashMap<String, usize>,
 ) -> WriterPropertiesBuilder {
     let index_time_partition: i32 = index_time_partition as i32;
-
+    let mut time_partition_field = DEFAULT_TIMESTAMP_KEY.to_string();
     if let Some(time_partition) = time_partition {
-        WriterProperties::builder()
-            .set_max_row_group_size(CONFIG.parseable.row_group_size)
-            .set_compression(CONFIG.parseable.parquet_compression.into())
-            .set_column_encoding(
-                ColumnPath::new(vec![time_partition]),
-                Encoding::DELTA_BYTE_ARRAY,
-            )
-            .set_sorting_columns(Some(vec![SortingColumn {
-                column_idx: index_time_partition,
-                descending: true,
-                nulls_first: true,
-            }]))
-    } else {
-        WriterProperties::builder()
-            .set_max_row_group_size(CONFIG.parseable.row_group_size)
-            .set_compression(CONFIG.parseable.parquet_compression.into())
-            .set_column_encoding(
-                ColumnPath::new(vec![DEFAULT_TIMESTAMP_KEY.to_string()]),
-                Encoding::DELTA_BINARY_PACKED,
-            )
-            .set_sorting_columns(Some(vec![SortingColumn {
-                column_idx: index_time_partition,
-                descending: true,
-                nulls_first: true,
-            }]))
+        time_partition_field = time_partition;
     }
+    let mut sorting_column_vec: Vec<SortingColumn> = Vec::new();
+    sorting_column_vec.push(SortingColumn {
+        column_idx: index_time_partition,
+        descending: true,
+        nulls_first: true,
+    });
+    let mut props = WriterProperties::builder()
+        .set_max_row_group_size(CONFIG.parseable.row_group_size)
+        .set_compression(CONFIG.parseable.parquet_compression.into())
+        .set_column_encoding(
+            ColumnPath::new(vec![time_partition_field]),
+            Encoding::DELTA_BINARY_PACKED,
+        );
+
+    for (field, index) in custom_partition_fields {
+        let field = ColumnPath::new(vec![field]);
+        let encoding = Encoding::DELTA_BYTE_ARRAY;
+        props = props.set_column_encoding(field, encoding);
+        let sorting_column = SortingColumn {
+            column_idx: index as i32,
+            descending: true,
+            nulls_first: true,
+        };
+        sorting_column_vec.push(sorting_column);
+    }
+    props = props.set_sorting_columns(Some(sorting_column_vec));
+
+    props
 }
 
 pub fn get_ingestor_info() -> anyhow::Result<IngestorMetadata> {

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -64,7 +64,7 @@ pub fn date_to_prefix(date: NaiveDate) -> String {
 }
 
 pub fn custom_partition_to_prefix(custom_partition: HashMap<String, String>) -> String {
-    let mut prefix = String::new();
+    let mut prefix = String::default();
     for (key, value) in custom_partition.iter().sorted_by_key(|v| v.0) {
         prefix.push_str(&format!("{key}={value}/", key = key, value = value));
     }

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -24,8 +24,9 @@ pub mod uid;
 pub mod update;
 use crate::option::CONFIG;
 use chrono::{DateTime, NaiveDate, Timelike, Utc};
+use itertools::Itertools;
 use sha2::{Digest, Sha256};
-
+use std::collections::HashMap;
 use std::env;
 use url::Url;
 
@@ -60,6 +61,14 @@ pub fn minute_to_slot(minute: u32, data_granularity: u32) -> Option<String> {
 pub fn date_to_prefix(date: NaiveDate) -> String {
     let date = format!("date={date}/");
     date.replace("UTC", "")
+}
+
+pub fn custom_partition_to_prefix(custom_partition: HashMap<String, String>) -> String {
+    let mut prefix = String::new();
+    for (key, value) in custom_partition.iter().sorted_by_key(|v| v.0) {
+        prefix.push_str(&format!("{key}={value}/", key = key, value = value));
+    }
+    prefix
 }
 
 pub fn hour_to_prefix(hour: u32) -> String {

--- a/server/src/utils/json.rs
+++ b/server/src/utils/json.rs
@@ -25,6 +25,7 @@ pub fn flatten_json_body(
     body: serde_json::Value,
     time_partition: Option<String>,
     time_partition_limit: Option<String>,
+    custom_partition: Option<String>,
     validation_required: bool,
 ) -> Result<Value, anyhow::Error> {
     flatten::flatten(
@@ -32,6 +33,7 @@ pub fn flatten_json_body(
         "_",
         time_partition,
         time_partition_limit,
+        custom_partition,
         validation_required,
     )
 }
@@ -40,8 +42,15 @@ pub fn convert_array_to_object(
     body: Value,
     time_partition: Option<String>,
     time_partition_limit: Option<String>,
+    custom_partition: Option<String>,
 ) -> Result<Vec<Value>, anyhow::Error> {
-    let data = flatten_json_body(body, time_partition, time_partition_limit, true)?;
+    let data = flatten_json_body(
+        body,
+        time_partition,
+        time_partition_limit,
+        custom_partition,
+        true,
+    )?;
     let value_arr = match data {
         Value::Array(arr) => arr,
         value @ Value::Object(_) => vec![value],


### PR DESCRIPTION
to allow - add an optional header - X-P-Custom-Partition in stream creation API with comma separated values 
the custom-partition will be stored in the stream.json file at the time of ingestion, 
below validations are put in place -
1. all events in the batch have the custom partitions
2. max of 3 partitions are allowed
3. custom partition values should not have a '.' in the log event
4. custom partition value should not be empty in the log event

Prefixes will be created in the alphabetical order of the custom partition fields

sort order in the parquet will be p_timestamp/time_partition and the custom partition fields same sort order will be reflected in the manifest file
