### PR TITLE
Add Users API for Dashboads, caching and filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@ env-file
 parseable
 parseable_*
 parseable-env-secret
-cache*
+cache
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -9,13 +9,14 @@ build = "build.rs"
 
 [dependencies]
 ### apache arrow/datafusion dependencies
+# arrow = "51.0.0"
 arrow-schema = { version = "51.0.0", features = ["serde"] }
 arrow-array = { version = "51.0.0" }
 arrow-json = "51.0.0"
 arrow-ipc = { version = "51.0.0", features = ["zstd"] }
 arrow-select = "51.0.0"
 datafusion = "37.1.0"
-object_store = { version = "0.9.1", features = ["cloud", "aws"] }
+object_store = { version = "0.9.1", features = ["cloud", "aws"] }  # cannot update object_store as datafusion has not caught up
 parquet = "51.0.0"
 arrow-flight = { version = "51.0.0", features = [ "tls" ] }
 tonic = {version = "0.11.0", features = ["tls", "transport", "gzip", "zstd"] }
@@ -72,11 +73,11 @@ relative-path = { version = "1.7", features = ["serde"] }
 reqwest = { version = "0.11.27", default_features = false, features = [
   "rustls-tls",
   "json",
-] }
-rustls = "0.22.4"
+] }         # cannot update cause rustls is not latest `see rustls`
+rustls = "0.22.4"       # cannot update to 0.23 actix has not caught up yet
 rustls-pemfile = "2.1.2"
 semver = "1.0"
-serde = { version = "1.0", features = ["rc"] }
+serde = { version = "1.0", features = ["rc", "derive"] }
 serde_json = "1.0"
 static-files = "0.2"
 sysinfo = "0.30.11"

--- a/server/src/catalog.rs
+++ b/server/src/catalog.rs
@@ -230,8 +230,7 @@ async fn create_manifest(
                 .ok_or(IOError::new(
                     ErrorKind::Other,
                     "Failed to create upper bound for manifest",
-                ))
-                .map_err(ObjectStorageError::IoError)?,
+                ))?,
         )
         .and_utc();
 

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -92,6 +92,12 @@ pub struct Cli {
 
     /// port use by airplane(flight query service)
     pub flight_port: u16,
+
+    /// to query cached data
+    pub query_cache_path: Option<PathBuf>,
+
+    /// Size for local cache
+    pub query_cache_size: u64,
 }
 
 impl Cli {
@@ -102,6 +108,8 @@ impl Cli {
     pub const DOMAIN_URI: &'static str = "origin";
     pub const STAGING: &'static str = "local-staging-path";
     pub const CACHE: &'static str = "cache-path";
+    pub const QUERY_CACHE: &'static str = "query-cache-path";
+    pub const QUERY_CACHE_SIZE: &'static str = "query-cache-size";
     pub const CACHE_SIZE: &'static str = "cache-size";
     pub const USERNAME: &'static str = "username";
     pub const PASSWORD: &'static str = "password";
@@ -191,6 +199,25 @@ impl Cli {
                     .next_line_help(true),
             )
 
+             .arg(
+                Arg::new(Self::QUERY_CACHE)
+                    .long(Self::QUERY_CACHE)
+                    .env("P_QUERY_CACHE_DIR")
+                    .value_name("DIR")
+                    .value_parser(validation::canonicalize_path)
+                    .help("Local path on this device to be used for caching data")
+                    .next_line_help(true),
+            )
+             .arg(
+                Arg::new(Self::QUERY_CACHE_SIZE)
+                    .long(Self::QUERY_CACHE_SIZE)
+                    .env("P_QUERY_CACHE_SIZE")
+                    .value_name("size")
+                    .default_value("1GiB")
+                    .value_parser(validation::cache_size)
+                    .help("Maximum allowed cache size for all streams combined (In human readable format, e.g 1GiB, 2GiB, 100MB)")
+                    .next_line_help(true),
+            )
             .arg(
                 Arg::new(Self::USERNAME)
                     .long(Self::USERNAME)
@@ -372,6 +399,7 @@ impl FromArgMatches for Cli {
 
     fn update_from_arg_matches(&mut self, m: &clap::ArgMatches) -> Result<(), clap::Error> {
         self.local_cache_path = m.get_one::<PathBuf>(Self::CACHE).cloned();
+        self.query_cache_path = m.get_one::<PathBuf>(Self::QUERY_CACHE).cloned();
         self.tls_cert_path = m.get_one::<PathBuf>(Self::TLS_CERT).cloned();
         self.tls_key_path = m.get_one::<PathBuf>(Self::TLS_KEY).cloned();
         self.domain_address = m.get_one::<Url>(Self::DOMAIN_URI).cloned();
@@ -394,6 +422,10 @@ impl FromArgMatches for Cli {
             .get_one::<u64>(Self::CACHE_SIZE)
             .cloned()
             .expect("default value for cache size");
+        self.query_cache_size = m
+            .get_one(Self::QUERY_CACHE_SIZE)
+            .cloned()
+            .expect("default value for query cache size");
         self.username = m
             .get_one::<String>(Self::USERNAME)
             .cloned()

--- a/server/src/event/writer/file_writer.rs
+++ b/server/src/event/writer/file_writer.rs
@@ -49,10 +49,7 @@ impl FileWriter {
     ) -> Result<(), StreamWriterError> {
         match self.get_mut(schema_key) {
             Some(writer) => {
-                writer
-                    .writer
-                    .write(record)
-                    .map_err(StreamWriterError::Writer)?;
+                writer.writer.write(record)?;
             }
             // entry is not present thus we create it
             None => {
@@ -100,8 +97,6 @@ fn init_new_stream_writer_file(
     let mut stream_writer = StreamWriter::try_new(file, &record.schema())
         .expect("File and RecordBatch both are checked");
 
-    stream_writer
-        .write(record)
-        .map_err(StreamWriterError::Writer)?;
+    stream_writer.write(record)?;
     Ok((path, stream_writer))
 }

--- a/server/src/handlers.rs
+++ b/server/src/handlers.rs
@@ -23,6 +23,8 @@ pub mod livetail;
 const PREFIX_TAGS: &str = "x-p-tag-";
 const PREFIX_META: &str = "x-p-meta-";
 const STREAM_NAME_HEADER_KEY: &str = "x-p-stream";
+const CACHE_RESULTS_HEADER_KEY: &str = "x-p-cache-results";
+const CACHE_VIEW_HEADER_KEY: &str = "x-p-show-cached";
 const LOG_SOURCE_KEY: &str = "x-p-log-source";
 const TIME_PARTITION_KEY: &str = "x-p-time-partition";
 const TIME_PARTITION_LIMIT_KEY: &str = "x-p-time-partition-limit";

--- a/server/src/handlers.rs
+++ b/server/src/handlers.rs
@@ -25,6 +25,7 @@ const PREFIX_META: &str = "x-p-meta-";
 const STREAM_NAME_HEADER_KEY: &str = "x-p-stream";
 const CACHE_RESULTS_HEADER_KEY: &str = "x-p-cache-results";
 const CACHE_VIEW_HEADER_KEY: &str = "x-p-show-cached";
+const USER_ID_HEADER_KEY: &str = "x-p-user-id";
 const LOG_SOURCE_KEY: &str = "x-p-log-source";
 const TIME_PARTITION_KEY: &str = "x-p-time-partition";
 const TIME_PARTITION_LIMIT_KEY: &str = "x-p-time-partition-limit";

--- a/server/src/handlers/airplane.rs
+++ b/server/src/handlers/airplane.rs
@@ -252,7 +252,8 @@ impl FlightService for AirServiceImpl {
             query.end.to_rfc3339(),
             ticket.query,
         )
-        .await {
+        .await
+        {
             log::error!("{}", err);
         };
 

--- a/server/src/handlers/airplane.rs
+++ b/server/src/handlers/airplane.rs
@@ -17,7 +17,6 @@
  */
 
 use arrow_array::RecordBatch;
-use arrow_flight::encode::FlightDataEncoderBuilder;
 use arrow_flight::flight_service_server::FlightServiceServer;
 use arrow_flight::PollInfo;
 use arrow_schema::ArrowError;
@@ -25,7 +24,6 @@ use arrow_schema::ArrowError;
 use datafusion::common::tree_node::TreeNode;
 use serde_json::json;
 use std::net::SocketAddr;
-use std::sync::Arc;
 use std::time::Instant;
 use tonic::codec::CompressionEncoding;
 
@@ -34,20 +32,22 @@ use futures_util::{Future, TryFutureExt};
 use tonic::transport::{Identity, Server, ServerTlsConfig};
 use tonic_web::GrpcWebLayer;
 
-use crate::event::commit_schema;
 use crate::handlers::http::cluster::get_ingestor_info;
-use crate::handlers::http::fetch_schema;
 
+use crate::handlers::{CACHE_RESULTS_HEADER_KEY, CACHE_VIEW_HEADER_KEY, USER_ID_HEADER_KEY};
 use crate::metrics::QUERY_EXECUTE_TIME;
-use crate::option::{Mode, CONFIG};
+use crate::option::CONFIG;
 
 use crate::handlers::livetail::cross_origin_config;
 
-use crate::handlers::http::query::{authorize_and_set_filter_tags, into_query};
+use crate::handlers::http::query::{
+    authorize_and_set_filter_tags, into_query, put_results_in_cache, update_schema_when_distributed,
+};
 use crate::query::{TableScanVisitor, QUERY_SESSION};
-use crate::storage::object_storage::commit_schema_to_storage;
+use crate::querycache::QueryCacheManager;
 use crate::utils::arrow::flight::{
-    append_temporary_events, get_query_from_ticket, run_do_get_rpc, send_to_ingester,
+    append_temporary_events, get_query_from_ticket, into_flight_data, run_do_get_rpc,
+    send_to_ingester,
 };
 use arrow_flight::{
     flight_service_server::FlightService, Action, ActionType, Criteria, Empty, FlightData,
@@ -55,12 +55,14 @@ use arrow_flight::{
     SchemaResult, Ticket,
 };
 use arrow_ipc::writer::IpcWriteOptions;
-use futures::{stream, TryStreamExt};
+use futures::stream;
 use tonic::{Request, Response, Status, Streaming};
 
 use crate::handlers::livetail::extract_session_key;
 use crate::metadata::STREAM_INFO;
 use crate::rbac::Users;
+
+use super::http::query::get_results_from_cache;
 
 #[derive(Clone, Debug)]
 pub struct AirServiceImpl {}
@@ -130,7 +132,7 @@ impl FlightService for AirServiceImpl {
     async fn do_get(&self, req: Request<Ticket>) -> Result<Response<Self::DoGetStream>, Status> {
         let key = extract_session_key(req.metadata())?;
 
-        let ticket = get_query_from_ticket(req)?;
+        let ticket = get_query_from_ticket(&req)?;
 
         log::info!("query requested to airplane: {:?}", ticket);
 
@@ -150,31 +152,56 @@ impl FlightService for AirServiceImpl {
         let mut visitor = TableScanVisitor::default();
         let _ = raw_logical_plan.visit(&mut visitor);
 
-        let tables = visitor.into_inner();
+        let streams = visitor.into_inner();
 
-        if CONFIG.parseable.mode == Mode::Query {
-            // using http to get the schema. may update to use flight later
-            for table in tables {
-                if let Ok(new_schema) = fetch_schema(&table).await {
-                    // commit schema merges the schema internally and updates the schema in storage.
-                    commit_schema_to_storage(&table, new_schema.clone())
-                        .await
-                        .map_err(|err| Status::internal(err.to_string()))?;
-                    commit_schema(&table, Arc::new(new_schema))
-                        .map_err(|err| Status::internal(err.to_string()))?;
-                }
-            }
+        let query_cache_manager = QueryCacheManager::global(CONFIG.parseable.query_cache_size)
+            .await
+            .unwrap_or(None);
+
+        let cache_results = req
+            .metadata()
+            .get(CACHE_RESULTS_HEADER_KEY)
+            .and_then(|value| value.to_str().ok()); // I dont think we need to own this.
+
+        let show_cached = req
+            .metadata()
+            .get(CACHE_VIEW_HEADER_KEY)
+            .and_then(|value| value.to_str().ok());
+
+        let user_id = req
+            .metadata()
+            .get(USER_ID_HEADER_KEY)
+            .and_then(|value| value.to_str().ok());
+        let stream_name = streams
+            .first()
+            .ok_or_else(|| Status::aborted("Malformed SQL Provided, Table Name Not Found"))?
+            .to_owned();
+
+        // send the cached results
+        if let Ok(cache_results) = get_results_from_cache(
+            show_cached,
+            query_cache_manager,
+            &stream_name,
+            user_id,
+            &ticket.start_time,
+            &ticket.end_time,
+            &ticket.query,
+            ticket.send_null,
+            ticket.fields,
+        )
+        .await
+        {
+            return cache_results.into_flight();
         }
+
+        update_schema_when_distributed(streams)
+            .await
+            .map_err(|err| Status::internal(err.to_string()))?;
 
         // map payload to query
         let mut query = into_query(&ticket, &session_state)
             .await
             .map_err(|_| Status::internal("Failed to parse query"))?;
-
-        // if table name is not present it is a Malformed Query
-        let stream_name = query
-            .first_table_name()
-            .ok_or_else(|| Status::invalid_argument("Malformed Query"))?;
 
         let event =
             if send_to_ingester(query.start.timestamp_millis(), query.end.timestamp_millis()) {
@@ -210,10 +237,22 @@ impl FlightService for AirServiceImpl {
             Status::permission_denied("User Does not have permission to access this")
         })?;
         let time = Instant::now();
-        let (results, _) = query
+        let (records, _) = query
             .execute(stream_name.clone())
             .await
             .map_err(|err| Status::internal(err.to_string()))?;
+
+        put_results_in_cache(
+            cache_results,
+            user_id,
+            query_cache_manager,
+            &stream_name,
+            &records,
+            query.start.to_rfc3339(),
+            query.end.to_rfc3339(),
+            ticket.query,
+        )
+        .await;
 
         /*
         * INFO: No returning the schema with the data.
@@ -226,18 +265,7 @@ impl FlightService for AirServiceImpl {
             .collect::<Vec<_>>();
         let schema = Schema::try_merge(schemas).map_err(|err| Status::internal(err.to_string()))?;
          */
-        let input_stream = futures::stream::iter(results.into_iter().map(Ok));
-        let write_options = IpcWriteOptions::default()
-            .try_with_compression(Some(arrow_ipc::CompressionType(1)))
-            .map_err(|err| Status::failed_precondition(err.to_string()))?;
-
-        let flight_data_stream = FlightDataEncoderBuilder::new()
-            .with_max_flight_data_size(usize::MAX)
-            .with_options(write_options)
-            // .with_schema(schema.into())
-            .build(input_stream);
-
-        let flight_data_stream = flight_data_stream.map_err(|err| Status::unknown(err.to_string()));
+        let out = into_flight_data(records);
 
         if let Some(event) = event {
             event.clear(&stream_name);
@@ -248,9 +276,7 @@ impl FlightService for AirServiceImpl {
             .with_label_values(&[&format!("flight-query-{}", stream_name)])
             .observe(time);
 
-        Ok(Response::new(
-            Box::pin(flight_data_stream) as Self::DoGetStream
-        ))
+        out
     }
 
     async fn do_put(

--- a/server/src/handlers/airplane.rs
+++ b/server/src/handlers/airplane.rs
@@ -1,3 +1,21 @@
+/*
+ * Parseable Server (C) 2022 - 2024 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 use arrow_array::RecordBatch;
 use arrow_flight::encode::FlightDataEncoderBuilder;
 use arrow_flight::flight_service_server::FlightServiceServer;

--- a/server/src/handlers/airplane.rs
+++ b/server/src/handlers/airplane.rs
@@ -242,7 +242,7 @@ impl FlightService for AirServiceImpl {
             .await
             .map_err(|err| Status::internal(err.to_string()))?;
 
-        put_results_in_cache(
+        if let Err(err) = put_results_in_cache(
             cache_results,
             user_id,
             query_cache_manager,
@@ -252,7 +252,9 @@ impl FlightService for AirServiceImpl {
             query.end.to_rfc3339(),
             ticket.query,
         )
-        .await;
+        .await {
+            log::error!("{}", err);
+        };
 
         /*
         * INFO: No returning the schema with the data.

--- a/server/src/handlers/http.rs
+++ b/server/src/handlers/http.rs
@@ -39,6 +39,7 @@ mod otel;
 pub(crate) mod query;
 pub(crate) mod rbac;
 pub(crate) mod role;
+pub mod users;
 
 pub const MAX_EVENT_PAYLOAD_SIZE: usize = 10485760;
 pub const API_BASE_PATH: &str = "api";

--- a/server/src/handlers/http.rs
+++ b/server/src/handlers/http.rs
@@ -26,6 +26,7 @@ use crate::option::CONFIG;
 use self::{cluster::get_ingestor_info, query::Query};
 
 pub(crate) mod about;
+mod cache;
 pub mod cluster;
 pub(crate) mod health_check;
 pub(crate) mod ingest;
@@ -40,7 +41,6 @@ pub(crate) mod query;
 pub(crate) mod rbac;
 pub(crate) mod role;
 pub mod users;
-
 pub const MAX_EVENT_PAYLOAD_SIZE: usize = 10485760;
 pub const API_BASE_PATH: &str = "api";
 pub const API_VERSION: &str = "v1";

--- a/server/src/handlers/http/cache.rs
+++ b/server/src/handlers/http/cache.rs
@@ -1,0 +1,95 @@
+/*
+ * Parseable Server (C) 2022 - 2024 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use actix_web::{web, HttpRequest, HttpResponse, Responder};
+use anyhow::anyhow;
+use bytes::Bytes;
+use http::StatusCode;
+use serde_json::json;
+
+use crate::{
+    option::CONFIG,
+    querycache::{CacheMetadata, QueryCacheManager},
+};
+
+use super::ingest::PostError;
+
+pub async fn list(req: HttpRequest) -> Result<impl Responder, PostError> {
+    let stream = req
+        .match_info()
+        .get("stream")
+        .ok_or_else(|| PostError::Invalid(anyhow!("Invalid Stream Name in resource path")))?;
+
+    let user_id = req
+        .match_info()
+        .get("user_id")
+        .ok_or_else(|| PostError::Invalid(anyhow!("Invalid User ID not in Resource path")))?;
+
+    let query_cache_manager = QueryCacheManager::global(CONFIG.parseable.query_cache_size)
+        .await
+        .unwrap_or(None);
+
+    if let Some(query_cache_manager) = query_cache_manager {
+        let cache = query_cache_manager
+            .get_cache(stream, user_id)
+            .await
+            .map_err(PostError::CacheError)?;
+
+        let size = cache.current_size();
+        let queries = cache.queries();
+
+        let out = json!({
+            "current_cache_size": size,
+            "cache": queries
+        });
+
+        Ok((web::Json(out), StatusCode::OK))
+    } else {
+        Err(PostError::Invalid(anyhow!(
+            "Query Caching is not active on server "
+        )))
+    }
+}
+
+pub async fn remove(req: HttpRequest, body: Bytes) -> Result<impl Responder, PostError> {
+    let stream = req
+        .match_info()
+        .get("stream")
+        .ok_or_else(|| PostError::Invalid(anyhow!("Invalid Stream Name in resource path")))?;
+
+    let user_id = req
+        .match_info()
+        .get("user_id")
+        .ok_or_else(|| PostError::Invalid(anyhow!("Invalid User ID not in Resource path")))?;
+
+    let query = serde_json::from_slice::<CacheMetadata>(&body)?;
+
+    let query_cache_manager = QueryCacheManager::global(CONFIG.parseable.query_cache_size)
+        .await
+        .unwrap_or(None);
+
+    if let Some(query_cache_manager) = query_cache_manager {
+        query_cache_manager
+            .remove_from_cache(query, stream, user_id)
+            .await?;
+
+        Ok(HttpResponse::Ok().finish())
+    } else {
+        Err(PostError::Invalid(anyhow!("Query Caching is not enabled")))
+    }
+}

--- a/server/src/handlers/http/cache.rs
+++ b/server/src/handlers/http/cache.rs
@@ -50,11 +50,11 @@ pub async fn list(req: HttpRequest) -> Result<impl Responder, PostError> {
             .await
             .map_err(PostError::CacheError)?;
 
-        let size = cache.current_size();
+        let size = cache.used_cache_size();
         let queries = cache.queries();
 
         let out = json!({
-            "current_cache_size": size,
+            "used_capacity": size,
             "cache": queries
         });
 

--- a/server/src/handlers/http/ingest.rs
+++ b/server/src/handlers/http/ingest.rs
@@ -30,6 +30,7 @@ use crate::handlers::{
     LOG_SOURCE_KEY, LOG_SOURCE_KINESIS, LOG_SOURCE_OTEL, PREFIX_META, PREFIX_TAGS, SEPARATOR,
     STREAM_NAME_HEADER_KEY,
 };
+use crate::localcache::CacheError;
 use crate::metadata::{self, STREAM_INFO};
 use crate::option::{Mode, CONFIG};
 use crate::storage::{LogStream, ObjectStorageError};
@@ -445,6 +446,8 @@ pub enum PostError {
     FiltersError(#[from] FiltersError),
     #[error("Error: {0}")]
     DashboardError(#[from] DashboardError),
+    #[error("Error: {0}")]
+    CacheError(#[from] CacheError),
 }
 
 impl actix_web::ResponseError for PostError {
@@ -465,6 +468,7 @@ impl actix_web::ResponseError for PostError {
             PostError::DashboardError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             PostError::FiltersError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             PostError::Error(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            PostError::CacheError(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 

--- a/server/src/handlers/http/ingest.rs
+++ b/server/src/handlers/http/ingest.rs
@@ -170,7 +170,7 @@ async fn push_logs(stream_name: String, req: HttpRequest, body: Bytes) -> Result
     let object_store_format = glob_storage
         .get_object_store_format(&stream_name)
         .await
-        .map_err(|_err| PostError::StreamNotFound(stream_name.clone()))?;
+        .map_err(|_| PostError::StreamNotFound(stream_name.clone()))?;
 
     let time_partition = object_store_format.time_partition;
     let time_partition_limit = object_store_format.time_partition_limit;
@@ -433,6 +433,9 @@ pub enum PostError {
     #[error("{0}")]
     CreateStream(#[from] CreateStreamError),
     #[error("Error: {0}")]
+    Error(std::io::Error),
+    #[allow(unused)]
+    #[error("Error: {0}")]
     CustomError(String),
     #[error("Error: {0}")]
     NetworkError(#[from] reqwest::Error),
@@ -461,6 +464,7 @@ impl actix_web::ResponseError for PostError {
             PostError::ObjectStorageError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             PostError::DashboardError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             PostError::FiltersError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            PostError::Error(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 

--- a/server/src/handlers/http/ingest.rs
+++ b/server/src/handlers/http/ingest.rs
@@ -18,6 +18,7 @@
 
 use super::cluster::INTERNAL_STREAM_NAME;
 use super::logstream::error::CreateStreamError;
+use super::users::dashboards::DashboardError;
 use super::{kinesis, otel};
 use crate::event::{
     self,
@@ -436,6 +437,9 @@ pub enum PostError {
     NetworkError(#[from] reqwest::Error),
     #[error("ObjectStorageError: {0}")]
     ObjectStorageError(#[from] ObjectStorageError),
+
+    #[error("Error: {0}")]
+    DashboardError(#[from] DashboardError),
 }
 
 impl actix_web::ResponseError for PostError {
@@ -453,6 +457,7 @@ impl actix_web::ResponseError for PostError {
             PostError::CustomError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             PostError::NetworkError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             PostError::ObjectStorageError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            PostError::DashboardError(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 

--- a/server/src/handlers/http/ingest.rs
+++ b/server/src/handlers/http/ingest.rs
@@ -19,6 +19,7 @@
 use super::cluster::INTERNAL_STREAM_NAME;
 use super::logstream::error::CreateStreamError;
 use super::users::dashboards::DashboardError;
+use super::users::filters::FiltersError;
 use super::{kinesis, otel};
 use crate::event::{
     self,
@@ -437,7 +438,8 @@ pub enum PostError {
     NetworkError(#[from] reqwest::Error),
     #[error("ObjectStorageError: {0}")]
     ObjectStorageError(#[from] ObjectStorageError),
-
+    #[error("Error: {0}")]
+    FiltersError(#[from] FiltersError),
     #[error("Error: {0}")]
     DashboardError(#[from] DashboardError),
 }
@@ -458,6 +460,7 @@ impl actix_web::ResponseError for PostError {
             PostError::NetworkError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             PostError::ObjectStorageError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             PostError::DashboardError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            PostError::FiltersError(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 

--- a/server/src/handlers/http/ingest.rs
+++ b/server/src/handlers/http/ingest.rs
@@ -433,8 +433,6 @@ pub enum PostError {
     Invalid(#[from] anyhow::Error),
     #[error("{0}")]
     CreateStream(#[from] CreateStreamError),
-    #[error("Error: {0}")]
-    Error(std::io::Error),
     #[allow(unused)]
     #[error("Error: {0}")]
     CustomError(String),
@@ -467,7 +465,6 @@ impl actix_web::ResponseError for PostError {
             PostError::ObjectStorageError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             PostError::DashboardError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             PostError::FiltersError(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            PostError::Error(_) => StatusCode::INTERNAL_SERVER_ERROR,
             PostError::CacheError(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }

--- a/server/src/handlers/http/modal/query_server.rs
+++ b/server/src/handlers/http/modal/query_server.rs
@@ -22,6 +22,8 @@ use crate::handlers::http::middleware::RouteExt;
 use crate::handlers::http::{base_path, cross_origin_config, API_BASE_PATH, API_VERSION};
 
 use crate::rbac::role::Action;
+use crate::users::dashboards::DASHBOARDS;
+use crate::users::filters::FILTERS;
 use crate::sync;
 use crate::{analytics, banner, metadata, metrics, migration, rbac, storage};
 use actix_web::web;
@@ -175,6 +177,10 @@ impl QueryServer {
         if let Err(e) = metadata::STREAM_INFO.load(&*storage).await {
             log::warn!("could not populate local metadata. {:?}", e);
         }
+
+        FILTERS.load().await?;
+        DASHBOARDS.load().await?;
+
 
         // load data from stats back to prometheus metrics
         metrics::fetch_stats_from_storage().await;

--- a/server/src/handlers/http/modal/query_server.rs
+++ b/server/src/handlers/http/modal/query_server.rs
@@ -121,6 +121,7 @@ impl QueryServer {
                 web::scope(&base_path())
                     // POST "/query" ==> Get results of the SQL query passed in request body
                     .service(Server::get_query_factory())
+                    .service(Server::get_cache_webscope())
                     .service(Server::get_liveness_factory())
                     .service(Server::get_readiness_factory())
                     .service(Server::get_about_factory())

--- a/server/src/handlers/http/modal/query_server.rs
+++ b/server/src/handlers/http/modal/query_server.rs
@@ -125,6 +125,7 @@ impl QueryServer {
                     .service(Server::get_logstream_webscope())
                     .service(Server::get_user_webscope())
                     .service(Server::get_dashboards_webscope())
+                    .service(Server::get_filters_webscope())
                     .service(Server::get_llm_webscope())
                     .service(Server::get_oauth_webscope(oidc_client))
                     .service(Server::get_user_role_webscope())

--- a/server/src/handlers/http/modal/query_server.rs
+++ b/server/src/handlers/http/modal/query_server.rs
@@ -124,6 +124,7 @@ impl QueryServer {
                     .service(Server::get_about_factory())
                     .service(Server::get_logstream_webscope())
                     .service(Server::get_user_webscope())
+                    .service(Server::get_dashboards_webscope())
                     .service(Server::get_llm_webscope())
                     .service(Server::get_oauth_webscope(oidc_client))
                     .service(Server::get_user_role_webscope())

--- a/server/src/handlers/http/modal/query_server.rs
+++ b/server/src/handlers/http/modal/query_server.rs
@@ -181,7 +181,6 @@ impl QueryServer {
         FILTERS.load().await?;
         DASHBOARDS.load().await?;
 
-
         // load data from stats back to prometheus metrics
         metrics::fetch_stats_from_storage().await;
         metrics::reset_daily_metric_from_global();

--- a/server/src/handlers/http/modal/query_server.rs
+++ b/server/src/handlers/http/modal/query_server.rs
@@ -22,9 +22,9 @@ use crate::handlers::http::middleware::RouteExt;
 use crate::handlers::http::{base_path, cross_origin_config, API_BASE_PATH, API_VERSION};
 
 use crate::rbac::role::Action;
+use crate::sync;
 use crate::users::dashboards::DASHBOARDS;
 use crate::users::filters::FILTERS;
-use crate::sync;
 use crate::{analytics, banner, metadata, metrics, migration, rbac, storage};
 use actix_web::web;
 use actix_web::web::ServiceConfig;

--- a/server/src/handlers/http/modal/server.rs
+++ b/server/src/handlers/http/modal/server.rs
@@ -24,6 +24,7 @@ use crate::handlers::http::base_path;
 use crate::handlers::http::health_check;
 use crate::handlers::http::query;
 use crate::handlers::http::users::dashboards;
+use crate::handlers::http::users::filters;
 use crate::handlers::http::API_BASE_PATH;
 use crate::handlers::http::API_VERSION;
 use crate::localcache::LocalCacheManager;
@@ -141,6 +142,7 @@ impl Server {
                     .service(Self::get_logstream_webscope())
                     .service(Self::get_user_webscope())
                     .service(Self::get_dashboards_webscope())
+                    .service(Self::get_filters_webscope())
                     .service(Self::get_llm_webscope())
                     .service(Self::get_oauth_webscope(oidc_client))
                     .service(Self::get_user_role_webscope()),
@@ -176,6 +178,33 @@ impl Server {
                                 web::delete()
                                     .to(dashboards::delete)
                                     .authorize(Action::DeleteDashboard),
+                            ),
+                    ),
+                ),
+        )
+    }
+
+    // get the filters web scope
+    pub fn get_filters_webscope() -> Scope {
+        web::scope("/filters").service(
+            web::scope("/{user_id}")
+                .service(
+                    web::resource("")
+                        .route(web::get().to(filters::list).authorize(Action::ListFilter)),
+                )
+                .service(
+                    web::scope("/{filter_id}").service(
+                        web::resource("")
+                            .route(web::get().to(filters::get).authorize(Action::GetFilter))
+                            .route(
+                                web::post()
+                                    .to(filters::post)
+                                    .authorize(Action::CreateFilter),
+                            )
+                            .route(
+                                web::delete()
+                                    .to(filters::delete)
+                                    .authorize(Action::DeleteFilter),
                             ),
                     ),
                 ),

--- a/server/src/handlers/http/modal/server.rs
+++ b/server/src/handlers/http/modal/server.rs
@@ -34,6 +34,8 @@ use crate::migration;
 use crate::rbac;
 use crate::storage;
 use crate::sync;
+use crate::users::dashboards::DASHBOARDS;
+use crate::users::filters::FILTERS;
 use std::sync::Arc;
 
 use actix_web::web::resource;
@@ -475,6 +477,10 @@ impl Server {
         if let Err(err) = metadata::STREAM_INFO.load(&*storage).await {
             log::warn!("could not populate local metadata. {:?}", err);
         }
+
+        FILTERS.load().await?;
+        DASHBOARDS.load().await?;
+
 
         metrics::fetch_stats_from_storage().await;
         metrics::reset_daily_metric_from_global();

--- a/server/src/handlers/http/modal/server.rs
+++ b/server/src/handlers/http/modal/server.rs
@@ -481,7 +481,6 @@ impl Server {
         FILTERS.load().await?;
         DASHBOARDS.load().await?;
 
-
         metrics::fetch_stats_from_storage().await;
         metrics::reset_daily_metric_from_global();
         storage::retention::load_retention_from_global();

--- a/server/src/handlers/http/query.rs
+++ b/server/src/handlers/http/query.rs
@@ -141,7 +141,8 @@ pub async fn query(req: HttpRequest, query_request: Query) -> Result<impl Respon
         query.end.to_rfc3339(),
         query_request.query,
     )
-    .await {
+    .await
+    {
         log::error!("{}", err);
     };
 
@@ -198,10 +199,11 @@ pub async fn put_results_in_cache(
         }
         // do cache
         (Some(should_cache), Some(query_cache_manager)) => {
-
             if should_cache != "true" {
                 log::error!("value of cache results header is false");
-                return Err(QueryError::CacheError(CacheError::Other("should not cache results")));
+                return Err(QueryError::CacheError(CacheError::Other(
+                    "should not cache results",
+                )));
             }
 
             let user_id = user_id.ok_or(CacheError::Other("User Id not provided"))?;
@@ -222,9 +224,7 @@ pub async fn put_results_in_cache(
             // fallthrough
             Ok(())
         }
-        (None, _) => {
-            Ok(())
-        }
+        (None, _) => Ok(()),
     }
 }
 
@@ -250,7 +250,9 @@ pub async fn get_results_from_cache(
         (Some(should_show), Some(query_cache_manager)) => {
             if should_show != "true" {
                 log::error!("value of show cached header is false");
-                return Err(QueryError::CacheError(CacheError::Other("should not return cached results")));
+                return Err(QueryError::CacheError(CacheError::Other(
+                    "should not return cached results",
+                )));
             }
 
             let user_id =

--- a/server/src/handlers/http/query.rs
+++ b/server/src/handlers/http/query.rs
@@ -53,7 +53,7 @@ use crate::utils::actix::extract_session_key_from_req;
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Query {
-    pub pub query: String,
+    pub query: String,
     pub start_time: String,
     pub end_time: String,
     #[serde(default)]

--- a/server/src/handlers/http/query.rs
+++ b/server/src/handlers/http/query.rs
@@ -290,6 +290,8 @@ pub enum QueryError {
     Execute(#[from] ExecuteError),
     #[error("ObjectStorage Error: {0}")]
     ObjectStorage(#[from] ObjectStorageError),
+    #[error("Cache Error: {0}")]
+    CacheError(#[from] CacheError),
     #[error("Evern Error: {0}")]
     EventError(#[from] EventError),
     #[error("Error: {0}")]

--- a/server/src/handlers/http/query.rs
+++ b/server/src/handlers/http/query.rs
@@ -197,7 +197,13 @@ pub async fn put_results_in_cache(
             Ok(())
         }
         // do cache
-        (Some(_), Some(query_cache_manager)) => {
+        (Some(should_cache), Some(query_cache_manager)) => {
+
+            if should_cache != "true" {
+                log::error!("value of cache results header is false");
+                return Err(QueryError::CacheError(CacheError::Other("should not cache results")));
+            }
+
             let user_id = user_id.ok_or(CacheError::Other("User Id not provided"))?;
 
             if let Err(err) = query_cache_manager
@@ -241,7 +247,12 @@ pub async fn get_results_from_cache(
             );
             None
         }
-        (Some(_), Some(query_cache_manager)) => {
+        (Some(should_show), Some(query_cache_manager)) => {
+            if should_show != "true" {
+                log::error!("value of show cached header is false");
+                return Err(QueryError::CacheError(CacheError::Other("should not return cached results")));
+            }
+
             let user_id =
                 user_id.ok_or_else(|| QueryError::Anyhow(anyhow!("User Id not provided")))?;
 

--- a/server/src/handlers/http/query.rs
+++ b/server/src/handlers/http/query.rs
@@ -43,7 +43,7 @@ use crate::option::{Mode, CONFIG};
 use crate::query::error::ExecuteError;
 use crate::query::Query as LogicalQuery;
 use crate::query::{TableScanVisitor, QUERY_SESSION};
-use crate::querycache::QueryCacheManager;
+use crate::querycache::{CacheMetadata, QueryCacheManager};
 use crate::rbac::role::{Action, Permission};
 use crate::rbac::Users;
 use crate::response::QueryResponse;
@@ -240,9 +240,12 @@ pub async fn get_results_from_cache(
             let mut query_cache = query_cache_manager.get_cache(stream, user_id).await?;
 
             let (start, end) = parse_human_time(start_time, end_time)?;
-            let key = format!("{}-{}-{}", start.to_rfc3339(), end.to_rfc3339(), query);
 
-            let file_path = query_cache.get_file(key);
+            let file_path = query_cache.get_file(CacheMetadata::new(
+                query.to_string(),
+                start.to_rfc3339(),
+                end.to_rfc3339(),
+            ));
             if let Some(file_path) = file_path {
                 let (records, fields) = query_cache.get_cached_records(&file_path).await?;
                 let response = QueryResponse {

--- a/server/src/handlers/http/users/dashboards.rs
+++ b/server/src/handlers/http/users/dashboards.rs
@@ -1,3 +1,21 @@
+/*
+ * Parseable Server (C) 2022 - 2024 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 use crate::{
     handlers::http::ingest::PostError,
     option::CONFIG,

--- a/server/src/handlers/http/users/dashboards.rs
+++ b/server/src/handlers/http/users/dashboards.rs
@@ -24,6 +24,7 @@ use crate::{
 };
 use actix_web::{http::header::ContentType, web, HttpRequest, HttpResponse, Responder};
 use bytes::Bytes;
+
 use http::StatusCode;
 use serde_json::{Error as SerdeError, Value as JsonValue};
 

--- a/server/src/handlers/http/users/dashboards.rs
+++ b/server/src/handlers/http/users/dashboards.rs
@@ -1,0 +1,140 @@
+use crate::{
+    handlers::http::ingest::PostError,
+    option::CONFIG,
+    storage::{object_storage::dashboard_path, ObjectStorageError},
+};
+use actix_web::{http::header::ContentType, web, HttpRequest, HttpResponse, Responder};
+use bytes::Bytes;
+use http::StatusCode;
+use serde_json::{Error as SerdeError, Value as JsonValue};
+
+pub async fn list(req: HttpRequest) -> Result<impl Responder, DashboardError> {
+    let user_id = req
+        .match_info()
+        .get("user_id")
+        .ok_or(DashboardError::Metadata("No User Id Provided"))?;
+
+    // .users/user_id/dashboards/
+    let path = dashboard_path(user_id, "");
+
+    let store = CONFIG.storage().get_object_store();
+    let dashboards = store
+        .get_objects(
+            Some(&path),
+            Box::new(|file_name: String| file_name.ends_with("json")),
+        )
+        .await?;
+
+    let mut dash = vec![];
+    for dashboard in dashboards {
+        dash.push(serde_json::from_slice::<JsonValue>(&dashboard)?)
+    }
+
+    Ok((web::Json(dash), StatusCode::OK))
+}
+
+pub async fn get(req: HttpRequest) -> Result<impl Responder, DashboardError> {
+    let user_id = req
+        .match_info()
+        .get("user_id")
+        .ok_or(DashboardError::Metadata("No User Id Provided"))?;
+
+    let dash_id = req
+        .match_info()
+        .get("dashboard_id")
+        .ok_or(DashboardError::Metadata("No Dashboard Id Provided"))?;
+
+    let dash_file_path = dashboard_path(user_id, &format!("{}.json", dash_id));
+    let resource = CONFIG
+        .storage()
+        .get_object_store()
+        .get_object(&dash_file_path)
+        .await?;
+    let resource = serde_json::from_slice::<JsonValue>(&resource)?;
+
+    Ok((web::Json(resource), StatusCode::OK))
+}
+
+pub async fn post(req: HttpRequest, body: Bytes) -> Result<HttpResponse, PostError> {
+    let user_id = req
+        .match_info()
+        .get("user_id")
+        .ok_or(DashboardError::Metadata("No User Id Provided"))?;
+
+    let dash_id = req
+        .match_info()
+        .get("dashboard_id")
+        .ok_or(DashboardError::Metadata("No Dashboard Id Provided"))?;
+
+    let dash_file_path = dashboard_path(user_id, &format!("{}.json", dash_id));
+
+    let store = CONFIG.storage().get_object_store();
+    store.put_object(&dash_file_path, body).await?;
+
+    Ok(HttpResponse::Ok().finish())
+}
+
+pub async fn delete(req: HttpRequest) -> Result<HttpResponse, PostError> {
+    let user_id = req
+        .match_info()
+        .get("user_id")
+        .ok_or(DashboardError::Metadata("No User Id Provided"))?;
+
+    let dash_id = req
+        .match_info()
+        .get("dashboard_id")
+        .ok_or(DashboardError::Metadata("No Dashboard Id Provided"))?;
+
+    let dash_file_path = dashboard_path(user_id, &format!("{}.json", dash_id));
+
+    let store = CONFIG.storage().get_object_store();
+    store.delete_object(&dash_file_path).await?;
+
+    Ok(HttpResponse::Ok().finish())
+}
+
+// #[derive(Debug, Serialize, Deserialize)]
+// pub struct Dashboard {
+//     version: String,
+//     name: String,
+//     id: String,
+//     time-filter: `type_not_defined`
+//     refresh_interval: u64,
+//     pannels: Vec<Pannel>,
+// }
+//
+// #[derive(Debug, Serialize, Deserialize)]
+// pub struct Pannel {
+//     stream_name: String,
+//     query: String,
+//     chart_type: String,
+//     columns: Vec<String>,
+//     headers: Vec<String>,
+//     dimensions: (u64, u64),
+// }
+
+#[derive(Debug, thiserror::Error)]
+pub enum DashboardError {
+    #[error("Failed to connect to storage: {0}")]
+    ObjectStorage(#[from] ObjectStorageError),
+    #[error("Serde Error: {0}")]
+    Serde(#[from] SerdeError),
+    #[error("Cannot perform this operation: {0}")]
+    Metadata(&'static str),
+}
+
+impl actix_web::ResponseError for DashboardError {
+    fn status_code(&self) -> http::StatusCode {
+        match self {
+            Self::ObjectStorage(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::Serde(_) => StatusCode::BAD_REQUEST,
+            Self::Metadata(_) => StatusCode::BAD_REQUEST,
+        }
+    }
+
+    fn error_response(&self) -> actix_web::HttpResponse<actix_web::body::BoxBody> {
+        actix_web::HttpResponse::build(self.status_code())
+            .insert_header(ContentType::plaintext())
+            .body(self.to_string())
+    }
+}

--- a/server/src/handlers/http/users/dashboards.rs
+++ b/server/src/handlers/http/users/dashboards.rs
@@ -98,7 +98,7 @@ pub async fn delete(req: HttpRequest) -> Result<HttpResponse, PostError> {
 //     version: String,
 //     name: String,
 //     id: String,
-//     time-filter: `type_not_defined`
+//     time_filter: TimeFilter
 //     refresh_interval: u64,
 //     pannels: Vec<Pannel>,
 // }
@@ -111,6 +111,12 @@ pub async fn delete(req: HttpRequest) -> Result<HttpResponse, PostError> {
 //     columns: Vec<String>,
 //     headers: Vec<String>,
 //     dimensions: (u64, u64),
+// }
+//
+// #[derive(Debug, Serialize, Deserialize)]
+// pub struct TimeFilter {
+//      to: String,
+//      from: String
 // }
 
 #[derive(Debug, thiserror::Error)]

--- a/server/src/handlers/http/users/filters.rs
+++ b/server/src/handlers/http/users/filters.rs
@@ -1,3 +1,21 @@
+/*
+ * Parseable Server (C) 2022 - 2024 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 use crate::{
     handlers::{http::ingest::PostError, STREAM_NAME_HEADER_KEY},
     option::CONFIG,

--- a/server/src/handlers/http/users/filters.rs
+++ b/server/src/handlers/http/users/filters.rs
@@ -1,0 +1,165 @@
+use crate::{
+    handlers::{http::ingest::PostError, STREAM_NAME_HEADER_KEY},
+    option::CONFIG,
+    storage::{object_storage::filter_path, ObjectStorageError},
+};
+use actix_web::{http::header::ContentType, web, HttpRequest, HttpResponse, Responder};
+use bytes::Bytes;
+use http::StatusCode;
+use serde_json::{Error as SerdeError, Value as JsonValue};
+
+pub async fn list(req: HttpRequest) -> Result<impl Responder, FiltersError> {
+    let user_id = req
+        .match_info()
+        .get("user_id")
+        .ok_or(FiltersError::Metadata("No User Id Provided"))?;
+
+    let stream_name = req
+        .headers()
+        .iter()
+        .find(|&(key, _)| key == STREAM_NAME_HEADER_KEY)
+        .ok_or_else(|| FiltersError::Metadata("Stream Name Not Provided"))?
+        .1
+        .to_str()
+        .map_err(|_| FiltersError::Metadata("Non ASCII Stream Name Provided"))?;
+
+    // .users/user_id/filters/stream_name/filter_id
+    let path = filter_path(user_id, stream_name, "");
+
+    let store = CONFIG.storage().get_object_store();
+    let filters = store
+        .get_objects(
+            Some(&path),
+            Box::new(|file_name: String| file_name.ends_with("json")),
+        )
+        .await?;
+
+    let mut filt = vec![];
+    for filter in filters {
+        filt.push(serde_json::from_slice::<JsonValue>(&filter)?)
+    }
+
+    Ok((web::Json(filt), StatusCode::OK))
+}
+
+pub async fn get(req: HttpRequest) -> Result<impl Responder, FiltersError> {
+    let user_id = req
+        .match_info()
+        .get("user_id")
+        .ok_or(FiltersError::Metadata("No User Id Provided"))?;
+
+    let filt_id = req
+        .match_info()
+        .get("filter_id")
+        .ok_or(FiltersError::Metadata("No Filter Id Provided"))?;
+
+    let stream_name = req
+        .headers()
+        .iter()
+        .find(|&(key, _)| key == STREAM_NAME_HEADER_KEY)
+        .ok_or_else(|| FiltersError::Metadata("Stream Name Not Provided"))?
+        .1
+        .to_str()
+        .map_err(|_| FiltersError::Metadata("Non ASCII Stream Name Provided"))?;
+
+    let path = filter_path(user_id, stream_name, &format!("{}.json", filt_id));
+    let resource = CONFIG
+        .storage()
+        .get_object_store()
+        .get_object(&path)
+        .await?;
+
+    let resource = serde_json::from_slice::<JsonValue>(&resource)?;
+
+    Ok((web::Json(resource), StatusCode::OK))
+}
+
+pub async fn post(req: HttpRequest, body: Bytes) -> Result<HttpResponse, PostError> {
+    let user_id = req
+        .match_info()
+        .get("user_id")
+        .ok_or(FiltersError::Metadata("No User Id Provided"))?;
+
+    let filt_id = req
+        .match_info()
+        .get("filter_id")
+        .ok_or(FiltersError::Metadata("No Filter Id Provided"))?;
+
+    let stream_name = req
+        .headers()
+        .iter()
+        .find(|&(key, _)| key == STREAM_NAME_HEADER_KEY)
+        .ok_or_else(|| FiltersError::Metadata("Stream Name Not Provided"))?
+        .1
+        .to_str()
+        .map_err(|_| FiltersError::Metadata("Non ASCII Stream Name Provided"))?;
+
+    let path = filter_path(user_id, stream_name, &format!("{}.json", filt_id));
+
+    let store = CONFIG.storage().get_object_store();
+    store.put_object(&path, body).await?;
+
+    Ok(HttpResponse::Ok().finish())
+}
+
+pub async fn delete(req: HttpRequest) -> Result<HttpResponse, PostError> {
+    let user_id = req
+        .match_info()
+        .get("user_id")
+        .ok_or(FiltersError::Metadata("No User Id Provided"))?;
+
+    let filt_id = req
+        .match_info()
+        .get("filter_id")
+        .ok_or(FiltersError::Metadata("No Filter Id Provided"))?;
+
+    let stream_name = req
+        .headers()
+        .iter()
+        .find(|&(key, _)| key == STREAM_NAME_HEADER_KEY)
+        .ok_or_else(|| FiltersError::Metadata("Stream Name Not Provided"))?
+        .1
+        .to_str()
+        .map_err(|_| FiltersError::Metadata("Non ASCII Stream Name Provided"))?;
+
+    let path = filter_path(user_id, stream_name, &format!("{}.json", filt_id));
+    let store = CONFIG.storage().get_object_store();
+    store.delete_object(&path).await?;
+
+    Ok(HttpResponse::Ok().finish())
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum FiltersError {
+    #[error("Failed to connect to storage: {0}")]
+    ObjectStorage(#[from] ObjectStorageError),
+    #[error("Serde Error: {0}")]
+    Serde(#[from] SerdeError),
+    #[error("Cannot perform this operation: {0}")]
+    Metadata(&'static str),
+}
+
+impl actix_web::ResponseError for FiltersError {
+    fn status_code(&self) -> http::StatusCode {
+        match self {
+            Self::ObjectStorage(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::Serde(_) => StatusCode::BAD_REQUEST,
+            Self::Metadata(_) => StatusCode::BAD_REQUEST,
+        }
+    }
+
+    fn error_response(&self) -> actix_web::HttpResponse<actix_web::body::BoxBody> {
+        actix_web::HttpResponse::build(self.status_code())
+            .insert_header(ContentType::plaintext())
+            .body(self.to_string())
+    }
+}
+
+// #[derive(Debug, Serialize, Deserialize)]
+// pub struct Filters {
+//     version: String,
+//     stream_name: String,
+//     filter_name: String,
+//     query: String,
+//     time-filter: `type_not_defined`
+// }

--- a/server/src/handlers/http/users/filters.rs
+++ b/server/src/handlers/http/users/filters.rs
@@ -161,5 +161,5 @@ impl actix_web::ResponseError for FiltersError {
 //     stream_name: String,
 //     filter_name: String,
 //     query: String,
-//     time-filter: `type_not_defined`
+//     time-filter: TimeFilter
 // }

--- a/server/src/handlers/http/users/mod.rs
+++ b/server/src/handlers/http/users/mod.rs
@@ -1,0 +1,4 @@
+pub mod dashboards;
+
+pub const USERS_ROOT_DIR: &str = ".users";
+pub const DASHBOARDS_DIR: &str = "dashboards";

--- a/server/src/handlers/http/users/mod.rs
+++ b/server/src/handlers/http/users/mod.rs
@@ -1,4 +1,6 @@
 pub mod dashboards;
+pub mod filters;
 
 pub const USERS_ROOT_DIR: &str = ".users";
 pub const DASHBOARDS_DIR: &str = "dashboards";
+pub const FILTER_DIR: &str = "filters";

--- a/server/src/handlers/http/users/mod.rs
+++ b/server/src/handlers/http/users/mod.rs
@@ -1,3 +1,21 @@
+/*
+ * Parseable Server (C) 2022 - 2024 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 pub mod dashboards;
 pub mod filters;
 

--- a/server/src/localcache.rs
+++ b/server/src/localcache.rs
@@ -263,4 +263,6 @@ pub enum CacheError {
     MetadataError(#[from] MetadataError),
     #[error("Error: Cache File Does Not Exist")]
     DoesNotExist,
+    #[error("Error: {0}")]
+    Other(&'static str),
 }

--- a/server/src/localcache.rs
+++ b/server/src/localcache.rs
@@ -261,4 +261,6 @@ pub enum CacheError {
     ParquetError(#[from] ParquetError),
     #[error("{0}")]
     MetadataError(#[from] MetadataError),
+    #[error("Error: Cache File Does Not Exist")]
+    DoesNotExist,
 }

--- a/server/src/localcache.rs
+++ b/server/src/localcache.rs
@@ -25,9 +25,10 @@ use human_size::{Byte, Gigibyte, SpecificSize};
 use itertools::{Either, Itertools};
 use object_store::{local::LocalFileSystem, ObjectStore};
 use once_cell::sync::OnceCell;
+use parquet::errors::ParquetError;
 use tokio::{fs, sync::Mutex};
 
-use crate::option::CONFIG;
+use crate::{metadata::error::stream_info::MetadataError, option::CONFIG};
 
 pub const STREAM_CACHE_FILENAME: &str = ".cache.json";
 pub const CACHE_META_FILENAME: &str = ".cache_meta.json";
@@ -256,4 +257,8 @@ pub enum CacheError {
     MoveError(#[from] fs_extra::error::Error),
     #[error("{0}")]
     ObjectStoreError(#[from] object_store::Error),
+    #[error("{0}")]
+    ParquetError(#[from] ParquetError),
+    #[error("{0}")]
+    MetadataError(#[from] MetadataError),
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -32,6 +32,7 @@ mod migration;
 mod oidc;
 mod option;
 mod query;
+mod querycache;
 mod rbac;
 mod response;
 mod static_schema;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -39,6 +39,7 @@ mod static_schema;
 mod stats;
 mod storage;
 mod sync;
+mod users;
 mod utils;
 mod validator;
 

--- a/server/src/metrics/prom_utils.rs
+++ b/server/src/metrics/prom_utils.rs
@@ -1,3 +1,21 @@
+/*
+ * Parseable Server (C) 2022 - 2024 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 use crate::handlers::http::base_path_without_preceding_slash;
 use crate::handlers::http::ingest::PostError;
 use crate::handlers::http::modal::IngestorMetadata;

--- a/server/src/migration.rs
+++ b/server/src/migration.rs
@@ -158,7 +158,7 @@ async fn migration_stream(stream: &str, storage: &dyn ObjectStorage) -> anyhow::
 }
 
 #[inline(always)]
-fn to_bytes(any: &(impl ?Sized + Serialize)) -> Bytes {
+pub fn to_bytes(any: &(impl ?Sized + Serialize)) -> Bytes {
     serde_json::to_vec(any)
         .map(|any| any.into())
         .expect("serialize cannot fail")

--- a/server/src/query.rs
+++ b/server/src/query.rs
@@ -186,8 +186,8 @@ impl TableScanVisitor {
     pub fn into_inner(self) -> Vec<String> {
         self.tables
     }
-    pub fn top(&self) -> &str {
-        self.tables[0].as_ref()
+    pub fn top(&self) -> Option<&str> {
+        self.tables.first().map(|s| s.as_ref())
     }
 }
 

--- a/server/src/query.rs
+++ b/server/src/query.rs
@@ -186,6 +186,9 @@ impl TableScanVisitor {
     pub fn into_inner(self) -> Vec<String> {
         self.tables
     }
+    pub fn top(&self) -> &str {
+        self.tables[0].as_ref()
+    }
 }
 
 impl TreeNodeVisitor for TableScanVisitor {

--- a/server/src/query/listing_table_builder.rs
+++ b/server/src/query/listing_table_builder.rs
@@ -167,7 +167,6 @@ impl ListingTableBuilder {
             })
             .try_collect()
             .await
-            // TODO: make the err map better
             .map_err(|err| DataFusionError::External(Box::new(err)))?;
 
         let mut res = res.into_iter().flatten().collect_vec();

--- a/server/src/query/stream_schema_provider.rs
+++ b/server/src/query/stream_schema_provider.rs
@@ -180,8 +180,8 @@ async fn collect_from_snapshot(
             .map(|item| item.manifest_path)
             .collect(),
     )
-    .await
-    .map_err(DataFusionError::ObjectStore)?;
+    .await?;
+
     let mut manifest_files: Vec<_> = manifest_files
         .into_iter()
         .flat_map(|file| file.files)

--- a/server/src/querycache.rs
+++ b/server/src/querycache.rs
@@ -1,0 +1,338 @@
+use arrow_array::RecordBatch;
+use chrono::Utc;
+use futures::TryStreamExt;
+use futures_util::TryFutureExt;
+use hashlru::Cache;
+use human_size::{Byte, Gigibyte, SpecificSize};
+use itertools::Itertools;
+use object_store::{local::LocalFileSystem, ObjectStore};
+use once_cell::sync::OnceCell;
+use parquet::arrow::{AsyncArrowWriter, ParquetRecordBatchStreamBuilder};
+use std::path::{Path, PathBuf};
+use tokio::fs as AsyncFs;
+use tokio::{fs, sync::Mutex};
+
+use crate::metadata::STREAM_INFO;
+use crate::storage::staging::parquet_writer_props;
+use crate::{localcache::CacheError, option::CONFIG, utils::hostname_unchecked};
+
+pub const QUERY_CACHE_FILENAME: &str = ".cache.json";
+pub const QUERY_CACHE_META_FILENAME: &str = ".cache_meta.json";
+pub const CURRENT_QUERY_CACHE_VERSION: &str = "v1";
+
+#[derive(Default, Clone, serde::Deserialize, serde::Serialize, Debug, Hash, Eq, PartialEq)]
+pub struct CacheMetadata {
+    query: String,
+    pub start_time: String,
+    pub end_time: String,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct QueryCache {
+    version: String,
+    current_size: u64,
+
+    /// Mapping between storage path and cache path.
+    files: Cache<String, PathBuf>,
+}
+
+impl QueryCache {
+    fn new() -> Self {
+        Self {
+            version: CURRENT_QUERY_CACHE_VERSION.to_string(),
+            current_size: 0,
+            files: Cache::new(100),
+        }
+    }
+
+    pub fn get_file(&mut self, key: String) -> Option<PathBuf> {
+        self.files.get(&key).cloned()
+    }
+
+    // read the parquet
+    // return the recordbatches
+    pub async fn get_cached_records(
+        &self,
+        path: &PathBuf,
+    ) -> Result<(Vec<RecordBatch>, Vec<String>), CacheError> {
+        let file = AsyncFs::File::open(path).await?;
+        let builder = ParquetRecordBatchStreamBuilder::new(file).await?;
+        // Build a async parquet reader.
+        let stream = builder.build()?;
+
+        let records = stream.try_collect::<Vec<_>>().await?;
+        let fields = records.first().map_or_else(Vec::new, |record| {
+            record
+                .schema()
+                .fields()
+                .iter()
+                .map(|field| field.name())
+                .cloned()
+                .collect_vec()
+        });
+
+        Ok((records, fields))
+    }
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct QueryCacheMeta {
+    version: String,
+    size_capacity: u64,
+}
+
+impl QueryCacheMeta {
+    fn new() -> Self {
+        Self {
+            version: CURRENT_QUERY_CACHE_VERSION.to_string(),
+            size_capacity: 0,
+        }
+    }
+}
+
+pub struct QueryCacheManager {
+    filesystem: LocalFileSystem,
+    cache_path: PathBuf,
+    cache_capacity: u64,
+    semaphore: Mutex<()>,
+}
+
+impl QueryCacheManager {
+    pub fn gen_file_path(query_staging_path: &str, stream: &str) -> PathBuf {
+        PathBuf::from_iter([
+            query_staging_path,
+            stream,
+            &format!(
+                "{}.{}.parquet",
+                hostname_unchecked(),
+                Utc::now().to_rfc3339()
+            ),
+        ])
+    }
+    pub async fn global(config_capacity: u64) -> Result<Option<&'static Self>, CacheError> {
+        static INSTANCE: OnceCell<QueryCacheManager> = OnceCell::new();
+
+        let cache_path = CONFIG.parseable.query_cache_path.as_ref();
+
+        if cache_path.is_none() {
+            return Ok(None);
+        }
+
+        let cache_path = cache_path.unwrap();
+
+        let cache_manager = INSTANCE.get_or_init(|| {
+            let cache_path = cache_path.clone();
+            std::fs::create_dir_all(&cache_path).unwrap();
+            Self {
+                filesystem: LocalFileSystem::new(),
+                cache_path,
+                cache_capacity: CONFIG.parseable.query_cache_size,
+                semaphore: Mutex::new(()),
+            }
+        });
+
+        cache_manager.validate(config_capacity).await?;
+
+        Ok(Some(cache_manager))
+    }
+
+    async fn validate(&self, config_capacity: u64) -> Result<(), CacheError> {
+        fs::create_dir_all(&self.cache_path).await?;
+        let path = query_cache_meta_path(&self.cache_path)
+            .map_err(|err| CacheError::ObjectStoreError(err.into()))?;
+        let resp = self
+            .filesystem
+            .get(&path)
+            .and_then(|resp| resp.bytes())
+            .await;
+
+        let updated_cache = match resp {
+            Ok(bytes) => {
+                let mut meta: QueryCacheMeta = serde_json::from_slice(&bytes)?;
+                if meta.size_capacity != config_capacity {
+                    // log the change in cache size
+                    let configured_size_human: SpecificSize<Gigibyte> =
+                        SpecificSize::new(config_capacity as f64, Byte)
+                            .unwrap()
+                            .into();
+                    let current_size_human: SpecificSize<Gigibyte> =
+                        SpecificSize::new(meta.size_capacity as f64, Byte)
+                            .unwrap()
+                            .into();
+                    log::warn!(
+                        "Cache size is updated from {} to {}",
+                        current_size_human,
+                        configured_size_human
+                    );
+                    meta.size_capacity = config_capacity;
+                    Some(meta)
+                } else {
+                    None
+                }
+            }
+            Err(object_store::Error::NotFound { .. }) => {
+                let mut meta = QueryCacheMeta::new();
+                meta.size_capacity = config_capacity;
+                Some(meta)
+            }
+            Err(err) => return Err(err.into()),
+        };
+
+        if let Some(updated_cache) = updated_cache {
+            let result = self
+                .filesystem
+                .put(&path, serde_json::to_vec(&updated_cache)?.into())
+                .await?;
+            log::info!("Cache meta file updated: {:?}", result);
+        }
+
+        Ok(())
+    }
+
+    pub async fn get_cache(&self, stream: &str) -> Result<QueryCache, CacheError> {
+        let path = query_cache_file_path(&self.cache_path, stream).unwrap();
+        let res = self
+            .filesystem
+            .get(&path)
+            .and_then(|resp| resp.bytes())
+            .await;
+        let cache = match res {
+            Ok(bytes) => serde_json::from_slice(&bytes)?,
+            Err(object_store::Error::NotFound { .. }) => QueryCache::new(),
+            Err(err) => return Err(err.into()),
+        };
+        Ok(cache)
+    }
+
+    pub async fn put_cache(&self, stream: &str, cache: &QueryCache) -> Result<(), CacheError> {
+        let path = query_cache_file_path(&self.cache_path, stream).unwrap();
+        let bytes = serde_json::to_vec(cache)?.into();
+        let result = self.filesystem.put(&path, bytes).await?;
+        log::info!("Cache file updated: {:?}", result);
+        Ok(())
+    }
+
+    pub async fn move_to_cache(
+        &self,
+        stream: &str,
+        key: String,
+        staging_path: &Path,
+    ) -> Result<(), CacheError> {
+        let lock = self.semaphore.lock().await;
+        let mut cache_path = self.cache_path.join(stream);
+        fs::create_dir_all(&cache_path).await?;
+        cache_path.push(staging_path.file_name().unwrap());
+        // this needs to be the record batches parquet
+        // fs_extra::file::move_file(staging_path, &cache_path, &self.copy_options)?;
+        let file_size = std::fs::metadata(&cache_path)?.len();
+        let mut cache = self.get_cache(stream).await?;
+
+        while cache.current_size + file_size > self.cache_capacity {
+            if let Some((_, file_for_removal)) = cache.files.pop_lru() {
+                let lru_file_size = std::fs::metadata(&file_for_removal)?.len();
+                cache.current_size = cache.current_size.saturating_sub(lru_file_size);
+                log::info!("removing cache entry");
+                tokio::spawn(fs::remove_file(file_for_removal));
+            } else {
+                log::error!("Cache size too small");
+                break;
+            }
+        }
+
+        if cache.files.is_full() {
+            cache.files.resize(cache.files.capacity() * 2);
+        }
+        cache.files.push(key, cache_path);
+        cache.current_size += file_size;
+        self.put_cache(stream, &cache).await?;
+        drop(lock);
+        Ok(())
+    }
+
+    pub async fn create_parquet_cache(
+        &self,
+        table_name: &str,
+        records: &[RecordBatch],
+        start: String,
+        end: String,
+        query: String,
+    ) -> Result<(), CacheError> {
+        let parquet_path = Self::gen_file_path(
+            self.cache_path.to_str().expect("utf-8 compat path"),
+            table_name,
+        );
+        AsyncFs::create_dir_all(parquet_path.parent().expect("parent path exists")).await?;
+        let parquet_file = AsyncFs::File::create(&parquet_path).await?;
+        let time_partition = STREAM_INFO.get_time_partition(table_name)?;
+        let props = parquet_writer_props(time_partition.clone(), 0).build();
+
+        let mut arrow_writer = AsyncArrowWriter::try_new(
+            parquet_file,
+            STREAM_INFO.schema(table_name).expect("schema present"),
+            Some(props),
+        )?;
+
+        for record in records {
+            if let Err(e) = arrow_writer.write(record).await {
+                log::error!("Error While Writing to Query Cache: {}", e);
+            }
+        }
+
+        arrow_writer.close().await?;
+        self.move_to_cache(
+            table_name,
+            format!("{}-{}-{}", start, end, query),
+            &parquet_path,
+        )
+        .await
+        // match AsyncArrowWriter::try_new(
+        //     parquet_file,
+        //     STREAM_INFO.schema(&table_name).expect("schema present"),
+        //     Some(props),
+        // ) {
+        //     Ok(mut writer) => {
+        //         for record in records {
+        //             if let Err(e) = writer.write(record).await {
+        //                 log::error!("Error While Writing to Query Cache: {}", e);
+        //                 err_flag = true;
+        //             }
+        //         }
+        //
+        //         if let Err(e) = writer.close().await {
+        //             log::error!(
+        //                 "Unstable State: Async ArrowWriter Faild to close. Error: {}",
+        //                 e
+        //             );
+        //
+        //             err_flag = true;
+        //         }
+        //     }
+        //     Err(err) => {
+        //         log::error!("Failed to create an Async ArrowWriter. Reason: {}", err);
+        //         err_flag = true;
+        //     }
+        // }
+        //
+        // if err_flag {
+        //     log::error!("Failed to cache query result");
+        // } else {
+        //
+        // }
+    }
+}
+
+fn query_cache_file_path(
+    root: impl AsRef<std::path::Path>,
+    stream: &str,
+) -> Result<object_store::path::Path, object_store::path::Error> {
+    let mut path = root.as_ref().join(stream);
+    path.push(QUERY_CACHE_FILENAME);
+    object_store::path::Path::from_absolute_path(path)
+}
+
+fn query_cache_meta_path(
+    root: impl AsRef<std::path::Path>,
+) -> Result<object_store::path::Path, object_store::path::Error> {
+    let path = root.as_ref().join(QUERY_CACHE_META_FILENAME);
+    object_store::path::Path::from_absolute_path(path)
+}

--- a/server/src/querycache.rs
+++ b/server/src/querycache.rs
@@ -1,3 +1,21 @@
+/*
+ * Parseable Server (C) 2022 - 2024 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 use arrow_array::RecordBatch;
 use chrono::Utc;
 use futures::TryStreamExt;
@@ -8,6 +26,7 @@ use itertools::Itertools;
 use object_store::{local::LocalFileSystem, ObjectStore};
 use once_cell::sync::OnceCell;
 use parquet::arrow::{AsyncArrowWriter, ParquetRecordBatchStreamBuilder};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tokio::fs as AsyncFs;
 use tokio::{fs, sync::Mutex};
@@ -273,7 +292,7 @@ impl QueryCacheManager {
         AsyncFs::create_dir_all(parquet_path.parent().expect("parent path exists")).await?;
         let parquet_file = AsyncFs::File::create(&parquet_path).await?;
         let time_partition = STREAM_INFO.get_time_partition(table_name)?;
-        let props = parquet_writer_props(time_partition.clone(), 0).build();
+        let props = parquet_writer_props(time_partition.clone(), 0, HashMap::new()).build();
 
         let mut arrow_writer = AsyncArrowWriter::try_new(
             parquet_file,

--- a/server/src/querycache.rs
+++ b/server/src/querycache.rs
@@ -151,7 +151,7 @@ impl QueryCacheManager {
             &format!(
                 "{}.{}.parquet",
                 hostname_unchecked(),
-                Utc::now().to_rfc3339()
+                Utc::now().timestamp().to_string()
             ),
         ])
     }

--- a/server/src/querycache.rs
+++ b/server/src/querycache.rs
@@ -332,9 +332,17 @@ impl QueryCacheManager {
         let time_partition = STREAM_INFO.get_time_partition(table_name)?;
         let props = parquet_writer_props(time_partition.clone(), 0, HashMap::new()).build();
 
+        let sch = if let Some(record) = records.first() {
+            record.schema()
+        } else {
+            // the record batch is empty, do not cache and return early
+            return Ok(());
+        };
+
+
         let mut arrow_writer = AsyncArrowWriter::try_new(
             parquet_file,
-            STREAM_INFO.schema(table_name).expect("schema present"),
+            sch,
             Some(props),
         )?;
 

--- a/server/src/rbac/role.rs
+++ b/server/src/rbac/role.rs
@@ -50,6 +50,10 @@ pub enum Action {
     Deleteingestor,
     All,
     GetAnalytics,
+    ListDashboard,
+    GetDashboard,
+    CreateDashboard,
+    DeleteDashboard,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -107,6 +111,10 @@ impl RoleBuilder {
                 | Action::ListCluster
                 | Action::ListClusterMetrics
                 | Action::Deleteingestor
+                | Action::ListDashboard
+                | Action::GetDashboard
+                | Action::CreateDashboard
+                | Action::DeleteDashboard
                 | Action::GetAnalytics => Permission::Unit(action),
                 Action::Ingest
                 | Action::GetSchema

--- a/server/src/rbac/role.rs
+++ b/server/src/rbac/role.rs
@@ -58,6 +58,8 @@ pub enum Action {
     GetFilter,
     CreateFilter,
     DeleteFilter,
+    ListCache,
+    RemoveCache,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -123,6 +125,8 @@ impl RoleBuilder {
                 | Action::ListFilter
                 | Action::CreateFilter
                 | Action::DeleteFilter
+                | Action::ListCache
+                | Action::RemoveCache
                 | Action::GetAnalytics => Permission::Unit(action),
                 Action::Ingest
                 | Action::GetSchema

--- a/server/src/rbac/role.rs
+++ b/server/src/rbac/role.rs
@@ -54,6 +54,10 @@ pub enum Action {
     GetDashboard,
     CreateDashboard,
     DeleteDashboard,
+    ListFilter,
+    GetFilter,
+    CreateFilter,
+    DeleteFilter,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -115,6 +119,10 @@ impl RoleBuilder {
                 | Action::GetDashboard
                 | Action::CreateDashboard
                 | Action::DeleteDashboard
+                | Action::GetFilter
+                | Action::ListFilter
+                | Action::CreateFilter
+                | Action::DeleteFilter
                 | Action::GetAnalytics => Permission::Unit(action),
                 Action::Ingest
                 | Action::GetSchema

--- a/server/src/response.rs
+++ b/server/src/response.rs
@@ -33,8 +33,8 @@ impl QueryResponse {
     pub fn to_http(&self) -> Result<impl Responder, QueryError> {
         log::info!("{}", "Returning query results");
         let records: Vec<&RecordBatch> = self.records.iter().collect();
-        let mut json_records = record_batches_to_json(&records)
-            .map_err(|err| QueryError::JsonParse(err.to_string()))?;
+        let mut json_records = record_batches_to_json(&records)?;
+
         if self.fill_null {
             for map in &mut json_records {
                 for field in &self.fields {

--- a/server/src/response.rs
+++ b/server/src/response.rs
@@ -16,11 +16,18 @@
  *
  */
 
-use crate::{handlers::http::query::QueryError, utils::arrow::record_batches_to_json};
+use crate::{
+    handlers::http::query::QueryError,
+    utils::arrow::{
+        flight::{into_flight_data, DoGetStream},
+        record_batches_to_json,
+    },
+};
 use actix_web::{web, Responder};
 use datafusion::arrow::record_batch::RecordBatch;
 use itertools::Itertools;
 use serde_json::{json, Value};
+use tonic::{Response, Status};
 
 pub struct QueryResponse {
     pub records: Vec<RecordBatch>,
@@ -56,5 +63,9 @@ impl QueryResponse {
         };
 
         Ok(web::Json(response))
+    }
+
+    pub fn into_flight(self) -> Result<Response<DoGetStream>, Status> {
+        into_flight_data(self.records)
     }
 }

--- a/server/src/static_schema.rs
+++ b/server/src/static_schema.rs
@@ -1,3 +1,21 @@
+/*
+ * Parseable Server (C) 2022 - 2024 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 use crate::event::{DEFAULT_METADATA_KEY, DEFAULT_TAGS_KEY, DEFAULT_TIMESTAMP_KEY};
 use crate::utils::arrow::get_field;
 use anyhow::{anyhow, Error as AnyError};

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -16,7 +16,9 @@
  *
  */
 
-use crate::{catalog::snapshot::Snapshot, stats::FullStats};
+use crate::{
+    catalog::snapshot::Snapshot, metadata::error::stream_info::MetadataError, stats::FullStats,
+};
 
 use chrono::Local;
 
@@ -209,6 +211,8 @@ pub enum ObjectStorageError {
     UnhandledError(Box<dyn std::error::Error + Send + Sync + 'static>),
     #[error("Error: {0}")]
     PathError(relative_path::FromPathError),
+    #[error("Error: {0}")]
+    MetadataError(#[from] MetadataError),
 
     #[allow(dead_code)]
     #[error("Authentication Error: {0}")]

--- a/server/src/storage/metrics_layer.rs
+++ b/server/src/storage/metrics_layer.rs
@@ -1,3 +1,21 @@
+/*
+ * Parseable Server (C) 2022 - 2024 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 use std::{
     ops::Range,
     task::{Context, Poll},

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -27,7 +27,7 @@ use super::{
 
 use crate::handlers::http::modal::ingest_server::INGESTOR_META;
 use crate::metrics::{LIFETIME_EVENTS_STORAGE_SIZE, STORAGE_SIZE_TODAY};
-use crate::handlers::http::users::{DASHBOARDS_DIR, USERS_ROOT_DIR};
+use crate::handlers::http::users::{DASHBOARDS_DIR, FILTER_DIR, USERS_ROOT_DIR};
 use crate::option::Mode;
 use crate::{
     alerts::Alerts,
@@ -606,8 +606,20 @@ pub fn stream_json_path(stream_name: &str) -> RelativePathBuf {
 
 /// if dashboard_id is an empty str it should not append it to the rel path
 #[inline(always)]
-pub fn dashboard_path(user_id: &str, dashboard_id: &str) -> RelativePathBuf {
-    RelativePathBuf::from_iter([USERS_ROOT_DIR, user_id, DASHBOARDS_DIR, dashboard_id])
+pub fn dashboard_path(user_id: &str, dashboard_file_name: &str) -> RelativePathBuf {
+    RelativePathBuf::from_iter([USERS_ROOT_DIR, user_id, DASHBOARDS_DIR, dashboard_file_name])
+}
+
+/// if filter_id is an empty str it should not append it to the rel path
+#[inline(always)]
+pub fn filter_path(user_id: &str, stream_name: &str, filter_file_name: &str) -> RelativePathBuf {
+    RelativePathBuf::from_iter([
+        USERS_ROOT_DIR,
+        user_id,
+        FILTER_DIR,
+        stream_name,
+        filter_file_name,
+    ])
 }
 
 /// path will be ".parseable/.parsable.json"

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -26,8 +26,8 @@ use super::{
 };
 
 use crate::handlers::http::modal::ingest_server::INGESTOR_META;
-use crate::metrics::{LIFETIME_EVENTS_STORAGE_SIZE, STORAGE_SIZE_TODAY};
 use crate::handlers::http::users::{DASHBOARDS_DIR, FILTER_DIR, USERS_ROOT_DIR};
+use crate::metrics::{LIFETIME_EVENTS_STORAGE_SIZE, STORAGE_SIZE_TODAY};
 use crate::option::Mode;
 use crate::{
     alerts::Alerts,

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -27,6 +27,7 @@ use super::{
 
 use crate::handlers::http::modal::ingest_server::INGESTOR_META;
 use crate::metrics::{LIFETIME_EVENTS_STORAGE_SIZE, STORAGE_SIZE_TODAY};
+use crate::handlers::http::users::{DASHBOARDS_DIR, USERS_ROOT_DIR};
 use crate::option::Mode;
 use crate::{
     alerts::Alerts,
@@ -66,7 +67,7 @@ pub trait ObjectStorageProvider: StorageMetrics + std::fmt::Debug {
 #[async_trait]
 pub trait ObjectStorage: Sync + 'static {
     async fn get_object(&self, path: &RelativePath) -> Result<Bytes, ObjectStorageError>;
-    // want to make it more generic with a filter function
+    // TODO: make the filter function optional as we may want to get all objects
     async fn get_objects(
         &self,
         base_path: Option<&RelativePath>,
@@ -601,6 +602,12 @@ pub fn stream_json_path(stream_name: &str) -> RelativePathBuf {
             STREAM_METADATA_FILE_NAME,
         ]),
     }
+}
+
+/// if dashboard_id is an empty str it should not append it to the rel path
+#[inline(always)]
+pub fn dashboard_path(user_id: &str, dashboard_id: &str) -> RelativePathBuf {
+    RelativePathBuf::from_iter([USERS_ROOT_DIR, user_id, DASHBOARDS_DIR, dashboard_id])
 }
 
 /// path will be ".parseable/.parsable.json"

--- a/server/src/storage/s3.rs
+++ b/server/src/storage/s3.rs
@@ -38,6 +38,7 @@ use std::path::Path as StdPath;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use crate::handlers::http::users::USERS_ROOT_DIR;
 use crate::metrics::storage::{s3::REQUEST_RESPONSE_TIME, StorageMetrics};
 use crate::storage::{LogStream, ObjectStorage, ObjectStorageError, PARSEABLE_ROOT_DIRECTORY};
 
@@ -305,6 +306,7 @@ impl S3 {
             .filter_map(|path| path.parts().next())
             .map(|name| name.as_ref().to_string())
             .filter(|x| x != PARSEABLE_ROOT_DIRECTORY)
+            .filter(|x| x != USERS_ROOT_DIR)
             .collect();
 
         let stream_json_check = FuturesUnordered::new();

--- a/server/src/storage/staging.rs
+++ b/server/src/storage/staging.rs
@@ -293,7 +293,7 @@ pub fn convert_disk_files_to_parquet(
     }
 }
 
-fn parquet_writer_props(
+pub fn parquet_writer_props(
     time_partition: Option<String>,
     index_time_partition: usize,
     custom_partition_fields: HashMap<String, usize>,

--- a/server/src/storage/store_metadata.rs
+++ b/server/src/storage/store_metadata.rs
@@ -116,9 +116,7 @@ pub async fn resolve_parseable_metadata() -> Result<StorageMetadata, ObjectStora
             overwrite_staging = true;
             if CONFIG.parseable.mode ==  Mode::All {
                 standalone_after_distributed(Mode::from_string(&metadata.server_mode).expect("mode should be valid at here"))
-                    .map_err(|err| {
-                        ObjectStorageError::Custom(err.to_string())
-                    })?;
+                    ?;
             }
             Ok(metadata)
         },
@@ -128,7 +126,10 @@ pub async fn resolve_parseable_metadata() -> Result<StorageMetadata, ObjectStora
         EnvChange::NewStaging(mut metadata) => {
             // if server is started in ingest mode,we need to make sure that query mode has been started
             // i.e the metadata is updated to reflect the server mode = Query
-            if Mode::from_string(&metadata.server_mode).map_err(ObjectStorageError::Custom)? == Mode::All && CONFIG.parseable.mode == Mode::Ingest {
+            if Mode::from_string(&metadata.server_mode)
+            .map_err(ObjectStorageError::Custom)
+            ?
+             == Mode::All && CONFIG.parseable.mode == Mode::Ingest {
                 Err("Starting Ingest Mode is not allowed, Since Query Server has not been started yet")
             } else {
                 create_dir_all(CONFIG.staging_dir())?;

--- a/server/src/users/dashboards.rs
+++ b/server/src/users/dashboards.rs
@@ -1,3 +1,21 @@
+/*
+ * Parseable Server (C) 2022 - 2024 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 use std::sync::RwLock;
 
 use once_cell::sync::Lazy;

--- a/server/src/users/dashboards.rs
+++ b/server/src/users/dashboards.rs
@@ -35,14 +35,14 @@ pub struct Pannel {
     chart_type: String,
     columns: Vec<String>,
     headers: Vec<String>,
-    dimensions: (u64, u64),
+    dimensions: Vec<u64>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct Dashboard {
     version: String,
-    name: String,
-    id: String,
+    dashboard_name: String,
+    dashboard_id: String,
     time_filter: TimeFilter,
     refresh_interval: u64,
     pannels: Vec<Pannel>,
@@ -50,11 +50,11 @@ pub struct Dashboard {
 
 impl Dashboard {
     pub fn dashboard_id(&self) -> &str {
-        &self.id
+        &self.dashboard_id
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Dashboards(RwLock<Vec<Dashboard>>);
 
 impl Dashboards {
@@ -64,7 +64,8 @@ impl Dashboards {
         let store = CONFIG.storage().get_object_store();
         let objs = store
             .get_objects(Some(&path), Box::new(|path| path.ends_with(".json")))
-            .await?;
+            .await
+            .unwrap_or_default();
 
         for obj in objs {
             if let Ok(filter) = serde_json::from_slice::<Dashboard>(&obj) {

--- a/server/src/users/dashboards.rs
+++ b/server/src/users/dashboards.rs
@@ -1,0 +1,77 @@
+use std::sync::RwLock;
+
+use once_cell::sync::Lazy;
+use relative_path::RelativePathBuf;
+use serde::{Deserialize, Serialize};
+
+use crate::{handlers::http::users::USERS_ROOT_DIR, metadata::LOCK_EXPECT, option::CONFIG};
+
+use super::TimeFilter;
+
+pub static DASHBOARDS: Lazy<Dashboards> = Lazy::new(Dashboards::default);
+
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+pub struct Pannel {
+    stream_name: String,
+    query: String,
+    chart_type: String,
+    columns: Vec<String>,
+    headers: Vec<String>,
+    dimensions: (u64, u64),
+}
+
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+pub struct Dashboard {
+    version: String,
+    name: String,
+    id: String,
+    time_filter: TimeFilter,
+    refresh_interval: u64,
+    pannels: Vec<Pannel>,
+}
+
+impl Dashboard {
+    pub fn dashboard_id(&self) -> &str {
+        &self.id
+    }
+}
+
+#[derive(Default)]
+pub struct Dashboards(RwLock<Vec<Dashboard>>);
+
+impl Dashboards {
+    pub async fn load(&self) -> anyhow::Result<()> {
+        let mut this = vec![];
+        let path = RelativePathBuf::from(USERS_ROOT_DIR);
+        let store = CONFIG.storage().get_object_store();
+        let objs = store
+            .get_objects(Some(&path), Box::new(|path| path.ends_with(".json")))
+            .await?;
+
+        for obj in objs {
+            if let Ok(filter) = serde_json::from_slice::<Dashboard>(&obj) {
+                this.push(filter);
+            }
+        }
+
+        let mut s = self.0.write().expect(LOCK_EXPECT);
+        s.append(&mut this);
+
+        Ok(())
+    }
+
+    pub fn update(&self, dashboard: Dashboard) {
+        let mut s = self.0.write().expect(LOCK_EXPECT);
+
+        s.push(dashboard);
+    }
+
+    pub fn find(&self, dashboard_id: &str) -> Option<Dashboard> {
+        self.0
+            .read()
+            .expect(LOCK_EXPECT)
+            .iter()
+            .find(|dashboard| dashboard.dashboard_id() == dashboard_id)
+            .cloned()
+    }
+}

--- a/server/src/users/filters.rs
+++ b/server/src/users/filters.rs
@@ -16,11 +16,10 @@
  *
  */
 
-use std::sync::RwLock;
-
 use once_cell::sync::Lazy;
 use relative_path::RelativePathBuf;
 use serde::{Deserialize, Serialize};
+use std::sync::RwLock;
 
 use super::TimeFilter;
 use crate::{handlers::http::users::USERS_ROOT_DIR, metadata::LOCK_EXPECT, option::CONFIG};
@@ -51,9 +50,11 @@ impl Filters {
         let mut this = vec![];
         let path = RelativePathBuf::from(USERS_ROOT_DIR);
         let store = CONFIG.storage().get_object_store();
+
         let objs = store
             .get_objects(Some(&path), Box::new(|path| path.ends_with(".json")))
-            .await?;
+            .await
+            .unwrap_or_default();
 
         for obj in objs {
             if let Ok(filter) = serde_json::from_slice::<Filter>(&obj) {

--- a/server/src/users/filters.rs
+++ b/server/src/users/filters.rs
@@ -1,0 +1,66 @@
+use std::sync::RwLock;
+
+use once_cell::sync::Lazy;
+use relative_path::RelativePathBuf;
+use serde::{Deserialize, Serialize};
+
+use super::TimeFilter;
+use crate::{handlers::http::users::USERS_ROOT_DIR, metadata::LOCK_EXPECT, option::CONFIG};
+
+pub static FILTERS: Lazy<Filters> = Lazy::new(Filters::default);
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Filter {
+    version: String,
+    stream_name: String,
+    filter_name: String,
+    filter_id: String,
+    query: String,
+    time_filter: Option<TimeFilter>,
+}
+
+impl Filter {
+    pub fn filter_id(&self) -> &str {
+        &self.filter_id
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Filters(RwLock<Vec<Filter>>);
+
+impl Filters {
+    pub async fn load(&self) -> anyhow::Result<()> {
+        let mut this = vec![];
+        let path = RelativePathBuf::from(USERS_ROOT_DIR);
+        let store = CONFIG.storage().get_object_store();
+        let objs = store
+            .get_objects(Some(&path), Box::new(|path| path.ends_with(".json")))
+            .await?;
+
+        for obj in objs {
+            if let Ok(filter) = serde_json::from_slice::<Filter>(&obj) {
+                this.push(filter);
+            }
+        }
+
+        let mut s = self.0.write().expect(LOCK_EXPECT);
+        s.append(&mut this);
+
+        Ok(())
+    }
+
+    pub fn update(&self, filter: Filter) {
+        let mut s = self.0.write().expect(LOCK_EXPECT);
+
+        s.push(filter);
+    }
+
+    pub fn find(&self, filter_id: &str) -> Option<Filter> {
+        self.0
+            .read()
+            .expect(LOCK_EXPECT)
+            .iter()
+            .find(|filter| filter.filter_id() == filter_id)
+            .cloned()
+    }
+}

--- a/server/src/users/filters.rs
+++ b/server/src/users/filters.rs
@@ -1,3 +1,21 @@
+/*
+ * Parseable Server (C) 2022 - 2024 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 use std::sync::RwLock;
 
 use once_cell::sync::Lazy;

--- a/server/src/users/mod.rs
+++ b/server/src/users/mod.rs
@@ -1,3 +1,21 @@
+/*
+ * Parseable Server (C) 2022 - 2024 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 pub mod dashboards;
 pub mod filters;
 

--- a/server/src/users/mod.rs
+++ b/server/src/users/mod.rs
@@ -1,0 +1,10 @@
+pub mod dashboards;
+pub mod filters;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+pub struct TimeFilter {
+    to: String,
+    from: String,
+}

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -280,7 +280,7 @@ pub fn get_ingestor_id() -> String {
     let result = format!("{:x}", hasher.finalize());
     let result = result.split_at(15).0.to_string();
     log::debug!("Ingestor ID: {}", &result);
-    result.to_string()
+    result
 }
 
 #[cfg(test)]

--- a/server/src/utils/arrow/flight.rs
+++ b/server/src/utils/arrow/flight.rs
@@ -1,3 +1,21 @@
+/*
+ * Parseable Server (C) 2022 - 2024 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 use crate::event::Event;
 use crate::handlers::http::ingest::push_logs_unchecked;
 use crate::handlers::http::query::Query as QueryJson;

--- a/server/src/utils/arrow/flight.rs
+++ b/server/src/utils/arrow/flight.rs
@@ -27,21 +27,25 @@ use crate::{
 };
 
 use arrow_array::RecordBatch;
-use arrow_flight::Ticket;
+use arrow_flight::encode::FlightDataEncoderBuilder;
+use arrow_flight::{FlightData, Ticket};
+use arrow_ipc::writer::IpcWriteOptions;
 use arrow_select::concat::concat_batches;
 use datafusion::logical_expr::BinaryExpr;
 use datafusion::prelude::Expr;
 use datafusion::scalar::ScalarValue;
-use futures::TryStreamExt;
+use futures::{stream, TryStreamExt};
 
-use tonic::{Request, Status};
+use tonic::{Request, Response, Status};
 
 use arrow_flight::FlightClient;
 use http::Uri;
 use tonic::transport::Channel;
 
-pub fn get_query_from_ticket(req: Request<Ticket>) -> Result<QueryJson, Status> {
-    serde_json::from_slice::<QueryJson>(&req.into_inner().ticket)
+pub type DoGetStream = stream::BoxStream<'static, Result<FlightData, Status>>;
+
+pub fn get_query_from_ticket(req: &Request<Ticket>) -> Result<QueryJson, Status> {
+    serde_json::from_slice::<QueryJson>(&req.get_ref().ticket)
         .map_err(|err| Status::internal(err.to_string()))
 }
 
@@ -136,4 +140,21 @@ pub fn send_to_ingester(start: i64, end: i64) -> bool {
 
 fn lit_timestamp_milli(time: i64) -> Expr {
     Expr::Literal(ScalarValue::TimestampMillisecond(Some(time), None))
+}
+
+pub fn into_flight_data(records: Vec<RecordBatch>) -> Result<Response<DoGetStream>, Status> {
+    let input_stream = futures::stream::iter(records.into_iter().map(Ok));
+    let write_options = IpcWriteOptions::default()
+        .try_with_compression(Some(arrow_ipc::CompressionType(1)))
+        .map_err(|err| Status::failed_precondition(err.to_string()))?;
+
+    let flight_data_stream = FlightDataEncoderBuilder::new()
+        .with_max_flight_data_size(usize::MAX)
+        .with_options(write_options)
+        // .with_schema(schema.into())
+        .build(input_stream);
+
+    let flight_data_stream = flight_data_stream.map_err(|err| Status::unknown(err.to_string()));
+
+    Ok(Response::new(Box::pin(flight_data_stream) as DoGetStream))
 }


### PR DESCRIPTION
### Description

Implement Query Results Caching. Add option ENV VAR `P_QUERY_CACHE_DIR` and `P_QUERY_CACHE_SIZE`.
Implement `/dashboards` endpoint. Implement `/filters` endpoint. Clean up errors.
<hr>

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.
