### PR TITLE
query optimization by remove table listing

### DIFF
--- a/server/src/query/stream_schema_provider.rs
+++ b/server/src/query/stream_schema_provider.rs
@@ -347,24 +347,6 @@ impl TableProvider for StandardTableProvider {
             merged_snapshot = object_store_format.snapshot;
         }
 
-        // Is query timerange is overlapping with older data.
-        if is_overlapping_query(&merged_snapshot.manifest_list, &time_filters) {
-            return legacy_listing_table(
-                self.stream.clone(),
-                memory_exec,
-                glob_storage,
-                object_store,
-                &time_filters,
-                self.schema.clone(),
-                state,
-                projection,
-                filters,
-                limit,
-                time_partition.clone(),
-            )
-            .await;
-        }
-
         let mut manifest_files = collect_from_snapshot(
             &merged_snapshot,
             &time_filters,
@@ -462,6 +444,7 @@ impl TableProvider for StandardTableProvider {
 }
 
 #[allow(clippy::too_many_arguments)]
+#[allow(dead_code)]
 async fn legacy_listing_table(
     stream: String,
     mem_exec: Option<Arc<dyn ExecutionPlan>>,
@@ -580,6 +563,7 @@ impl PartialTimeFilter {
     }
 }
 
+#[allow(dead_code)]
 fn is_overlapping_query(
     manifest_list: &[ManifestItem],
     time_filters: &[PartialTimeFilter],


### PR DESCRIPTION
to support the  deployments older than 1 year, when Parseable did not have the concept of catalogues (manifest.json),
query module checks if the query time range has date without manifest in the storage if true (overlapping query), query result is served directly by listing all parquets in the time range
this slows down the performance and increases S3 cost

hence, the fix is to remove the check with assumption that all dates must have the catalogues and manifest must decide the execution plan for the query

still, to support the older deployments, we can write a separate tool to generate the manifest from the available parquets for a particular date to be run separately

