### PR TITLE
feat: Add hot-tier feature for distributed deployments

### DIFF
--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -101,6 +101,9 @@ pub struct Cli {
 
     /// CORS behaviour
     pub cors: bool,
+
+    /// The local hot_tier path is used for optimising the query performance in the distributed systems
+    pub hot_tier_storage_path: Option<PathBuf>,
 }
 
 impl Cli {
@@ -134,6 +137,7 @@ impl Cli {
     pub const DEFAULT_PASSWORD: &'static str = "admin";
     pub const FLIGHT_PORT: &'static str = "flight-port";
     pub const CORS: &'static str = "cors";
+    pub const HOT_TIER_PATH: &'static str = "hot-tier-path";
 
     pub fn local_stream_data_path(&self, stream_name: &str) -> PathBuf {
         self.local_staging_path.join(stream_name)
@@ -395,6 +399,15 @@ impl Cli {
                         "lz4",
                         "zstd"])
                     .help("Parquet compression algorithm"),
+            )
+            .arg(
+                Arg::new(Self::HOT_TIER_PATH)
+                    .long(Self::HOT_TIER_PATH)
+                    .env("P_HOT_TIER_DIR")
+                    .value_name("DIR")
+                    .value_parser(validation::canonicalize_path)
+                    .help("Local path on this device to be used for hot tier data")
+                    .next_line_help(true),
             ).group(
                 ArgGroup::new("oidc")
                     .args([Self::OPENID_CLIENT_ID, Self::OPENID_CLIENT_SECRET, Self::OPENID_ISSUER])
@@ -531,6 +544,8 @@ impl FromArgMatches for Cli {
             "all" => Mode::All,
             _ => unreachable!(),
         };
+
+        self.hot_tier_storage_path = m.get_one::<PathBuf>(Self::HOT_TIER_PATH).cloned();
 
         Ok(())
     }

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -416,7 +416,7 @@ impl Cli {
             .arg(
                 Arg::new(Self::MAX_DISK_USAGE)
                     .long(Self::MAX_DISK_USAGE)
-                    .env("P_MAX_DISK_USAGE")
+                    .env("P_MAX_DISK_USAGE_PERCENT")
                     .value_name("percentage")
                     .default_value("80.0")
                     .value_parser(validation::validate_disk_usage)

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -104,12 +104,6 @@ pub struct Cli {
 
     /// The local hot_tier path is used for optimising the query performance in the distributed systems
     pub hot_tier_storage_path: Option<PathBuf>,
-
-    /// Size for local cache
-    pub min_hot_tier_size: u64,
-
-    ///maximum disk usage for hot tier
-    pub max_disk_usage: f64,
 }
 
 impl Cli {
@@ -144,8 +138,6 @@ impl Cli {
     pub const FLIGHT_PORT: &'static str = "flight-port";
     pub const CORS: &'static str = "cors";
     pub const HOT_TIER_PATH: &'static str = "hot-tier-path";
-    pub const MIN_HOT_TIER_SIZE: &'static str = "hot-tier-size";
-    pub const MAX_DISK_USAGE: &'static str = "max-disk-usage";
 
     pub fn local_stream_data_path(&self, stream_name: &str) -> PathBuf {
         self.local_staging_path.join(stream_name)
@@ -417,25 +409,6 @@ impl Cli {
                     .help("Local path on this device to be used for hot tier data")
                     .next_line_help(true),
             )
-            .arg(
-                Arg::new(Self::MIN_HOT_TIER_SIZE)
-                    .long(Self::MIN_HOT_TIER_SIZE)
-                    .env("P_MIN_HOT_TIER_SIZE")
-                    .value_name("size")
-                    .default_value("100GiB")
-                    .value_parser(validation::hot_tier_size)
-                    .help("Minimum allowed cache size for all streams combined (In human readable format, e.g 1GiB, 2GiB, 100MB)")
-                    .next_line_help(true),
-            )
-            .arg(
-                Arg::new(Self::MAX_DISK_USAGE)
-                    .long(Self::MAX_DISK_USAGE)
-                    .env("P_MAX_DISK_USAGE")
-                    .value_name("size")
-                    .default_value("80.0")
-                    .value_parser(validation::disk_usage)
-                    .help("Maximum disk usage for hot tier"),
-            )
             .group(
                 ArgGroup::new("oidc")
                     .args([Self::OPENID_CLIENT_ID, Self::OPENID_CLIENT_SECRET, Self::OPENID_ISSUER])
@@ -574,15 +547,7 @@ impl FromArgMatches for Cli {
         };
 
         self.hot_tier_storage_path = m.get_one::<PathBuf>(Self::HOT_TIER_PATH).cloned();
-        self.min_hot_tier_size = m
-            .get_one::<u64>(Self::MIN_HOT_TIER_SIZE)
-            .cloned()
-            .expect("default value for cache size");
 
-        self.max_disk_usage = m
-            .get_one::<f64>(Self::MAX_DISK_USAGE)
-            .cloned()
-            .expect("default value for max disk usage");
         Ok(())
     }
 }

--- a/server/src/handlers/http/logstream.rs
+++ b/server/src/handlers/http/logstream.rs
@@ -962,13 +962,6 @@ pub async fn put_stream_hot_tier(
         &hottier.size.to_string(),
     )?;
 
-    let storage = CONFIG.storage().get_object_store();
-    let mut stream_metadata = storage.get_object_store_format(&stream_name).await?;
-    stream_metadata.hot_tier_enabled = Some(true);
-    storage
-        .put_stream_manifest(&stream_name, &stream_metadata)
-        .await?;
-
     STREAM_INFO.set_hot_tier(&stream_name, true)?;
     if let Some(hot_tier_manager) = HotTierManager::global() {
         let hottier = StreamHotTier {
@@ -983,6 +976,12 @@ pub async fn put_stream_hot_tier(
 
         hot_tier_manager
             .put_hot_tier(&stream_name, &hottier)
+            .await?;
+        let storage = CONFIG.storage().get_object_store();
+        let mut stream_metadata = storage.get_object_store_format(&stream_name).await?;
+        stream_metadata.hot_tier_enabled = Some(true);
+        storage
+            .put_stream_manifest(&stream_name, &stream_metadata)
             .await?;
     }
 

--- a/server/src/handlers/http/logstream.rs
+++ b/server/src/handlers/http/logstream.rs
@@ -964,18 +964,19 @@ pub async fn put_stream_hot_tier(
 
     STREAM_INFO.set_hot_tier(&stream_name, true)?;
     if let Some(hot_tier_manager) = HotTierManager::global() {
-        let hottier = StreamHotTier {
+        let mut hottier = StreamHotTier {
             start_date: hottier.start_date,
             end_date: hottier.end_date,
             size: hottier.size.clone(),
             used_size: Some("0GiB".to_string()),
             available_size: Some(hottier.size),
+            updated_date_range: None,
         };
 
         hot_tier_manager.validate(&stream_name, &hottier).await?;
 
         hot_tier_manager
-            .put_hot_tier(&stream_name, &hottier)
+            .put_hot_tier(&stream_name, &mut hottier)
             .await?;
         let storage = CONFIG.storage().get_object_store();
         let mut stream_metadata = storage.get_object_store_format(&stream_name).await?;

--- a/server/src/handlers/http/logstream.rs
+++ b/server/src/handlers/http/logstream.rs
@@ -27,6 +27,7 @@ use crate::handlers::{
     CUSTOM_PARTITION_KEY, STATIC_SCHEMA_FLAG, TIME_PARTITION_KEY, TIME_PARTITION_LIMIT_KEY,
     UPDATE_STREAM_KEY,
 };
+use crate::hottier::{HotTierManager, StreamHotTier};
 use crate::metadata::STREAM_INFO;
 use crate::metrics::{EVENTS_INGESTED_DATE, EVENTS_INGESTED_SIZE_DATE, EVENTS_STORAGE_SIZE_DATE};
 use crate::option::{Mode, CONFIG};
@@ -37,6 +38,7 @@ use crate::{
     catalog::{self, remove_manifest_from_snapshot},
     event, stats,
 };
+
 use crate::{metadata, validator};
 use actix_web::http::StatusCode;
 use actix_web::{web, HttpRequest, Responder};
@@ -919,6 +921,91 @@ pub async fn get_stream_info(req: HttpRequest) -> Result<impl Responder, StreamE
     Ok((web::Json(stream_info), StatusCode::OK))
 }
 
+pub async fn put_stream_hot_tier(
+    req: HttpRequest,
+    body: web::Json<serde_json::Value>,
+) -> Result<impl Responder, StreamError> {
+    if CONFIG.parseable.mode != Mode::Query {
+        return Err(StreamError::Custom {
+            msg: "Hot tier can only be enabled in query mode".to_string(),
+            status: StatusCode::BAD_REQUEST,
+        });
+    }
+    let stream_name: String = req.match_info().get("logstream").unwrap().parse().unwrap();
+    if !metadata::STREAM_INFO.stream_exists(&stream_name) {
+        return Err(StreamError::StreamNotFound(stream_name));
+    }
+    if CONFIG.parseable.hot_tier_storage_path.is_none() {
+        return Err(StreamError::HotTierNotEnabled(stream_name));
+    }
+
+    let body = body.into_inner();
+    let hottier: StreamHotTier = match serde_json::from_value(body) {
+        Ok(hottier) => hottier,
+        Err(err) => return Err(StreamError::InvalidHotTierConfig(err)),
+    };
+
+    validator::hot_tier(
+        &hottier.hot_tier_start_date,
+        &hottier.hot_tier_end_date,
+        &hottier.hot_tier_size.to_string(),
+    )?;
+
+    let storage = CONFIG.storage().get_object_store();
+    let mut stream_metadata = storage.get_object_store_format(&stream_name).await?;
+    stream_metadata.hot_tier_enabled = Some(true);
+    storage
+        .put_stream_manifest(&stream_name, &stream_metadata)
+        .await?;
+
+    STREAM_INFO.set_hot_tier(&stream_name, true)?;
+    if let Some(hot_tier_manager) = HotTierManager::global() {
+        let hottier = StreamHotTier {
+            hot_tier_start_date: hottier.hot_tier_start_date,
+            hot_tier_end_date: hottier.hot_tier_end_date,
+            hot_tier_size: hottier.hot_tier_size.clone(),
+            hot_tier_used_size: Some(0.to_string()),
+            hot_tier_available_size: Some(hottier.hot_tier_size),
+        };
+        hot_tier_manager
+            .put_hot_tier(&stream_name, &hottier)
+            .await?;
+    }
+
+    Ok((
+        format!("hot tier set for log stream {stream_name}"),
+        StatusCode::OK,
+    ))
+}
+
+pub async fn get_stream_hot_tier(req: HttpRequest) -> Result<impl Responder, StreamError> {
+    if CONFIG.parseable.mode != Mode::Query {
+        return Err(StreamError::Custom {
+            msg: "Hot tier can only be enabled in query mode".to_string(),
+            status: StatusCode::BAD_REQUEST,
+        });
+    }
+
+    let stream_name: String = req.match_info().get("logstream").unwrap().parse().unwrap();
+
+    if !metadata::STREAM_INFO.stream_exists(&stream_name) {
+        return Err(StreamError::StreamNotFound(stream_name));
+    }
+
+    if CONFIG.parseable.hot_tier_storage_path.is_none() {
+        return Err(StreamError::HotTierNotEnabled(stream_name));
+    }
+
+    if let Some(hot_tier_manager) = HotTierManager::global() {
+        let hot_tier = hot_tier_manager.get_hot_tier(&stream_name).await?;
+        Ok((web::Json(hot_tier), StatusCode::OK))
+    } else {
+        Err(StreamError::Custom {
+            msg: format!("hot tier not initialised for stream {}", stream_name),
+            status: (StatusCode::BAD_REQUEST),
+        })
+    }
+}
 #[allow(unused)]
 fn classify_json_error(kind: serde_json::error::Category) -> StatusCode {
     match kind {
@@ -935,9 +1022,12 @@ pub mod error {
     use http::StatusCode;
 
     use crate::{
+        hottier::HotTierError,
         metadata::error::stream_info::MetadataError,
         storage::ObjectStorageError,
-        validator::error::{AlertValidationError, StreamNameValidationError},
+        validator::error::{
+            AlertValidationError, HotTierValidationError, StreamNameValidationError,
+        },
     };
 
     #[allow(unused)]
@@ -997,6 +1087,16 @@ pub mod error {
         Network(#[from] reqwest::Error),
         #[error("Could not deserialize into JSON object, {0}")]
         SerdeError(#[from] serde_json::Error),
+        #[error(
+            "Hot tier is not enabled at the server config, cannot enable hot tier for stream {0}"
+        )]
+        HotTierNotEnabled(String),
+        #[error("failed to enable hottier due to err: {0}")]
+        InvalidHotTierConfig(serde_json::Error),
+        #[error("Hot tier validation failed due to {0}")]
+        HotTierValidation(#[from] HotTierValidationError),
+        #[error("Failed to update stream hot tier due to err: {0}")]
+        HotTierError(#[from] HotTierError),
     }
 
     impl actix_web::ResponseError for StreamError {
@@ -1030,6 +1130,10 @@ pub mod error {
                 StreamError::Network(err) => {
                     err.status().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
                 }
+                StreamError::HotTierNotEnabled(_) => StatusCode::BAD_REQUEST,
+                StreamError::InvalidHotTierConfig(_) => StatusCode::BAD_REQUEST,
+                StreamError::HotTierValidation(_) => StatusCode::BAD_REQUEST,
+                StreamError::HotTierError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             }
         }
 

--- a/server/src/handlers/http/modal/query_server.rs
+++ b/server/src/handlers/http/modal/query_server.rs
@@ -20,7 +20,7 @@ use crate::handlers::airplane;
 use crate::handlers::http::cluster::{self, init_cluster_metrics_schedular};
 use crate::handlers::http::middleware::RouteExt;
 use crate::handlers::http::{base_path, cross_origin_config, API_BASE_PATH, API_VERSION};
-
+use crate::hottier::HotTierManager;
 use crate::rbac::role::Action;
 use crate::sync;
 use crate::users::dashboards::DASHBOARDS;
@@ -188,6 +188,10 @@ impl QueryServer {
         if matches!(init_cluster_metrics_schedular(), Ok(())) {
             log::info!("Cluster metrics scheduler started successfully");
         }
+
+        if let Some(hot_tier_manager) = HotTierManager::global() {
+            hot_tier_manager.download_from_s3()?;
+        };
         let (localsync_handler, mut localsync_outbox, localsync_inbox) = sync::run_local_sync();
         let (mut remote_sync_handler, mut remote_sync_outbox, mut remote_sync_inbox) =
             sync::object_store_sync();

--- a/server/src/handlers/http/modal/server.rs
+++ b/server/src/handlers/http/modal/server.rs
@@ -343,6 +343,20 @@ impl Server {
                                     .to(logstream::get_cache_enabled)
                                     .authorize_for_stream(Action::GetCacheEnabled),
                             ),
+                    )
+                    .service(
+                        web::resource("/hottier")
+                            // PUT "/logstream/{logstream}/hottier" ==> Set hottier for given logstream
+                            .route(
+                                web::put()
+                                    .to(logstream::put_stream_hot_tier)
+                                    .authorize_for_stream(Action::PutHotTierEnabled),
+                            )
+                            .route(
+                                web::get()
+                                    .to(logstream::get_stream_hot_tier)
+                                    .authorize_for_stream(Action::GetHotTierEnabled),
+                            ),
                     ),
             )
     }

--- a/server/src/handlers/http/modal/server.rs
+++ b/server/src/handlers/http/modal/server.rs
@@ -356,6 +356,11 @@ impl Server {
                                 web::get()
                                     .to(logstream::get_stream_hot_tier)
                                     .authorize_for_stream(Action::GetHotTierEnabled),
+                            )
+                            .route(
+                                web::delete()
+                                    .to(logstream::delete_stream_hot_tier)
+                                    .authorize_for_stream(Action::DeleteHotTierEnabled),
                             ),
                     ),
             )

--- a/server/src/hottier.rs
+++ b/server/src/hottier.rs
@@ -16,7 +16,11 @@
  *
  */
 
-use std::{io, path::PathBuf, sync::Arc};
+use std::{
+    io,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use crate::{
     catalog::manifest::{File, Manifest},
@@ -26,7 +30,7 @@ use crate::{
         CONFIG,
     },
     storage::{ObjectStorage, ObjectStorageError},
-    utils::get_dir_size,
+    utils::{extract_datetime, get_dir_size},
     validator::{error::HotTierValidationError, parse_human_date},
 };
 use chrono::{NaiveDate, Utc};
@@ -38,6 +42,7 @@ use once_cell::sync::OnceCell;
 use parquet::errors::ParquetError;
 use relative_path::RelativePathBuf;
 use std::time::Duration;
+use sysinfo::{Disks, System};
 use tokio::fs::{self, DirEntry};
 use tokio::io::AsyncWriteExt;
 use tokio_stream::wrappers::ReadDirStream;
@@ -83,65 +88,86 @@ impl HotTierManager {
         }))
     }
 
+    ///validate the hot tier configuration, check the disk availability
+    /// update the hot tier range if the disk is not available to download the entire set
+    /// delete the existing hot tier files once validation is successful
     pub async fn validate(
         &self,
         stream: &str,
-        stream_hot_tier: &StreamHotTier,
+        stream_hot_tier: &mut StreamHotTier,
     ) -> Result<(), HotTierError> {
-        let date_list = self.get_date_list(
-            &stream_hot_tier.start_date,
-            &stream_hot_tier.end_date,
-            &None,
-        )?;
-        let object_store = CONFIG.storage().get_object_store();
-        let s3_file_list = object_store.list_files(stream).await?;
-        let mut manifest_list = Vec::new();
-        let mut total_size_to_download = 0;
-        for date in date_list {
-            let date_str = date.to_string();
-            let manifest_files_to_download = s3_file_list
-                .iter()
-                .filter(|file| file.starts_with(&format!("{}/date={}", stream, date_str)))
-                .collect::<Vec<_>>();
+        async fn validate_helper(
+            this: &HotTierManager,
+            stream: &str,
+            stream_hot_tier: &mut StreamHotTier,
+        ) -> Result<(), HotTierError> {
+            let date_list = this.get_date_list(
+                &stream_hot_tier.start_date,
+                &stream_hot_tier.end_date,
+                &stream_hot_tier.updated_date_range,
+            )?;
+            let object_store = CONFIG.storage().get_object_store();
+            let s3_file_list = object_store.list_files(stream).await?;
+            let mut manifest_list = Vec::new();
+            let mut total_size_to_download = 0;
 
-            for file in manifest_files_to_download {
-                let manifest_path: RelativePathBuf = RelativePathBuf::from(file);
-                let manifest_file = object_store.get_object(&manifest_path).await?;
+            for date in &date_list {
+                let date_str = date.to_string();
+                let manifest_files_to_download = s3_file_list
+                    .iter()
+                    .filter(|file| file.starts_with(&format!("{}/date={}", stream, date_str)))
+                    .collect::<Vec<_>>();
 
-                let manifest: Manifest = serde_json::from_slice(&manifest_file)?;
-                manifest_list.push(manifest.clone());
+                for file in manifest_files_to_download {
+                    let manifest_path: RelativePathBuf = RelativePathBuf::from(file);
+                    let manifest_file = object_store.get_object(&manifest_path).await?;
+                    let manifest: Manifest = serde_json::from_slice(&manifest_file)?;
+                    manifest_list.push(manifest.clone());
+                }
             }
-        }
-        for manifest in &manifest_list {
-            total_size_to_download += manifest
-                .files
-                .iter()
-                .map(|file| file.file_size)
-                .sum::<u64>();
-        }
-        if human_size_to_bytes(&stream_hot_tier.size).unwrap() < total_size_to_download {
-            return Err(HotTierError::ObjectStorageError(ObjectStorageError::Custom(
-                format!(
-                    "Total size required to download the files: {}. Provided hot tier size: {}. Not enough space in the hot tier. Please increase the hot tier size and try again.",
-                    bytes_to_human_size(total_size_to_download),
-                    &stream_hot_tier.size
-                ),
-            )));
-        }
-        if let Ok(mut existing_hot_tier) = self.get_hot_tier(stream).await {
-            let available_date_list = self.fetch_hot_tier_dates(stream).await?;
-            self.delete_files_from_hot_tier(
-                &mut existing_hot_tier,
-                stream,
-                &available_date_list,
-                true,
-            )
-            .await?;
+
+            for manifest in &manifest_list {
+                total_size_to_download += manifest
+                    .files
+                    .iter()
+                    .map(|file| file.file_size)
+                    .sum::<u64>();
+            }
+
+            if (!this
+                .is_disk_available(total_size_to_download, &stream_hot_tier.size)
+                .await?
+                || human_size_to_bytes(&stream_hot_tier.size).unwrap() < total_size_to_download)
+                && date_list.len() > 1
+            {
+                stream_hot_tier.updated_date_range = Some(
+                    date_list
+                        .iter()
+                        .skip(1)
+                        .map(|date| date.to_string())
+                        .collect(),
+                );
+                return Box::pin(validate_helper(this, stream, stream_hot_tier)).await;
+            }
+
+            if let Ok(mut existing_hot_tier) = this.get_hot_tier(stream).await {
+                let available_date_list = this.fetch_hot_tier_dates(stream).await?;
+                this.delete_files_from_hot_tier(
+                    &mut existing_hot_tier,
+                    stream,
+                    &available_date_list,
+                    true,
+                )
+                .await?;
+            }
+
+            Ok(())
         }
 
-        Ok(())
+        validate_helper(self, stream, stream_hot_tier).await
     }
 
+    ///get the hot tier metadata file for the stream
     pub async fn get_hot_tier(&self, stream: &str) -> Result<StreamHotTier, HotTierError> {
         if !self.check_stream_hot_tier_exists(stream) {
             return Err(HotTierError::HotTierValidationError(
@@ -160,6 +186,8 @@ impl HotTierManager {
         }
     }
 
+    ///put the hot tier metadata file for the stream
+    /// set the updated_date_range in the hot tier metadata file
     pub async fn put_hot_tier(
         &self,
         stream: &str,
@@ -184,6 +212,7 @@ impl HotTierManager {
         Ok(())
     }
 
+    ///schedule the download of the hot tier files from S3 every minute
     pub fn download_from_s3<'a>(&'a self) -> Result<(), HotTierError>
     where
         'a: 'static,
@@ -207,6 +236,7 @@ impl HotTierManager {
         Ok(())
     }
 
+    ///sync the hot tier files from S3 to the hot tier directory for all streams
     async fn sync_hot_tier(&self) -> Result<(), HotTierError> {
         let streams = STREAM_INFO.list_streams();
         for stream in streams {
@@ -217,6 +247,8 @@ impl HotTierManager {
         Ok(())
     }
 
+    ///process the hot tier files for the stream
+    /// delete the files from the hot tier directory if the available date range is outside the hot tier range
     async fn process_stream(&self, stream: String) -> Result<(), HotTierError> {
         let mut stream_hot_tier = self.get_hot_tier(&stream).await?;
         let mut parquet_file_size =
@@ -250,6 +282,9 @@ impl HotTierManager {
         Ok(())
     }
 
+    ///get the list of date range from hot tier metadata
+    /// if updated_date_range is available, get the list of dates from the updated_date_range
+    /// else get the list of dates from the start and end date
     fn get_date_list(
         &self,
         start_date: &str,
@@ -273,6 +308,10 @@ impl HotTierManager {
         Ok(date_list)
     }
 
+    ///process the hot tier files for the date for the stream
+    /// collect all manifests from S3 for the date, sort the parquet file list
+    /// in order to download the latest files first
+    /// download the parquet files if not present in hot tier directory
     async fn process_date(
         &self,
         stream: &str,
@@ -307,62 +346,93 @@ impl HotTierManager {
             let manifest: Manifest = serde_json::from_slice(&manifest_file)?;
             manifest_list.push(manifest.clone());
         }
-
+        let mut parquet_file_list = Vec::new();
         for manifest in manifest_list {
-            for parquet_file in manifest.files {
-                self.process_parquet_file(
-                    stream,
-                    stream_hot_tier,
-                    &parquet_file,
-                    parquet_file_size,
-                )
-                .await?;
+            parquet_file_list.extend(manifest.files);
+        }
+        parquet_file_list.sort_by_key(|file| file.file_path.clone());
+        parquet_file_list.reverse();
+        for parquet_file in parquet_file_list {
+            let parquet_file_path = &parquet_file.file_path;
+            let parquet_path = self.hot_tier_path.join(parquet_file_path);
+            if !parquet_path.exists() {
+                if !self
+                    .process_parquet_file(
+                        stream,
+                        stream_hot_tier,
+                        &parquet_file,
+                        parquet_file_size,
+                        parquet_path,
+                    )
+                    .await?
+                {
+                    break;
+                }
+            } else {
+                continue;
             }
         }
+
         Ok(())
     }
 
+    ///process the parquet file for the stream
+    /// check if the disk is available to download the parquet file
+    /// if not available, delete the oldest entry from the hot tier directory
+    /// download the parquet file from S3 to the hot tier directory
+    /// update the used and available size in the hot tier metadata
+    /// return true if the parquet file is processed successfully
     async fn process_parquet_file(
         &self,
         stream: &str,
         stream_hot_tier: &mut StreamHotTier,
         parquet_file: &File,
         parquet_file_size: &mut u64,
-    ) -> Result<(), HotTierError> {
-        let parquet_file_path = &parquet_file.file_path;
-        let parquet_path = self.hot_tier_path.join(parquet_file_path);
-
-        if !parquet_path.exists() {
-            let parquet_file_path = RelativePathBuf::from(parquet_file_path);
-            if human_size_to_bytes(&stream_hot_tier.available_size.clone().unwrap()).unwrap()
+        parquet_path: PathBuf,
+    ) -> Result<bool, HotTierError> {
+        let mut file_processed = false;
+        if !self
+            .is_disk_available(parquet_file.file_size, &stream_hot_tier.size)
+            .await?
+            || human_size_to_bytes(&stream_hot_tier.available_size.clone().unwrap()).unwrap()
                 <= parquet_file.file_size
+        {
+            if !self
+                .delete_1minute_data(
+                    stream,
+                    stream_hot_tier,
+                    &parquet_path,
+                    parquet_file.file_size,
+                )
+                .await?
             {
-                let date_list = self.fetch_hot_tier_dates(stream).await?;
-                let date_to_delete = vec![*date_list.first().unwrap()];
-                self.delete_files_from_hot_tier(stream_hot_tier, stream, &date_to_delete, false)
-                    .await?;
-                *parquet_file_size =
-                    human_size_to_bytes(&stream_hot_tier.used_size.clone().unwrap()).unwrap();
+                return Ok(file_processed);
             }
-
-            fs::create_dir_all(parquet_path.parent().unwrap()).await?;
-            let mut file = fs::File::create(parquet_path.clone()).await?;
-            let parquet_data = CONFIG
-                .storage()
-                .get_object_store()
-                .get_object(&parquet_file_path)
-                .await?;
-            file.write_all(&parquet_data).await?;
-            *parquet_file_size += parquet_file.file_size;
-            stream_hot_tier.used_size = Some(bytes_to_human_size(*parquet_file_size));
-            stream_hot_tier.available_size = Some(bytes_to_human_size(
-                human_size_to_bytes(&stream_hot_tier.available_size.clone().unwrap()).unwrap()
-                    - parquet_file.file_size,
-            ));
+            *parquet_file_size =
+                human_size_to_bytes(&stream_hot_tier.used_size.clone().unwrap()).unwrap();
         }
-        Ok(())
+        let parquet_file_path = RelativePathBuf::from(parquet_file.file_path.clone());
+        fs::create_dir_all(parquet_path.parent().unwrap()).await?;
+        let mut file = fs::File::create(parquet_path.clone()).await?;
+        let parquet_data = CONFIG
+            .storage()
+            .get_object_store()
+            .get_object(&parquet_file_path)
+            .await?;
+        file.write_all(&parquet_data).await?;
+        *parquet_file_size += parquet_file.file_size;
+        stream_hot_tier.used_size = Some(bytes_to_human_size(*parquet_file_size));
+
+        stream_hot_tier.available_size = Some(bytes_to_human_size(
+            human_size_to_bytes(&stream_hot_tier.available_size.clone().unwrap()).unwrap()
+                - parquet_file.file_size,
+        ));
+        file_processed = true;
+        Ok(file_processed)
     }
 
+    ///delete the files for the date range given from the hot tier directory for the stream
+    /// update the used and available size in the hot tier metadata
     pub async fn delete_files_from_hot_tier(
         &self,
         stream_hot_tier: &mut StreamHotTier,
@@ -381,7 +451,7 @@ impl HotTierManager {
                     {
                         return Err(HotTierError::ObjectStorageError(ObjectStorageError::Custom(
                             format!(
-                                "Hot tier capacity for stream {} is exhausted (Total: {}, Available - {})Today's data cannot be deleted. Please increase the hot tier size. Download will resume tomorrow"
+                                "Hot tier capacity for stream {} is exhausted (Total: {}, Available - {}). Today's data cannot be deleted. Please increase the hot tier size. Download will resume tomorrow"
                             , stream, stream_hot_tier.size, stream_hot_tier.available_size.clone().unwrap()) )));
                     }
                     stream_hot_tier.used_size = Some(bytes_to_human_size(
@@ -393,6 +463,7 @@ impl HotTierManager {
                             .unwrap()
                             + size,
                     ));
+                    self.put_hot_tier(stream, stream_hot_tier).await?;
                 }
                 fs::remove_dir_all(path.clone()).await?;
             }
@@ -403,6 +474,7 @@ impl HotTierManager {
         Ok(())
     }
 
+    ///check if the current date is the last date available in the hot tier directory
     async fn check_current_date_for_deletion(
         &self,
         stream_hot_tier: &StreamHotTier,
@@ -417,6 +489,7 @@ impl HotTierManager {
         Ok(available_date_list.len() == 1 && is_current_date_available && is_end_date_today)
     }
 
+    ///fetch the list of dates available in the hot tier directory for the stream and sort them
     pub async fn fetch_hot_tier_dates(&self, stream: &str) -> Result<Vec<NaiveDate>, HotTierError> {
         let mut date_list = Vec::new();
         let path = self.hot_tier_path.join(stream);
@@ -438,19 +511,35 @@ impl HotTierManager {
         Ok(date_list)
     }
 
+    ///update the hot tier time range for the stream
+    /// remove the date given from the updated_date_range
+    /// put the hot tier metadata file for the stream
     pub async fn update_hot_tier_time_range(
         &self,
         stream: &str,
         stream_hot_tier: &mut StreamHotTier,
         date: &str,
     ) -> Result<(), HotTierError> {
+        if stream_hot_tier.updated_date_range.as_ref().unwrap().len() == 1
+            && stream_hot_tier
+                .updated_date_range
+                .as_ref()
+                .unwrap()
+                .contains(&Utc::now().date_naive().to_string())
+        {
+            return Ok(());
+        }
         let mut existing_date_range = stream_hot_tier.updated_date_range.as_ref().unwrap().clone();
         existing_date_range.retain(|d| d != date);
         stream_hot_tier.updated_date_range = Some(existing_date_range);
+
         self.put_hot_tier(stream, stream_hot_tier).await?;
         Ok(())
     }
 
+    ///get the updated hot tier time range for the stream
+    /// get the existing dates from the updated_date_range
+    /// update the updated_date_range with the existing dates and the new dates
     pub async fn get_hot_tier_time_range(
         &self,
         stream_hot_tier: &StreamHotTier,
@@ -480,6 +569,7 @@ impl HotTierManager {
         Ok(updated_date_range)
     }
 
+    ///get the list of files from all the manifests present in hot tier directory for the stream
     pub async fn get_hot_tier_manifest_files(
         &self,
         stream: &str,
@@ -498,6 +588,7 @@ impl HotTierManager {
         Ok((hot_tier_files, remaining_files))
     }
 
+    ///get the list of parquet files from the hot tier directory for the stream
     pub async fn get_hot_tier_parquet_files(
         &self,
         stream: &str,
@@ -534,6 +625,8 @@ impl HotTierManager {
         }
         Ok(hot_tier_parquet_files)
     }
+
+    ///check if the hot tier metadata file exists for the stream
     pub fn check_stream_hot_tier_exists(&self, stream: &str) -> bool {
         let path = self
             .hot_tier_path
@@ -541,14 +634,183 @@ impl HotTierManager {
             .join(STREAM_HOT_TIER_FILENAME);
         path.exists()
     }
+
+    ///delete the parquet file from the hot tier directory for the stream
+    /// loop through all manifests in the hot tier directory for the stream
+    /// loop through all parquet files in the manifest
+    /// check for the oldest entry to delete if the path exists in hot tier
+    /// update the used and available size in the hot tier metadata
+    /// loop if available size is still less than the parquet file size
+    pub async fn delete_1minute_data(
+        &self,
+        stream: &str,
+        stream_hot_tier: &mut StreamHotTier,
+        download_file_path: &Path,
+        parquet_file_size: u64,
+    ) -> Result<bool, HotTierError> {
+        let mut delete_successful = false;
+        let date_list = self.get_date_list(
+            &stream_hot_tier.start_date,
+            &stream_hot_tier.end_date,
+            &stream_hot_tier.updated_date_range,
+        )?;
+
+        if let Some(date_to_delete) = date_list.first() {
+            let date_str = date_to_delete.to_string();
+            let path = self
+                .hot_tier_path
+                .join(stream)
+                .join(format!("date={}", date_str));
+
+            if !path.exists() {
+                return Ok(delete_successful);
+            }
+
+            let date_dirs = ReadDirStream::new(fs::read_dir(&path).await?);
+            let mut manifest_files: Vec<DirEntry> = date_dirs.try_collect().await?;
+            manifest_files.retain(|file| {
+                file.file_name()
+                    .to_string_lossy()
+                    .ends_with("manifest.json")
+            });
+            'loop_manifests: for manifest_file in manifest_files {
+                let file = fs::read(manifest_file.path()).await?;
+                let mut manifest: Manifest = serde_json::from_slice(&file)?;
+
+                manifest.files.sort_by_key(|file| file.file_path.clone());
+                manifest.files.reverse();
+
+                'loop_files: while let Some(file_to_delete) = manifest.files.pop() {
+                    let file_size = file_to_delete.file_size;
+                    let path_to_delete = CONFIG
+                        .parseable
+                        .hot_tier_storage_path
+                        .as_ref()
+                        .unwrap()
+                        .join(&file_to_delete.file_path);
+
+                    if path_to_delete.exists() {
+                        if let (Some(download_date_time), Some(delete_date_time)) = (
+                            extract_datetime(download_file_path.to_str().unwrap()),
+                            extract_datetime(path_to_delete.to_str().unwrap()),
+                        ) {
+                            if download_date_time <= delete_date_time {
+                                delete_successful = false;
+                                break 'loop_files;
+                            }
+                        }
+
+                        fs::write(manifest_file.path(), serde_json::to_vec(&manifest)?).await?;
+                        fs::remove_dir_all(&path_to_delete.parent().unwrap()).await?;
+
+                        stream_hot_tier.used_size = Some(bytes_to_human_size(
+                            human_size_to_bytes(&stream_hot_tier.used_size.clone().unwrap())
+                                .unwrap()
+                                - file_size,
+                        ));
+                        stream_hot_tier.available_size = Some(bytes_to_human_size(
+                            human_size_to_bytes(&stream_hot_tier.available_size.clone().unwrap())
+                                .unwrap()
+                                + file_size,
+                        ));
+                        self.put_hot_tier(stream, stream_hot_tier).await?;
+                        delete_successful = true;
+
+                        if human_size_to_bytes(&stream_hot_tier.available_size.clone().unwrap())
+                            .unwrap()
+                            <= parquet_file_size
+                        {
+                            continue 'loop_files;
+                        } else {
+                            break 'loop_manifests;
+                        }
+                    } else {
+                        fs::write(manifest_file.path(), serde_json::to_vec(&manifest)?).await?;
+                    }
+                }
+            }
+        }
+        Ok(delete_successful)
+    }
+
+    ///check if the disk is available to download the parquet file
+    /// check if the disk usage is above the threshold
+    pub async fn is_disk_available(
+        &self,
+        size_to_download: u64,
+        hot_tier_size: &str,
+    ) -> Result<bool, HotTierError> {
+        let (total_disk_space, available_disk_space, used_disk_space) = get_disk_usage();
+
+        if let Some(available_space) = available_disk_space {
+            let hot_tier_size = human_size_to_bytes(hot_tier_size).unwrap();
+            if available_space < hot_tier_size {
+                return Err(HotTierError::ObjectStorageError(ObjectStorageError::Custom(format!(
+                    "Not enough space left in the disk for hot tier. Disk available Size: {}, Hot Tier Size: {}",
+                    bytes_to_human_size(available_space),
+                    bytes_to_human_size(hot_tier_size)
+                ))));
+            }
+
+            if used_disk_space.unwrap() as f64 * 100.0 / total_disk_space.unwrap() as f64
+                > CONFIG.parseable.max_disk_usage
+            {
+                return Err(HotTierError::ObjectStorageError(ObjectStorageError::Custom(format!(
+                    "Disk usage is above the threshold. Disk Used Size: {}, Disk Total Size: {}, Disk Usage {}%",
+                    bytes_to_human_size(used_disk_space.unwrap()),
+                    bytes_to_human_size(total_disk_space.unwrap()),
+                    used_disk_space.unwrap() as f64 * 100.0 / total_disk_space.unwrap() as f64
+                ))));
+            }
+            if available_space < size_to_download {
+                return Ok(false);
+            }
+
+            if ((used_disk_space.unwrap() + size_to_download) as f64 * 100.0
+                / total_disk_space.unwrap() as f64)
+                > CONFIG.parseable.max_disk_usage
+            {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
 }
 
+/// get the hot tier file path for the stream
 pub fn hot_tier_file_path(
     root: impl AsRef<std::path::Path>,
     stream: &str,
 ) -> Result<object_store::path::Path, object_store::path::Error> {
     let path = root.as_ref().join(stream).join(STREAM_HOT_TIER_FILENAME);
     object_store::path::Path::from_absolute_path(path)
+}
+
+///get the disk usage for the hot tier storage path
+pub fn get_disk_usage() -> (Option<u64>, Option<u64>, Option<u64>) {
+    let mut sys = System::new_all();
+    sys.refresh_all();
+    let path = CONFIG.parseable.hot_tier_storage_path.as_ref().unwrap();
+
+    let mut disks = Disks::new_with_refreshed_list();
+    disks.sort_by_key(|disk| disk.mount_point().to_str().unwrap().len());
+    disks.reverse();
+
+    for disk in disks.iter() {
+        if path.starts_with(disk.mount_point().to_str().unwrap()) {
+            let total_disk_space = disk.total_space();
+            let available_disk_space = disk.available_space();
+            let used_disk_space = total_disk_space - available_disk_space;
+            return (
+                Some(total_disk_space),
+                Some(available_disk_space),
+                Some(used_disk_space),
+            );
+        }
+    }
+
+    (None, None, None)
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/server/src/hottier.rs
+++ b/server/src/hottier.rs
@@ -575,7 +575,12 @@ impl HotTierManager {
         stream: &str,
         manifest_files: Vec<File>,
     ) -> Result<(Vec<File>, Vec<File>), HotTierError> {
-        let hot_tier_files = self.get_hot_tier_parquet_files(stream).await?;
+        let mut hot_tier_files = self.get_hot_tier_parquet_files(stream).await?;
+        hot_tier_files.retain(|file| {
+            manifest_files
+                .iter()
+                .any(|manifest_file| manifest_file.file_path.eq(&file.file_path))
+        });
         let remaining_files: Vec<File> = manifest_files
             .into_iter()
             .filter(|manifest_file| {
@@ -584,7 +589,6 @@ impl HotTierManager {
                     .all(|file| !file.file_path.eq(&manifest_file.file_path))
             })
             .collect();
-
         Ok((hot_tier_files, remaining_files))
     }
 

--- a/server/src/hottier.rs
+++ b/server/src/hottier.rs
@@ -1,0 +1,318 @@
+/*
+ * Parseable Server (C) 2022 - 2024 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use std::{io, path::PathBuf};
+
+use crate::{
+    catalog::manifest::{File, Manifest},
+    metadata::{error::stream_info::MetadataError, STREAM_INFO},
+    option::{
+        validation::{bytes_to_human_size, human_size_to_bytes},
+        CONFIG,
+    },
+    storage::ObjectStorageError,
+};
+use chrono::NaiveDate;
+use clokwerk::{AsyncScheduler, Interval};
+use futures_util::TryFutureExt;
+use object_store::{local::LocalFileSystem, ObjectStore};
+use once_cell::sync::OnceCell;
+use parquet::errors::ParquetError;
+use relative_path::RelativePathBuf;
+use std::time::Duration;
+use tokio::fs::{self};
+use tokio::io::AsyncWriteExt;
+
+pub const STREAM_HOT_TIER_FILENAME: &str = ".hot_tier.json";
+
+const HOT_TIER_SYNC_DURATION: Interval = clokwerk::Interval::Minutes(1);
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct StreamHotTier {
+    #[serde(rename = "hotTierSize")]
+    pub hot_tier_size: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hot_tier_used_size: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hot_tier_available_size: Option<String>,
+    #[serde(rename = "hotTierStartDate")]
+    pub hot_tier_start_date: String,
+    #[serde(rename = "hotTierEndDate")]
+    pub hot_tier_end_date: String,
+}
+
+pub struct HotTierManager {
+    filesystem: LocalFileSystem,
+    hot_tier_path: PathBuf,
+}
+
+impl HotTierManager {
+    pub fn global() -> Option<&'static HotTierManager> {
+        static INSTANCE: OnceCell<HotTierManager> = OnceCell::new();
+
+        let hot_tier_path = CONFIG.parseable.hot_tier_storage_path.as_ref()?;
+
+        Some(INSTANCE.get_or_init(|| {
+            let hot_tier_path = hot_tier_path.clone();
+            std::fs::create_dir_all(&hot_tier_path).unwrap();
+            HotTierManager {
+                filesystem: LocalFileSystem::new(),
+                hot_tier_path,
+            }
+        }))
+    }
+
+    pub async fn get_hot_tier(&self, stream: &str) -> Result<StreamHotTier, HotTierError> {
+        let path = hot_tier_file_path(&self.hot_tier_path, stream)?;
+        let res = self
+            .filesystem
+            .get(&path)
+            .and_then(|resp| resp.bytes())
+            .await;
+        match res {
+            Ok(bytes) => serde_json::from_slice(&bytes).map_err(Into::into),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    pub async fn put_hot_tier(
+        &self,
+        stream: &str,
+        hot_tier: &StreamHotTier,
+    ) -> Result<(), HotTierError> {
+        let path = hot_tier_file_path(&self.hot_tier_path, stream)?;
+        let bytes = serde_json::to_vec(hot_tier)?.into();
+        self.filesystem.put(&path, bytes).await?;
+        Ok(())
+    }
+
+    pub fn download_from_s3<'a>(&'a self) -> Result<(), HotTierError>
+    where
+        'a: 'static,
+    {
+        let mut scheduler = AsyncScheduler::new();
+        scheduler.every(HOT_TIER_SYNC_DURATION).run(move || async {
+            if let Err(err) = self.sync_hot_tier().await {
+                log::error!("Error in hot tier scheduler: {:?}", err);
+            }
+        });
+
+        tokio::spawn(async move {
+            loop {
+                scheduler.run_pending().await;
+                tokio::time::sleep(Duration::from_secs(10)).await;
+            }
+        });
+        Ok(())
+    }
+
+    async fn sync_hot_tier(&self) -> Result<(), HotTierError> {
+        let streams = STREAM_INFO.list_streams();
+        for stream in streams {
+            if STREAM_INFO.get_hot_tier(&stream).unwrap_or(false) {
+                self.process_stream(stream).await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn process_stream(&self, stream: String) -> Result<(), HotTierError> {
+        let mut stream_hot_tier = self.get_hot_tier(&stream).await?;
+        let mut parquet_file_size =
+            human_size_to_bytes(&stream_hot_tier.hot_tier_used_size.clone().unwrap()).unwrap();
+        let date_list = self.get_date_list(
+            &stream_hot_tier.hot_tier_start_date,
+            &stream_hot_tier.hot_tier_end_date,
+        )?;
+
+        let object_store = CONFIG.storage().get_object_store();
+        let s3_file_list = object_store.list_files(&stream).await?;
+
+        for date in date_list {
+            self.process_date(
+                &stream,
+                &mut stream_hot_tier,
+                &s3_file_list,
+                date,
+                &mut parquet_file_size,
+            )
+            .await?;
+        }
+
+        self.put_hot_tier(&stream, &stream_hot_tier).await?;
+        Ok(())
+    }
+
+    fn get_date_list(
+        &self,
+        start_date: &str,
+        end_date: &str,
+    ) -> Result<Vec<NaiveDate>, HotTierError> {
+        let start_date = NaiveDate::parse_from_str(start_date, "%Y-%m-%d").unwrap();
+        let end_date = NaiveDate::parse_from_str(end_date, "%Y-%m-%d").unwrap();
+        let mut date_list = Vec::new();
+        let mut current_date = start_date;
+        while current_date <= end_date {
+            date_list.push(current_date);
+            current_date += chrono::Duration::days(1);
+        }
+        Ok(date_list)
+    }
+
+    async fn process_date(
+        &self,
+        stream: &str,
+        stream_hot_tier: &mut StreamHotTier,
+        s3_file_list: &[String],
+        date: NaiveDate,
+        parquet_file_size: &mut u64,
+    ) -> Result<(), HotTierError> {
+        let date_str = date.to_string();
+        let manifest_files_to_download = s3_file_list
+            .iter()
+            .filter(|file| file.starts_with(&format!("{}/date={}", stream, date_str)))
+            .collect::<Vec<_>>();
+
+        for file in manifest_files_to_download {
+            let path = self.hot_tier_path.join(file);
+            fs::create_dir_all(path.parent().unwrap()).await?;
+            let manifest_path: RelativePathBuf = RelativePathBuf::from(file);
+            let manifest_file = CONFIG
+                .storage()
+                .get_object_store()
+                .get_object(&manifest_path)
+                .await?;
+            let mut file = fs::File::create(path.clone()).await?;
+            file.write_all(&manifest_file).await?;
+            let manifest: Manifest = serde_json::from_slice(&manifest_file)?;
+
+            for parquet_file in manifest.files {
+                self.process_parquet_file(
+                    stream,
+                    stream_hot_tier,
+                    &parquet_file,
+                    parquet_file_size,
+                )
+                .await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn process_parquet_file(
+        &self,
+        stream: &str,
+        stream_hot_tier: &mut StreamHotTier,
+        parquet_file: &File,
+        parquet_file_size: &mut u64,
+    ) -> Result<(), HotTierError> {
+        let parquet_file_path = &parquet_file.file_path;
+        let parquet_path = self.hot_tier_path.join(parquet_file_path);
+
+        if !parquet_path.exists() {
+            fs::create_dir_all(parquet_path.parent().unwrap()).await?;
+            let parquet_file_path = RelativePathBuf::from(parquet_file_path);
+
+            if human_size_to_bytes(&stream_hot_tier.hot_tier_available_size.clone().unwrap())
+                .unwrap()
+                <= parquet_file.file_size
+            {
+                self.delete_from_hot_tier(
+                    stream,
+                    &self.get_date_list(
+                        &stream_hot_tier.hot_tier_start_date,
+                        &stream_hot_tier.hot_tier_end_date,
+                    )?[0],
+                )
+                .await?;
+                fs::create_dir_all(parquet_path.parent().unwrap()).await?;
+                let mut file = fs::File::create(parquet_path.clone()).await?;
+                let parquet_data = CONFIG
+                    .storage()
+                    .get_object_store()
+                    .get_object(&parquet_file_path)
+                    .await?;
+                file.write_all(&parquet_data).await?;
+                *parquet_file_size += parquet_file.file_size;
+                stream_hot_tier.hot_tier_used_size = Some(bytes_to_human_size(*parquet_file_size));
+                stream_hot_tier.hot_tier_available_size = Some(bytes_to_human_size(
+                    human_size_to_bytes(&stream_hot_tier.hot_tier_available_size.clone().unwrap())
+                        .unwrap()
+                        - parquet_file.file_size,
+                ));
+            } else {
+                let mut file = fs::File::create(parquet_path.clone()).await?;
+                let parquet_data = CONFIG
+                    .storage()
+                    .get_object_store()
+                    .get_object(&parquet_file_path)
+                    .await?;
+                file.write_all(&parquet_data).await?;
+                *parquet_file_size += parquet_file.file_size;
+                stream_hot_tier.hot_tier_used_size = Some(bytes_to_human_size(*parquet_file_size));
+                stream_hot_tier.hot_tier_available_size = Some(bytes_to_human_size(
+                    human_size_to_bytes(&stream_hot_tier.hot_tier_available_size.clone().unwrap())
+                        .unwrap()
+                        - parquet_file.file_size,
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn delete_from_hot_tier(
+        &self,
+        stream: &str,
+        date: &NaiveDate,
+    ) -> Result<(), HotTierError> {
+        let path = self.hot_tier_path.join(format!("{}/date={}", stream, date));
+        if path.exists() {
+            fs::remove_dir_all(path).await?;
+        }
+
+        Ok(())
+    }
+}
+
+pub fn hot_tier_file_path(
+    root: impl AsRef<std::path::Path>,
+    stream: &str,
+) -> Result<object_store::path::Path, object_store::path::Error> {
+    let path = root.as_ref().join(stream).join(STREAM_HOT_TIER_FILENAME);
+    object_store::path::Path::from_absolute_path(path)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum HotTierError {
+    #[error("{0}")]
+    Serde(#[from] serde_json::Error),
+    #[error("{0}")]
+    IOError(#[from] io::Error),
+    #[error("{0}")]
+    MoveError(#[from] fs_extra::error::Error),
+    #[error("{0}")]
+    ObjectStoreError(#[from] object_store::Error),
+    #[error("{0}")]
+    ObjectStorePathError(#[from] object_store::path::Error),
+    #[error("{0}")]
+    ObjectStorageError(#[from] ObjectStorageError),
+    #[error("{0}")]
+    ParquetError(#[from] ParquetError),
+    #[error("{0}")]
+    MetadataError(#[from] MetadataError),
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -24,6 +24,7 @@ mod catalog;
 mod cli;
 mod event;
 mod handlers;
+mod hottier;
 mod livetail;
 mod localcache;
 mod metadata;

--- a/server/src/metadata.rs
+++ b/server/src/metadata.rs
@@ -61,6 +61,7 @@ pub struct LogStreamMetadata {
     pub time_partition_limit: Option<String>,
     pub custom_partition: Option<String>,
     pub static_schema_flag: Option<String>,
+    pub hot_tier_enabled: Option<bool>,
 }
 
 // It is very unlikely that panic will occur when dealing with metadata.
@@ -248,6 +249,22 @@ impl StreamInfo {
         Ok(())
     }
 
+    pub fn set_hot_tier(&self, stream_name: &str, enable: bool) -> Result<(), MetadataError> {
+        let mut map = self.write().expect(LOCK_EXPECT);
+        let stream = map
+            .get_mut(stream_name)
+            .ok_or(MetadataError::StreamMetaNotFound(stream_name.to_string()))?;
+        stream.hot_tier_enabled = Some(enable);
+        Ok(())
+    }
+
+    pub fn get_hot_tier(&self, stream_name: &str) -> Result<bool, MetadataError> {
+        let map = self.read().expect(LOCK_EXPECT);
+        map.get(stream_name)
+            .ok_or(MetadataError::StreamMetaNotFound(stream_name.to_string()))
+            .map(|metadata| metadata.hot_tier_enabled.unwrap_or(false))
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn add_stream(
         &self,
@@ -330,6 +347,7 @@ impl StreamInfo {
             time_partition_limit: meta.time_partition_limit,
             custom_partition: meta.custom_partition,
             static_schema_flag: meta.static_schema_flag,
+            hot_tier_enabled: meta.hot_tier_enabled,
         };
 
         let mut map = self.write().expect(LOCK_EXPECT);
@@ -459,6 +477,7 @@ pub async fn load_stream_metadata_on_server_start(
         time_partition_limit,
         custom_partition,
         static_schema_flag: meta.static_schema_flag.clone(),
+        hot_tier_enabled: meta.hot_tier_enabled,
     };
 
     let mut map = STREAM_INFO.write().expect(LOCK_EXPECT);

--- a/server/src/metadata.rs
+++ b/server/src/metadata.rs
@@ -258,13 +258,6 @@ impl StreamInfo {
         Ok(())
     }
 
-    pub fn get_hot_tier(&self, stream_name: &str) -> Result<bool, MetadataError> {
-        let map = self.read().expect(LOCK_EXPECT);
-        map.get(stream_name)
-            .ok_or(MetadataError::StreamMetaNotFound(stream_name.to_string()))
-            .map(|metadata| metadata.hot_tier_enabled.unwrap_or(false))
-    }
-
     #[allow(clippy::too_many_arguments)]
     pub fn add_stream(
         &self,

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -328,7 +328,7 @@ pub mod validation {
         url::Url::parse(s).map_err(|_| "Invalid URL provided".to_string())
     }
 
-    fn human_size_to_bytes(s: &str) -> Result<u64, String> {
+    pub fn human_size_to_bytes(s: &str) -> Result<u64, String> {
         fn parse_and_map<T: human_size::Multiple>(
             s: &str,
         ) -> Result<u64, human_size::ParsingError> {
@@ -343,13 +343,29 @@ pub mod validation {
             .or(parse_and_map::<multiples::Terabyte>(s))
             .map_err(|_| "Could not parse given size".to_string())?;
 
-        if size < MIN_CACHE_SIZE_BYTES {
-            return Err(
-                "Specified value of cache size is smaller than current minimum of 1GiB".to_string(),
-            );
-        }
-
         Ok(size)
+    }
+
+    pub fn bytes_to_human_size(bytes: u64) -> String {
+        const KIB: u64 = 1024;
+        const MIB: u64 = KIB * 1024;
+        const GIB: u64 = MIB * 1024;
+        const TIB: u64 = GIB * 1024;
+        const PIB: u64 = TIB * 1024;
+
+        if bytes < KIB {
+            format!("{} B", bytes)
+        } else if bytes < MIB {
+            format!("{:.2} KB", bytes as f64 / KIB as f64)
+        } else if bytes < GIB {
+            format!("{:.2} MiB", bytes as f64 / MIB as f64)
+        } else if bytes < TIB {
+            format!("{:.2} GiB", bytes as f64 / GIB as f64)
+        } else if bytes < PIB {
+            format!("{:.2} TiB", bytes as f64 / TIB as f64)
+        } else {
+            format!("{:.2} PiB", bytes as f64 / PIB as f64)
+        }
     }
 
     pub fn cache_size(s: &str) -> Result<u64, String> {

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -28,7 +28,7 @@ use parquet::basic::{BrotliLevel, GzipLevel, ZstdLevel};
 use std::env;
 use std::path::PathBuf;
 use std::sync::Arc;
-pub const MIN_CACHE_SIZE_BYTES: u64 = 1000u64.pow(3); // 1 GiB
+pub const MIN_CACHE_SIZE_BYTES: u64 = 1073741824; // 1 GiB
 pub const JOIN_COMMUNITY: &str =
     "Join us on Parseable Slack community for questions : https://logg.ing/community";
 pub static CONFIG: Lazy<Arc<Config>> = Lazy::new(|| Arc::new(Config::new()));
@@ -342,7 +342,6 @@ pub mod validation {
             .or(parse_and_map::<multiples::Tebibyte>(s))
             .or(parse_and_map::<multiples::Terabyte>(s))
             .map_err(|_| "Could not parse given size".to_string())?;
-
         Ok(size)
     }
 
@@ -371,10 +370,28 @@ pub mod validation {
     pub fn cache_size(s: &str) -> Result<u64, String> {
         let size = human_size_to_bytes(s)?;
         if size < MIN_CACHE_SIZE_BYTES {
+            return Err(format!(
+                "Specified value of cache size is smaller than current minimum of {}",
+                human_size_to_bytes(&MIN_CACHE_SIZE_BYTES.to_string()).unwrap()
+            ));
+        }
+        Ok(size)
+    }
+
+    pub fn hot_tier_size(s: &str) -> Result<u64, String> {
+        let size = human_size_to_bytes(s)?;
+        if size < MIN_CACHE_SIZE_BYTES {
             return Err(
                 "Specified value of cache size is smaller than current minimum of 1GiB".to_string(),
             );
         }
         Ok(size)
+    }
+
+    pub fn disk_usage(s: &str) -> Result<f64, String> {
+        let disk_usage = s
+            .parse::<f64>()
+            .map_err(|_| "Invalid disk usage value".to_string())?;
+        Ok(disk_usage)
     }
 }

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -30,7 +30,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 pub const MIN_CACHE_SIZE_BYTES: u64 = 1073741824; // 1 GiB
 
-pub const MAX_DISK_USAGE: f64 = 80.0; //max disk usage is 80%
 pub const JOIN_COMMUNITY: &str =
     "Join us on Parseable Slack community for questions : https://logg.ing/community";
 pub static CONFIG: Lazy<Arc<Config>> = Lazy::new(|| Arc::new(Config::new()));
@@ -378,5 +377,17 @@ pub mod validation {
             ));
         }
         Ok(size)
+    }
+
+    pub fn validate_disk_usage(max_disk_usage: &str) -> Result<f64, String> {
+        if let Ok(max_disk_usage) = max_disk_usage.parse::<f64>() {
+            if (0.0..=100.0).contains(&max_disk_usage) {
+                Ok(max_disk_usage)
+            } else {
+                Err("Invalid value for max disk usage. It should be between 0 and 100".to_string())
+            }
+        } else {
+            Err("Invalid value for max disk usage. It should be given as 90.0 for 90%".to_string())
+        }
     }
 }

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -29,6 +29,8 @@ use std::env;
 use std::path::PathBuf;
 use std::sync::Arc;
 pub const MIN_CACHE_SIZE_BYTES: u64 = 1073741824; // 1 GiB
+
+pub const MAX_DISK_USAGE: f64 = 80.0; //max disk usage is 80%
 pub const JOIN_COMMUNITY: &str =
     "Join us on Parseable Slack community for questions : https://logg.ing/community";
 pub static CONFIG: Lazy<Arc<Config>> = Lazy::new(|| Arc::new(Config::new()));
@@ -376,22 +378,5 @@ pub mod validation {
             ));
         }
         Ok(size)
-    }
-
-    pub fn hot_tier_size(s: &str) -> Result<u64, String> {
-        let size = human_size_to_bytes(s)?;
-        if size < MIN_CACHE_SIZE_BYTES {
-            return Err(
-                "Specified value of cache size is smaller than current minimum of 1GiB".to_string(),
-            );
-        }
-        Ok(size)
-    }
-
-    pub fn disk_usage(s: &str) -> Result<f64, String> {
-        let disk_usage = s
-            .parse::<f64>()
-            .map_err(|_| "Invalid disk usage value".to_string())?;
-        Ok(disk_usage)
     }
 }

--- a/server/src/query/stream_schema_provider.rs
+++ b/server/src/query/stream_schema_provider.rs
@@ -422,7 +422,7 @@ impl TableProvider for StandardTableProvider {
         if let Some(hot_tier_manager) = HotTierManager::global() {
             if hot_tier_manager.check_stream_hot_tier_exists(&self.stream) {
                 let (hot_tier_files, remainder) = hot_tier_manager
-                    .get_hot_tier_manifests(&self.stream, manifest_files)
+                    .get_hot_tier_manifest_files(&self.stream, manifest_files)
                     .await
                     .map_err(|err| DataFusionError::External(Box::new(err)))?;
                 // Assign remaining entries back to manifest list

--- a/server/src/rbac/role.rs
+++ b/server/src/rbac/role.rs
@@ -32,6 +32,8 @@ pub enum Action {
     PutRetention,
     GetCacheEnabled,
     PutCacheEnabled,
+    PutHotTierEnabled,
+    GetHotTierEnabled,
     PutAlert,
     GetAlert,
     PutUser,
@@ -117,6 +119,8 @@ impl RoleBuilder {
                 | Action::ListCluster
                 | Action::ListClusterMetrics
                 | Action::Deleteingestor
+                | Action::PutHotTierEnabled
+                | Action::GetHotTierEnabled
                 | Action::ListDashboard
                 | Action::GetDashboard
                 | Action::CreateDashboard
@@ -206,6 +210,8 @@ pub mod model {
                 Action::PutRetention,
                 Action::PutCacheEnabled,
                 Action::GetCacheEnabled,
+                Action::PutHotTierEnabled,
+                Action::GetHotTierEnabled,
                 Action::PutAlert,
                 Action::GetAlert,
                 Action::GetAbout,
@@ -249,6 +255,7 @@ pub mod model {
                 Action::GetAbout,
                 Action::QueryLLM,
                 Action::ListCluster,
+                Action::GetHotTierEnabled,
             ],
             stream: None,
             tag: None,

--- a/server/src/rbac/role.rs
+++ b/server/src/rbac/role.rs
@@ -34,6 +34,7 @@ pub enum Action {
     PutCacheEnabled,
     PutHotTierEnabled,
     GetHotTierEnabled,
+    DeleteHotTierEnabled,
     PutAlert,
     GetAlert,
     PutUser,
@@ -121,6 +122,7 @@ impl RoleBuilder {
                 | Action::Deleteingestor
                 | Action::PutHotTierEnabled
                 | Action::GetHotTierEnabled
+                | Action::DeleteHotTierEnabled
                 | Action::ListDashboard
                 | Action::GetDashboard
                 | Action::CreateDashboard
@@ -212,6 +214,7 @@ pub mod model {
                 Action::GetCacheEnabled,
                 Action::PutHotTierEnabled,
                 Action::GetHotTierEnabled,
+                Action::DeleteHotTierEnabled,
                 Action::PutAlert,
                 Action::GetAlert,
                 Action::GetAbout,

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -100,6 +100,8 @@ pub struct ObjectStoreFormat {
     pub custom_partition: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub static_schema_flag: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hot_tier_enabled: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -167,6 +169,7 @@ impl Default for ObjectStoreFormat {
             time_partition_limit: None,
             custom_partition: None,
             static_schema_flag: None,
+            hot_tier_enabled: None,
         }
     }
 }

--- a/server/src/storage/localfs.rs
+++ b/server/src/storage/localfs.rs
@@ -411,6 +411,11 @@ impl ObjectStorage for LocalFS {
         Ok(dates.into_iter().flatten().collect())
     }
 
+    async fn list_files(&self, _stream_name: &str) -> Result<Vec<String>, ObjectStorageError> {
+        //unimplemented
+        Ok(vec![])
+    }
+
     async fn upload_file(&self, key: &str, path: &Path) -> Result<(), ObjectStorageError> {
         let op = CopyOptions {
             overwrite: true,

--- a/server/src/storage/localfs.rs
+++ b/server/src/storage/localfs.rs
@@ -17,6 +17,7 @@
  */
 
 use std::{
+    collections::BTreeMap,
     path::{Path, PathBuf},
     sync::Arc,
     time::Instant,
@@ -411,9 +412,12 @@ impl ObjectStorage for LocalFS {
         Ok(dates.into_iter().flatten().collect())
     }
 
-    async fn list_files(&self, _stream_name: &str) -> Result<Vec<String>, ObjectStorageError> {
+    async fn list_manifest_files(
+        &self,
+        _stream_name: &str,
+    ) -> Result<BTreeMap<String, Vec<String>>, ObjectStorageError> {
         //unimplemented
-        Ok(vec![])
+        Ok(BTreeMap::new())
     }
 
     async fn upload_file(&self, key: &str, path: &Path) -> Result<(), ObjectStorageError> {

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -87,6 +87,7 @@ pub trait ObjectStorage: Sync + 'static {
     async fn get_all_saved_filters(&self) -> Result<Vec<Bytes>, ObjectStorageError>;
     async fn get_all_dashboards(&self) -> Result<Vec<Bytes>, ObjectStorageError>;
     async fn list_dates(&self, stream_name: &str) -> Result<Vec<String>, ObjectStorageError>;
+    async fn list_files(&self, stream_name: &str) -> Result<Vec<String>, ObjectStorageError>;
     async fn upload_file(&self, key: &str, path: &Path) -> Result<(), ObjectStorageError>;
     async fn delete_object(&self, path: &RelativePath) -> Result<(), ObjectStorageError>;
     async fn get_ingestor_meta_file_paths(

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -49,6 +49,7 @@ use itertools::Itertools;
 use relative_path::RelativePath;
 use relative_path::RelativePathBuf;
 
+use std::collections::BTreeMap;
 use std::{
     collections::HashMap,
     fs,
@@ -87,7 +88,10 @@ pub trait ObjectStorage: Sync + 'static {
     async fn get_all_saved_filters(&self) -> Result<Vec<Bytes>, ObjectStorageError>;
     async fn get_all_dashboards(&self) -> Result<Vec<Bytes>, ObjectStorageError>;
     async fn list_dates(&self, stream_name: &str) -> Result<Vec<String>, ObjectStorageError>;
-    async fn list_files(&self, stream_name: &str) -> Result<Vec<String>, ObjectStorageError>;
+    async fn list_manifest_files(
+        &self,
+        stream_name: &str,
+    ) -> Result<BTreeMap<String, Vec<String>>, ObjectStorageError>;
     async fn upload_file(&self, key: &str, path: &Path) -> Result<(), ObjectStorageError>;
     async fn delete_object(&self, path: &RelativePath) -> Result<(), ObjectStorageError>;
     async fn get_ingestor_meta_file_paths(

--- a/server/src/storage/s3.rs
+++ b/server/src/storage/s3.rs
@@ -360,12 +360,12 @@ impl S3 {
         for date in dates.clone() {
             let hour_path = object_store::path::Path::from(format!("{}/{}", stream, date));
             let resp = self.client.list_with_delimiter(Some(&hour_path)).await?;
-            let manifest = resp
+            let manifest: Vec<String> = resp
                 .objects
                 .iter()
                 .map(|name| name.location.to_string())
-                .collect::<String>();
-            result_file_list.push(manifest);
+                .collect();
+            result_file_list.extend(manifest);
         }
 
         Ok(result_file_list)

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -23,14 +23,14 @@ pub mod json;
 pub mod uid;
 pub mod update;
 use crate::option::CONFIG;
-use chrono::{DateTime, NaiveDate, Timelike, Utc};
+use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Timelike, Utc};
 use itertools::Itertools;
+use regex::Regex;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::{env, fs};
 use url::Url;
-
 #[allow(dead_code)]
 pub fn hostname() -> Option<String> {
     hostname::get()
@@ -325,6 +325,22 @@ pub fn get_dir_size(path: PathBuf) -> Result<u64, anyhow::Error> {
     }
 
     dir_size_recursive(&path)
+}
+
+pub fn extract_datetime(path: &str) -> Option<NaiveDateTime> {
+    let re = Regex::new(r"date=(\d{4}-\d{2}-\d{2})/hour=(\d{2})/minute=(\d{2})").unwrap();
+    if let Some(caps) = re.captures(path) {
+        let date_str = caps.get(1)?.as_str();
+        let hour_str = caps.get(2)?.as_str();
+        let minute_str = caps.get(3)?.as_str();
+
+        let date = NaiveDate::parse_from_str(date_str, "%Y-%m-%d").ok()?;
+        let time =
+            NaiveTime::parse_from_str(&format!("{}:{}", hour_str, minute_str), "%H:%M").ok()?;
+        Some(NaiveDateTime::new(date, time))
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -28,8 +28,7 @@ use itertools::Itertools;
 use regex::Regex;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
-use std::path::PathBuf;
-use std::{env, fs};
+use std::env;
 use url::Url;
 #[allow(dead_code)]
 pub fn hostname() -> Option<String> {
@@ -304,27 +303,6 @@ pub fn get_ingestor_id() -> String {
     let result = result.split_at(15).0.to_string();
     log::debug!("Ingestor ID: {}", &result);
     result
-}
-
-pub fn get_dir_size(path: PathBuf) -> Result<u64, anyhow::Error> {
-    fn dir_size_recursive(path: &PathBuf) -> Result<u64, anyhow::Error> {
-        let mut size = 0;
-
-        for entry in fs::read_dir(path)? {
-            let entry = entry?;
-            let metadata = entry.metadata()?;
-
-            if metadata.is_dir() {
-                size += dir_size_recursive(&entry.path())?;
-            } else {
-                size += metadata.len();
-            }
-        }
-
-        Ok(size)
-    }
-
-    dir_size_recursive(&path)
 }
 
 pub fn extract_datetime(path: &str) -> Option<NaiveDateTime> {


### PR DESCRIPTION
- Env var P_HOT_TIER_DIR to store the files in the query server
- PUT /logstream/{logstream}/hottier with below JSON body to set hottier for stream
 `{ "hotTierSize": "1GiB", "hotTierStartDate": "2024-07-16", "hotTierEndDate": "2024-07-19" }`

- GET /logstream/{logstream}/hottier to fetch the current state of hottier for a stream Response JSON -
`{
    "hotTierSize": "1GiB",
    "hot_tier_used_size": "1019.41 MiB",
    "hot_tier_available_size": "4.59 MiB",
    "hotTierStartDate": "2024-07-16",
    "hotTierEndDate": "2024-07-19"
}`

Ingestion flow completed -
- Query server periodically (every 1 minute) downloads the parquet files and corresponding manifest file from S3 for the range provided in the hot tier
- deletes files if downloaded file size exceeds the hot tier size

