### PR TITLE
add send_analytics flag in about API response

### DIFF
--- a/server/src/handlers/http/about.rs
+++ b/server/src/handlers/http/about.rs
@@ -94,6 +94,8 @@ pub async fn about() -> Json<serde_json::Value> {
         )
     };
 
+    let send_analytics = CONFIG.parseable.send_analytics;
+
     Json(json!({
         "version": current_version,
         "uiVersion": ui_version,
@@ -112,6 +114,7 @@ pub async fn about() -> Json<serde_json::Value> {
         "store": {
             "type": CONFIG.get_storage_mode_string(),
             "path": store_endpoint
-        }
+        },
+        "sendAnalytics": send_analytics
     }))
 }


### PR DESCRIPTION
About API response will have a new field - sendAnalytics with value of true/false
based on value set in env var P_SEND_ANONYMOUS_USAGE_DATA default for this env var is true.

Updated About API Response JSON:

```
{
    "version": "v1.3.0",
    "uiVersion": "development",
    "commit": "81ce80e",
    "deploymentId": "01J2VSSH60CJTXHV562WPNXQXJ",
    "updateAvailable": false,
    "latestVersion": "v1.3.0",
    "llmActive": false,
    "llmProvider": null,
    "oidcActive": false,
    "license": "AGPL-3.0-only",
    "mode": "Standalone",
    "staging": "/Users/nikhilsinha/Parseable/parseable/staging",
    "cache": "Disabled",
    "grpcPort": 8001,
    "store": {
        "type": "Local drive",
        "path": "/Users/nikhilsinha/Parseable/parseable/data"
    },
    "sendAnalytics": true
}
```
