### PR TITLE
fix for stats for each date

### DIFF
--- a/server/src/event.rs
+++ b/server/src/event.rs
@@ -82,6 +82,7 @@ impl Event {
             self.origin_format,
             self.origin_size,
             num_rows,
+            self.parsed_timestamp,
         )?;
 
         crate::livetail::LIVETAIL.process(&self.stream_name, &self.rb);

--- a/server/src/handlers/http/modal/ingest_server.rs
+++ b/server/src/handlers/http/modal/ingest_server.rs
@@ -337,7 +337,6 @@ impl IngestServer {
         }
 
         metrics::fetch_stats_from_storage().await;
-        metrics::reset_daily_metric_from_global();
 
         let (localsync_handler, mut localsync_outbox, localsync_inbox) = sync::run_local_sync();
         let (mut remote_sync_handler, mut remote_sync_outbox, mut remote_sync_inbox) =

--- a/server/src/handlers/http/modal/query_server.rs
+++ b/server/src/handlers/http/modal/query_server.rs
@@ -184,7 +184,6 @@ impl QueryServer {
 
         // load data from stats back to prometheus metrics
         metrics::fetch_stats_from_storage().await;
-        metrics::reset_daily_metric_from_global();
         // track all parquet files already in the data directory
         storage::retention::load_retention_from_global();
 

--- a/server/src/handlers/http/modal/server.rs
+++ b/server/src/handlers/http/modal/server.rs
@@ -496,7 +496,6 @@ impl Server {
         DASHBOARDS.load().await?;
 
         metrics::fetch_stats_from_storage().await;
-        metrics::reset_daily_metric_from_global();
         storage::retention::load_retention_from_global();
 
         let (localsync_handler, mut localsync_outbox, localsync_inbox) = sync::run_local_sync();

--- a/server/src/metadata.rs
+++ b/server/src/metadata.rs
@@ -18,7 +18,7 @@
 
 use arrow_array::RecordBatch;
 use arrow_schema::{Field, Fields, Schema};
-use chrono::Local;
+use chrono::{Local, NaiveDateTime};
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
@@ -27,10 +27,10 @@ use std::sync::{Arc, RwLock};
 use self::error::stream_info::{CheckAlertError, LoadError, MetadataError};
 use crate::alerts::Alerts;
 use crate::metrics::{
-    EVENTS_INGESTED, EVENTS_INGESTED_SIZE, EVENTS_INGESTED_SIZE_TODAY, EVENTS_INGESTED_TODAY,
-    LIFETIME_EVENTS_INGESTED, LIFETIME_EVENTS_INGESTED_SIZE,
+    EVENTS_INGESTED, EVENTS_INGESTED_DATE, EVENTS_INGESTED_SIZE, EVENTS_INGESTED_SIZE_DATE,
+    EVENTS_STORAGE_SIZE_DATE, LIFETIME_EVENTS_INGESTED, LIFETIME_EVENTS_INGESTED_SIZE,
 };
-use crate::storage::{LogStream, ObjectStorage, StorageDir};
+use crate::storage::{LogStream, ObjectStorage, ObjectStoreFormat, StorageDir};
 use crate::utils::arrow::MergedRecordReader;
 use derive_more::{Deref, DerefMut};
 
@@ -244,7 +244,8 @@ impl StreamInfo {
         let alerts = storage.get_alerts(&stream.name).await?;
         let schema = storage.get_schema_on_server_start(&stream.name).await?;
         let meta = storage.get_stream_metadata(&stream.name).await?;
-
+        let meta_clone = meta.clone();
+        let stream_name = stream.name.clone();
         let schema = update_schema_from_staging(&stream.name, schema);
         let schema = HashMap::from_iter(
             schema
@@ -268,8 +269,28 @@ impl StreamInfo {
         let mut map = self.write().expect(LOCK_EXPECT);
 
         map.insert(stream.name, metadata);
+        Self::load_daily_metrics(meta_clone, &stream_name);
 
         Ok(())
+    }
+
+    fn load_daily_metrics(meta: ObjectStoreFormat, stream_name: &str) {
+        let manifests = meta.snapshot.manifest_list;
+        for manifest in manifests {
+            let manifest_date = manifest.time_lower_bound.date_naive().to_string();
+            let events_ingested = manifest.events_ingested;
+            let ingestion_size = manifest.ingestion_size;
+            let storage_size = manifest.storage_size;
+            EVENTS_INGESTED_DATE
+                .with_label_values(&[stream_name, "json", &manifest_date])
+                .set(events_ingested as i64);
+            EVENTS_INGESTED_SIZE_DATE
+                .with_label_values(&[stream_name, "json", &manifest_date])
+                .set(ingestion_size as i64);
+            EVENTS_STORAGE_SIZE_DATE
+                .with_label_values(&["data", stream_name, "parquet", &manifest_date])
+                .set(storage_size as i64);
+        }
     }
 
     pub fn list_streams(&self) -> Vec<String> {
@@ -286,18 +307,20 @@ impl StreamInfo {
         origin: &'static str,
         size: u64,
         num_rows: u64,
+        parsed_timestamp: NaiveDateTime,
     ) -> Result<(), MetadataError> {
+        let parsed_date = parsed_timestamp.date().to_string();
         EVENTS_INGESTED
             .with_label_values(&[stream_name, origin])
             .add(num_rows as i64);
-        EVENTS_INGESTED_TODAY
-            .with_label_values(&[stream_name, origin])
+        EVENTS_INGESTED_DATE
+            .with_label_values(&[stream_name, origin, parsed_date.as_str()])
             .add(num_rows as i64);
         EVENTS_INGESTED_SIZE
             .with_label_values(&[stream_name, origin])
             .add(size as i64);
-        EVENTS_INGESTED_SIZE_TODAY
-            .with_label_values(&[stream_name, origin])
+        EVENTS_INGESTED_SIZE_DATE
+            .with_label_values(&[stream_name, origin, parsed_date.as_str()])
             .add(size as i64);
         LIFETIME_EVENTS_INGESTED
             .with_label_values(&[stream_name, origin])

--- a/server/src/migration/stream_metadata_migration.rs
+++ b/server/src/migration/stream_metadata_migration.rs
@@ -39,11 +39,6 @@ pub fn v1_v4(mut stream_metadata: Value) -> Value {
             "events": 0,
             "ingestion": 0,
             "storage": 0
-        },
-        "current_date_stats": {
-            "events": 0,
-            "ingestion": 0,
-            "storage": 0
         }
     });
     stream_metadata_map.insert("stats".to_owned(), default_stats);
@@ -80,11 +75,6 @@ pub fn v2_v4(mut stream_metadata: Value) -> Value {
             "storage": stats.get("storage").unwrap()
         },
         "deleted_stats": {
-            "events": 0,
-            "ingestion": 0,
-            "storage": 0
-        },
-        "current_date_stats": {
             "events": 0,
             "ingestion": 0,
             "storage": 0
@@ -126,11 +116,6 @@ pub fn v3_v4(mut stream_metadata: Value) -> Value {
             "storage": stats.get("storage").unwrap()
         },
         "deleted_stats": {
-            "events": 0,
-            "ingestion": 0,
-            "storage": 0
-        },
-        "current_date_stats": {
             "events": 0,
             "ingestion": 0,
             "storage": 0


### PR DESCRIPTION
update stats in manifest list in snapshot for each date load daily stats on server start
update GET /stats endpoint to accept query param
if given /stats/date={date in yyyy-mm-dd} format, date level stats is returned

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
