### PR TITLE
update: dashboard APIs

### DIFF
--- a/server/src/users/dashboards.rs
+++ b/server/src/users/dashboards.rs
@@ -33,7 +33,6 @@ pub struct Tiles {
     name: String,
     pub tile_id: Option<String>,
     description: String,
-    stream: String,
     query: String,
     order: Option<u64>,
     visualization: Visualization,
@@ -57,7 +56,7 @@ pub struct CircularChartConfig {
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct GraphConfig {
     x_key: String,
-    y_key: Vec<String>,
+    y_keys: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]


### PR DESCRIPTION
1. remove stream field from tile struct
2. rename y_key to y_keys in graph config
3. fix to generate tile_id for each tile in POST /dashboards
4. fix to generate tile_id for new tiles where tile_id is not present in the request in the PUT /dashboards/dashboard/<dashboard-id>
5. return dashboard json in PUT response

