### PR TITLE
fix for invalid parquet

### DIFF
--- a/server/src/storage/staging.rs
+++ b/server/src/storage/staging.rs
@@ -280,7 +280,7 @@ pub fn convert_disk_files_to_parquet(
         }
 
         writer.close()?;
-        if parquet_file.metadata().unwrap().len() == 0 {
+        if parquet_file.metadata().unwrap().len() < parquet::file::FOOTER_SIZE as u64 {
             log::error!(
                 "Invalid parquet file {:?} detected for stream {}, removing it",
                 &parquet_path,


### PR DESCRIPTION
delete invalid parquets where file size is less than the length of the parquet footer

Fixes: #848

