### PR TITLE
enhancement: saved filters

### DIFF
--- a/server/src/storage/localfs.rs
+++ b/server/src/storage/localfs.rs
@@ -31,8 +31,11 @@ use relative_path::{RelativePath, RelativePathBuf};
 use tokio::fs::{self, DirEntry};
 use tokio_stream::wrappers::ReadDirStream;
 
-use crate::metrics::storage::{localfs::REQUEST_RESPONSE_TIME, StorageMetrics};
 use crate::option::validation;
+use crate::{
+    handlers::http::users::USERS_ROOT_DIR,
+    metrics::storage::{localfs::REQUEST_RESPONSE_TIME, StorageMetrics},
+};
 
 use super::{
     LogStream, ObjectStorage, ObjectStorageError, ObjectStorageProvider, PARSEABLE_ROOT_DIRECTORY,
@@ -291,7 +294,7 @@ impl ObjectStorage for LocalFS {
     }
 
     async fn list_streams(&self) -> Result<Vec<LogStream>, ObjectStorageError> {
-        let ignore_dir = &["lost+found", PARSEABLE_ROOT_DIRECTORY];
+        let ignore_dir = &["lost+found", PARSEABLE_ROOT_DIRECTORY, USERS_ROOT_DIR];
         let directories = ReadDirStream::new(fs::read_dir(&self.root).await?);
         let entries: Vec<DirEntry> = directories.try_collect().await?;
         let entries = entries

--- a/server/src/users/filters.rs
+++ b/server/src/users/filters.rs
@@ -26,14 +26,43 @@ use crate::{handlers::http::users::USERS_ROOT_DIR, metadata::LOCK_EXPECT, option
 
 pub static FILTERS: Lazy<Filters> = Lazy::new(Filters::default);
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct Filter {
     version: String,
     stream_name: String,
     filter_name: String,
     filter_id: String,
-    query: String,
+    query: FilterQuery,
     time_filter: Option<TimeFilter>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct FilterQuery {
+    filter_type: String,
+    filter_query: Option<String>,
+    filter_builder: Option<FilterBuilder>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct FilterBuilder {
+    id: String,
+    combinator: String,
+    rules: Vec<FilterRules>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct FilterRules {
+    id: String,
+    combinator: String,
+    rules: Vec<Rules>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct Rules {
+    id: String,
+    field: String,
+    value: String,
+    operator: String,
 }
 
 impl Filter {
@@ -70,7 +99,7 @@ impl Filters {
 
     pub fn update(&self, filter: Filter) {
         let mut s = self.0.write().expect(LOCK_EXPECT);
-
+        s.retain(|f| f.filter_id() != filter.filter_id());
         s.push(filter);
     }
 

--- a/server/src/users/mod.rs
+++ b/server/src/users/mod.rs
@@ -21,7 +21,7 @@ pub mod filters;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+#[derive(Debug, Serialize, Deserialize, Default, Clone, PartialEq, Eq)]
 pub struct TimeFilter {
     to: String,
     from: String,


### PR DESCRIPTION
updated json for filters with sql -
{
    "version": "v1",
    "stream_name": "mystream",
    "filter_name": "My Filter",
    "filter_id": "12345r",
    "query": {
        "filter_type": "sql",
        "filter_query": "SELECT * FROM mystream WHERE datetime = '2019-01-01T00:00:00Z' OR datetime = '2019-01-02T00:00:00Z' AND datetime = '2019-01-03T00:00:00Z'"
    },

    "time_filter": {
        "from": "<utc-timestamp>",
        "to":  "<utc-timestamp>"
    }

}

updated json for filters with builder -
{
    "version": "v1",
    "stream_name": "mystream",
    "filter_name": "My Filter",
    "filter_id": "12345r",
    "query": {
        "filter_type": "builder",
        "filter_builder": {
            "id": "root",
            "combinator": "or",
            "rules": [
                {
                    "id": "ruleset-K8MABA",
                    "combinator": "or",
                    "rules": [
                        {
                            "id": "rule-BUt9yY",
                            "field": "datetime",
                            "value": "asadadsdsad",
                            "operator": "="
                        },
                        {
                            "id": "rule-zC7EF9",
                            "field": "datetime",
                            "value": "ssasassasas",
                            "operator": "="
                        }
                    ]
                },
                {
                    "id": "ruleset-UwqIcb",
                    "combinator": "and",
                    "rules": [
                        {
                            "id": "rule-tXgB5C",
                            "field": "datetime",
                            "value": "aasasass",
                            "operator": "="
                        }
                    ]
                }
            ]
        }
    },
    "time_filter": {
        "from": "<utc-timestamp>",
        "to":  "<utc-timestamp>"
    }

}
