### PR TITLE
changes for upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,14 +48,14 @@ dependencies = [
  "ahash",
  "base64 0.21.7",
  "bitflags 2.5.0",
- "brotli",
+ "brotli 3.5.0",
  "bytes",
  "bytestring",
  "derive_more",
  "encoding_rs",
  "flate2",
  "futures-core",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "httparse",
  "httpdate",
@@ -425,9 +425,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "arrow"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219d05930b81663fd3b32e3bde8ce5bff3c4d23052a99f11a8fa50a3b47b2658"
+checksum = "05048a8932648b63f21c37d88b552ccc8a65afb6dfe9fc9f30ce79174c2e7a85"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -446,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0272150200c07a86a390be651abdd320a2d12e84535f0837566ca87ecd8f95e0"
+checksum = "1d8a57966e43bfe9a3277984a14c24ec617ad874e4c0e1d2a1b083a39cfbf22c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8010572cf8c745e242d1b632bd97bd6d4f40fefed5ed1290a8f433abaa686fea"
+checksum = "16f4a9468c882dc66862cef4e1fd8423d47e67972377d85d80e022786427768c"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -472,15 +472,15 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "half",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "num",
 ]
 
 [[package]]
 name = "arrow-buffer"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0a2432f0cba5692bf4cb757469c66791394bac9ec7ce63c1afe74744c37b27"
+checksum = "c975484888fc95ec4a632cdc98be39c085b1bb518531b0c80c5d462063e5daa1"
 dependencies = [
  "bytes",
  "half",
@@ -489,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9abc10cd7995e83505cc290df9384d6e5412b207b79ce6bdff89a10505ed2cba"
+checksum = "da26719e76b81d8bc3faad1d4dbdc1bcc10d14704e63dc17fc9f3e7e1e567c8e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -510,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95cbcba196b862270bf2a5edb75927380a7f3a163622c61d40cbba416a6305f2"
+checksum = "c13c36dc5ddf8c128df19bab27898eea64bf9da2b555ec1cd17a8ff57fba9ec2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -529,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2742ac1f6650696ab08c88f6dd3f0eb68ce10f8c253958a18c943a68cd04aec5"
+checksum = "dd9d6f18c65ef7a2573ab498c374d8ae364b4a4edf67105357491c031f716ca5"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -541,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-flight"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3241ce691192d789b7b94f56a10e166ee608bdc3932c759eb0b85f09235352bb"
+checksum = "8e7ffbc96072e466ae5188974725bb46757587eafe427f77a25b828c375ae882"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -562,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42ea853130f7e78b9b9d178cb4cd01dee0f78e64d96c2949dc0a915d6d9e19d"
+checksum = "e786e1cdd952205d9a8afc69397b317cfbb6e0095e445c69cda7e8da5c1eeb0f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -578,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaafb5714d4e59feae964714d724f880511500e3569cc2a94d02456b403a2a49"
+checksum = "fb22284c5a2a01d73cebfd88a33511a3234ab45d66086b2ca2d1228c3498e445"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -598,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e6b61e3dc468f503181dccc2fc705bdcc5f2f146755fa5b56d0a6c5943f412"
+checksum = "42745f86b1ab99ef96d1c0bcf49180848a64fe2c7a7a0d945bc64fa2b21ba9bc"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -613,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848ee52bb92eb459b811fb471175ea3afcf620157674c8794f539838920f9228"
+checksum = "4cd09a518c602a55bd406bcc291a967b284cfa7a63edfbf8b897ea4748aad23c"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -623,23 +623,22 @@ dependencies = [
  "arrow-data",
  "arrow-schema",
  "half",
- "hashbrown 0.14.3",
 ]
 
 [[package]]
 name = "arrow-schema"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d9483aaabe910c4781153ae1b6ae0393f72d9ef757d38d09d450070cf2e528"
+checksum = "9e972cd1ff4a4ccd22f86d3e53e835c2ed92e0eea6a3e8eadb72b4f1ac802cf8"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "849524fa70e0e3c5ab58394c770cb8f514d0122d20de08475f7b472ed8075830"
+checksum = "600bae05d43483d216fb3494f8c32fdbefd8aa4e1de237e790dbb3d9f44690a3"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -651,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9373cb5a021aee58863498c37eb484998ef13377f69989c6c5ccfbd258236cdb"
+checksum = "f0dc1985b67cb45f6606a248ac2b4a288849f196bab8c657ea5589f47cdd55e6"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -725,6 +724,12 @@ checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -883,7 +888,18 @@ checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor",
+ "brotli-decompressor 2.5.1",
+]
+
+[[package]]
+name = "brotli"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor 4.0.1",
 ]
 
 [[package]]
@@ -891,6 +907,16 @@ name = "brotli-decompressor"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1039,9 +1065,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
+checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
 dependencies = [
  "chrono",
  "chrono-tz-build",
@@ -1050,9 +1076,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz-build"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
+checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
 dependencies = [
  "parse-zoneinfo",
  "phf",
@@ -1340,7 +1366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -1354,9 +1380,8 @@ checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
 name = "datafusion"
-version = "37.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85069782056753459dc47e386219aa1fdac5b731f26c28abb8c0ffd4b7c5ab11"
+version = "39.0.0"
+source = "git+https://github.com/apache/datafusion.git?rev=a64df83502821f18067fb4ff65dd217815b305c9#a64df83502821f18067fb4ff65dd217815b305c9"
 dependencies = [
  "ahash",
  "arrow",
@@ -1374,23 +1399,26 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-functions",
+ "datafusion-functions-aggregate",
  "datafusion-functions-array",
  "datafusion-optimizer",
  "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-sql",
  "flate2",
  "futures",
  "glob",
  "half",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "indexmap 2.2.6",
- "itertools",
+ "itertools 0.12.1",
  "log",
  "num_cpus",
  "object_store",
  "parking_lot",
  "parquet",
+ "paste",
  "pin-project-lite",
  "rand",
  "sqlparser",
@@ -1405,9 +1433,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "37.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "309d9040751f6dc9e33c85dce6abb55a46ef7ea3644577dd014611c379447ef3"
+version = "39.0.0"
+source = "git+https://github.com/apache/datafusion.git?rev=a64df83502821f18067fb4ff65dd217815b305c9#a64df83502821f18067fb4ff65dd217815b305c9"
 dependencies = [
  "ahash",
  "arrow",
@@ -1416,6 +1443,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
+ "hashbrown 0.14.5",
  "instant",
  "libc",
  "num_cpus",
@@ -1426,18 +1454,16 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "37.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e4a44d8ef1b1e85d32234e6012364c411c3787859bb3bba893b0332cb03dfd"
+version = "39.0.0"
+source = "git+https://github.com/apache/datafusion.git?rev=a64df83502821f18067fb4ff65dd217815b305c9#a64df83502821f18067fb4ff65dd217815b305c9"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-execution"
-version = "37.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06a3a29ae36bcde07d179cc33b45656a8e7e4d023623e320e48dcf1200eeee95"
+version = "39.0.0"
+source = "git+https://github.com/apache/datafusion.git?rev=a64df83502821f18067fb4ff65dd217815b305c9#a64df83502821f18067fb4ff65dd217815b305c9"
 dependencies = [
  "arrow",
  "chrono",
@@ -1445,7 +1471,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "futures",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "log",
  "object_store",
  "parking_lot",
@@ -1456,16 +1482,17 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "37.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a3542aa322029c2121a671ce08000d4b274171070df13f697b14169ccf4f628"
+version = "39.0.0"
+source = "git+https://github.com/apache/datafusion.git?rev=a64df83502821f18067fb4ff65dd217815b305c9#a64df83502821f18067fb4ff65dd217815b305c9"
 dependencies = [
  "ahash",
  "arrow",
  "arrow-array",
+ "arrow-buffer",
  "chrono",
  "datafusion-common",
  "paste",
+ "serde_json",
  "sqlparser",
  "strum",
  "strum_macros",
@@ -1473,9 +1500,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions"
-version = "37.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd221792c666eac174ecc09e606312844772acc12cbec61a420c2fca1ee70959"
+version = "39.0.0"
+source = "git+https://github.com/apache/datafusion.git?rev=a64df83502821f18067fb4ff65dd217815b305c9#a64df83502821f18067fb4ff65dd217815b305c9"
 dependencies = [
  "arrow",
  "base64 0.22.0",
@@ -1485,11 +1511,12 @@ dependencies = [
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-physical-expr",
+ "hashbrown 0.14.5",
  "hex",
- "itertools",
+ "itertools 0.12.1",
  "log",
  "md-5",
+ "rand",
  "regex",
  "sha2",
  "unicode-segmentation",
@@ -1497,10 +1524,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-functions-aggregate"
+version = "39.0.0"
+source = "git+https://github.com/apache/datafusion.git?rev=a64df83502821f18067fb4ff65dd217815b305c9#a64df83502821f18067fb4ff65dd217815b305c9"
+dependencies = [
+ "ahash",
+ "arrow",
+ "arrow-schema",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "log",
+ "paste",
+ "sqlparser",
+]
+
+[[package]]
 name = "datafusion-functions-array"
-version = "37.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e501801e84d9c6ef54caaebcda1b18a6196a24176c12fb70e969bc0572e03c55"
+version = "39.0.0"
+source = "git+https://github.com/apache/datafusion.git?rev=a64df83502821f18067fb4ff65dd217815b305c9#a64df83502821f18067fb4ff65dd217815b305c9"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1511,16 +1554,15 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-functions",
- "itertools",
+ "itertools 0.12.1",
  "log",
  "paste",
 ]
 
 [[package]]
 name = "datafusion-optimizer"
-version = "37.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bd7f5087817deb961764e8c973d243b54f8572db414a8f0a8f33a48f991e0a"
+version = "39.0.0"
+source = "git+https://github.com/apache/datafusion.git?rev=a64df83502821f18067fb4ff65dd217815b305c9#a64df83502821f18067fb4ff65dd217815b305c9"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1528,17 +1570,18 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "datafusion-physical-expr",
- "hashbrown 0.14.3",
- "itertools",
+ "hashbrown 0.14.5",
+ "indexmap 2.2.6",
+ "itertools 0.12.1",
  "log",
+ "paste",
  "regex-syntax",
 ]
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "37.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cabc0d9aaa0f5eb1b472112f16223c9ffd2fb04e58cbf65c0a331ee6e993f96"
+version = "39.0.0"
+source = "git+https://github.com/apache/datafusion.git?rev=a64df83502821f18067fb4ff65dd217815b305c9#a64df83502821f18067fb4ff65dd217815b305c9"
 dependencies = [
  "ahash",
  "arrow",
@@ -1548,37 +1591,45 @@ dependencies = [
  "arrow-schema",
  "arrow-string",
  "base64 0.22.0",
- "blake2",
- "blake3",
  "chrono",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
+ "datafusion-physical-expr-common",
  "half",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "hex",
  "indexmap 2.2.6",
- "itertools",
+ "itertools 0.12.1",
  "log",
- "md-5",
  "paste",
  "petgraph",
- "rand",
  "regex",
- "sha2",
- "unicode-segmentation",
+]
+
+[[package]]
+name = "datafusion-physical-expr-common"
+version = "39.0.0"
+source = "git+https://github.com/apache/datafusion.git?rev=a64df83502821f18067fb4ff65dd217815b305c9#a64df83502821f18067fb4ff65dd217815b305c9"
+dependencies = [
+ "ahash",
+ "arrow",
+ "datafusion-common",
+ "datafusion-expr",
+ "hashbrown 0.14.5",
+ "rand",
 ]
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "37.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c0523e9c8880f2492a88bbd857dde02bed1ed23f3e9211a89d3d7ec3b44af9"
+version = "39.0.0"
+source = "git+https://github.com/apache/datafusion.git?rev=a64df83502821f18067fb4ff65dd217815b305c9#a64df83502821f18067fb4ff65dd217815b305c9"
 dependencies = [
  "ahash",
  "arrow",
  "arrow-array",
  "arrow-buffer",
+ "arrow-ord",
  "arrow-schema",
  "async-trait",
  "chrono",
@@ -1586,12 +1637,14 @@ dependencies = [
  "datafusion-common-runtime",
  "datafusion-execution",
  "datafusion-expr",
+ "datafusion-functions-aggregate",
  "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
  "futures",
  "half",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "indexmap 2.2.6",
- "itertools",
+ "itertools 0.12.1",
  "log",
  "once_cell",
  "parking_lot",
@@ -1602,9 +1655,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "37.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49eb54b42227136f6287573f2434b1de249fe1b8e6cd6cc73a634e4a3ec29356"
+version = "39.0.0"
+source = "git+https://github.com/apache/datafusion.git?rev=a64df83502821f18067fb4ff65dd217815b305c9#a64df83502821f18067fb4ff65dd217815b305c9"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1612,6 +1664,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "log",
+ "regex",
  "sqlparser",
  "strum",
 ]
@@ -1743,9 +1796,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flatbuffers"
-version = "23.5.26"
+version = "24.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dac53e22462d78c16d64a1cd22371b54cc3fe94aa15e7886a2fa6e5d1ab8640"
+checksum = "8add37afff2d4ffa83bc748a70b4b1370984f6980768554182424ef71447c35f"
 dependencies = [
  "bitflags 1.3.2",
  "rustc_version",
@@ -1947,6 +2000,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1974,9 +2046,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -2142,7 +2214,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -2158,13 +2230,14 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2 0.4.5",
  "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
@@ -2197,7 +2270,7 @@ checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "hyper-util",
  "rustls 0.22.4",
  "rustls-pki-types",
@@ -2220,16 +2293,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2300,7 +2373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2343,6 +2416,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2741,24 +2823,24 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.9.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8718f8b65fdf67a45108d1548347d4af7d71fb81ce727bbf9e3b2535e079db3"
+checksum = "e6da452820c715ce78221e8202ccc599b4a52f3e1eb3eedb487b680c81a8e3f3"
 dependencies = [
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bytes",
  "chrono",
  "futures",
  "humantime",
- "hyper 0.14.28",
- "itertools",
+ "hyper 1.4.1",
+ "itertools 0.13.0",
  "md-5",
  "parking_lot",
  "percent-encoding",
  "quick-xml",
  "rand",
- "reqwest 0.11.27",
+ "reqwest 0.12.4",
  "ring",
  "serde",
  "serde_json",
@@ -2840,9 +2922,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "51.0.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "096795d4f47f65fd3ee1ec5a98b77ab26d602f2cc785b0e4be5443add17ecc32"
+checksum = "e977b9066b4d3b03555c22bdc442f3fadebd96a39111249113087d0edb2691cd"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -2853,13 +2935,13 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "base64 0.22.0",
- "brotli",
+ "brotli 6.0.0",
  "bytes",
  "chrono",
  "flate2",
  "futures",
  "half",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "lz4_flex",
  "num",
  "num-bigint",
@@ -2871,6 +2953,7 @@ dependencies = [
  "tokio",
  "twox-hash",
  "zstd 0.13.1",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -2925,7 +3008,7 @@ dependencies = [
  "human-size",
  "humantime",
  "humantime-serde",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "maplit",
  "mime",
@@ -2985,9 +3068,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "path-clean"
@@ -3194,7 +3277,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "811031bea65e5a401fb2e1f37d802cca6601e204ac463809a3189352d13b78a5"
 dependencies = [
  "chrono",
- "itertools",
+ "itertools 0.12.1",
  "once_cell",
  "regex",
 ]
@@ -3217,7 +3300,7 @@ checksum = "80b776a1b2dc779f5ee0641f8ade0125bc1298dd41a9a0c16d8bd57b42d222b1"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -3237,7 +3320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19de2de2a00075bf566bee3bd4db014b11587e84184d3f7a791bc17f1a8e9e48"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.60",
@@ -3276,9 +3359,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.31.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+checksum = "96a05e2e8efddfa51a84ca47cec303fac86c8541b686d37cac5efc0e094417bc"
 dependencies = [
  "memchr",
  "serde",
@@ -3410,7 +3493,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
@@ -3423,7 +3506,6 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.11",
- "rustls-native-certs",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -3432,12 +3514,10 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-rustls 0.24.1",
- "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
  "webpki-roots 0.25.4",
  "winreg 0.50.0",
@@ -3453,10 +3533,11 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2 0.4.5",
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "hyper-rustls 0.26.0",
  "hyper-util",
  "ipnet",
@@ -3467,6 +3548,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.22.4",
+ "rustls-native-certs",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
@@ -3475,10 +3557,12 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.25.0",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 0.26.1",
  "winreg 0.52.0",
@@ -3598,12 +3682,13 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.3"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
@@ -3927,9 +4012,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "sqlparser"
-version = "0.44.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf9c7ff146298ffda83a200f8d5084f08dcee1edfc135fcc1d646a45d50ffd6"
+checksum = "295e9930cd7a97e58ca2a070541a3ca502b17f5d1fa7157376d0fabd85324f25"
 dependencies = [
  "log",
  "sqlparser_derive",
@@ -4027,9 +4112,9 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sysinfo"
-version = "0.30.11"
+version = "0.30.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87341a165d73787554941cd5ef55ad728011566fe714e987d1b976c15dbc3a83"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -4307,7 +4392,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "flate2",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -10,15 +10,15 @@ build = "build.rs"
 [dependencies]
 ### apache arrow/datafusion dependencies
 # arrow = "51.0.0"
-arrow-schema = { version = "51.0.0", features = ["serde"] }
-arrow-array = { version = "51.0.0" }
-arrow-json = "51.0.0"
-arrow-ipc = { version = "51.0.0", features = ["zstd"] }
-arrow-select = "51.0.0"
-datafusion = "37.1.0"
-object_store = { version = "0.9.1", features = ["cloud", "aws"] }  # cannot update object_store as datafusion has not caught up
-parquet = "51.0.0"
-arrow-flight = { version = "51.0.0", features = [ "tls" ] }
+arrow-schema = { version = "52.1.0", features = ["serde"] }
+arrow-array = { version = "52.1.0" }
+arrow-json = "52.1.0"
+arrow-ipc = { version = "52.1.0", features = ["zstd"] }
+arrow-select = "52.1.0"
+datafusion = { git = "https://github.com/apache/datafusion.git", rev = "a64df83502821f18067fb4ff65dd217815b305c9" }
+object_store = { version = "0.10.2", features = ["cloud", "aws"] }  # cannot update object_store as datafusion has not caught up
+parquet = "52.1.0"
+arrow-flight = { version = "52.1.0", features = [ "tls" ] }
 tonic = {version = "0.11.0", features = ["tls", "transport", "gzip", "zstd"] }
 tonic-web = "0.11.0"
 tower-http = { version = "0.4.4", features = ["cors"] }
@@ -62,7 +62,7 @@ hex = "0.4"
 hostname = "0.4.0"
 http = "0.2.7"
 humantime-serde = "1.1"
-itertools = "0.12.1"
+itertools = "0.13.0"
 log = "0.4"
 num_cpus = "1.15"
 once_cell = "1.17.1"

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -101,6 +101,12 @@ pub struct Cli {
 
     /// CORS behaviour
     pub cors: bool,
+
+    /// The local hot_tier path is used for optimising the query performance in the distributed systems
+    pub hot_tier_storage_path: Option<PathBuf>,
+
+    ///maximum disk usage allowed
+    pub max_disk_usage: f64,
 }
 
 impl Cli {
@@ -134,6 +140,8 @@ impl Cli {
     pub const DEFAULT_PASSWORD: &'static str = "admin";
     pub const FLIGHT_PORT: &'static str = "flight-port";
     pub const CORS: &'static str = "cors";
+    pub const HOT_TIER_PATH: &'static str = "hot-tier-path";
+    pub const MAX_DISK_USAGE: &'static str = "max-disk-usage";
 
     pub fn local_stream_data_path(&self, stream_name: &str) -> PathBuf {
         self.local_staging_path.join(stream_name)
@@ -395,7 +403,27 @@ impl Cli {
                         "lz4",
                         "zstd"])
                     .help("Parquet compression algorithm"),
-            ).group(
+            )
+            .arg(
+                Arg::new(Self::HOT_TIER_PATH)
+                    .long(Self::HOT_TIER_PATH)
+                    .env("P_HOT_TIER_DIR")
+                    .value_name("DIR")
+                    .value_parser(validation::canonicalize_path)
+                    .help("Local path on this device to be used for hot tier data")
+                    .next_line_help(true),
+            )
+            .arg(
+                Arg::new(Self::MAX_DISK_USAGE)
+                    .long(Self::MAX_DISK_USAGE)
+                    .env("P_MAX_DISK_USAGE_PERCENT")
+                    .value_name("percentage")
+                    .default_value("80.0")
+                    .value_parser(validation::validate_disk_usage)
+                    .help("Maximum allowed disk usage in percentage e.g 90.0 for 90%")
+                    .next_line_help(true),
+            )
+            .group(
                 ArgGroup::new("oidc")
                     .args([Self::OPENID_CLIENT_ID, Self::OPENID_CLIENT_SECRET, Self::OPENID_ISSUER])
                     .requires_all([Self::OPENID_CLIENT_ID, Self::OPENID_CLIENT_SECRET, Self::OPENID_ISSUER])
@@ -531,6 +559,12 @@ impl FromArgMatches for Cli {
             "all" => Mode::All,
             _ => unreachable!(),
         };
+
+        self.hot_tier_storage_path = m.get_one::<PathBuf>(Self::HOT_TIER_PATH).cloned();
+        self.max_disk_usage = m
+            .get_one::<f64>(Self::MAX_DISK_USAGE)
+            .cloned()
+            .expect("default for max disk usage");
 
         Ok(())
     }

--- a/server/src/handlers/http/ingest.rs
+++ b/server/src/handlers/http/ingest.rs
@@ -182,6 +182,9 @@ pub async fn post_event(req: HttpRequest, body: Bytes) -> Result<HttpResponse, P
             stream_name
         )));
     }
+    if !STREAM_INFO.stream_exists(&stream_name) {
+        return Err(PostError::StreamNotFound(stream_name));
+    }
     flatten_and_push_logs(req, body, stream_name).await?;
     Ok(HttpResponse::Ok().finish())
 }

--- a/server/src/handlers/http/modal/ingest_server.rs
+++ b/server/src/handlers/http/modal/ingest_server.rs
@@ -18,6 +18,7 @@
 use crate::analytics;
 use crate::banner;
 use crate::handlers::airplane;
+use crate::handlers::http::ingest;
 use crate::handlers::http::logstream;
 use crate::handlers::http::middleware::RouteExt;
 use crate::localcache::LocalCacheManager;
@@ -167,15 +168,23 @@ impl IngestServer {
             web::scope("/{logstream}")
                 .service(
                     web::resource("")
+                        // DELETE "/logstream/{logstream}" ==> Delete a log stream
                         .route(
                             web::delete()
                                 .to(logstream::delete)
                                 .authorize_for_stream(Action::DeleteStream),
                         )
+                        // PUT "/logstream/{logstream}" ==> Create a new log stream
                         .route(
                             web::put()
                                 .to(logstream::put_stream)
                                 .authorize_for_stream(Action::CreateStream),
+                        )
+                        // POST "/logstream/{logstream}" ==> Post logs to given log stream
+                        .route(
+                            web::post()
+                                .to(ingest::post_event)
+                                .authorize_for_stream(Action::Ingest),
                         ),
                 )
                 .service(

--- a/server/src/handlers/http/modal/query_server.rs
+++ b/server/src/handlers/http/modal/query_server.rs
@@ -20,7 +20,7 @@ use crate::handlers::airplane;
 use crate::handlers::http::cluster::{self, init_cluster_metrics_schedular};
 use crate::handlers::http::middleware::RouteExt;
 use crate::handlers::http::{base_path, cross_origin_config, API_BASE_PATH, API_VERSION};
-
+use crate::hottier::HotTierManager;
 use crate::rbac::role::Action;
 use crate::sync;
 use crate::users::dashboards::DASHBOARDS;
@@ -188,6 +188,10 @@ impl QueryServer {
         if matches!(init_cluster_metrics_schedular(), Ok(())) {
             log::info!("Cluster metrics scheduler started successfully");
         }
+
+        if let Some(hot_tier_manager) = HotTierManager::global() {
+            hot_tier_manager.download_from_s3()?;
+        };
         let (localsync_handler, mut localsync_outbox, localsync_inbox) = sync::run_local_sync();
         let (mut remote_sync_handler, mut remote_sync_outbox, mut remote_sync_inbox) =
             sync::object_store_sync();

--- a/server/src/handlers/http/modal/server.rs
+++ b/server/src/handlers/http/modal/server.rs
@@ -343,6 +343,25 @@ impl Server {
                                     .to(logstream::get_cache_enabled)
                                     .authorize_for_stream(Action::GetCacheEnabled),
                             ),
+                    )
+                    .service(
+                        web::resource("/hottier")
+                            // PUT "/logstream/{logstream}/hottier" ==> Set hottier for given logstream
+                            .route(
+                                web::put()
+                                    .to(logstream::put_stream_hot_tier)
+                                    .authorize_for_stream(Action::PutHotTierEnabled),
+                            )
+                            .route(
+                                web::get()
+                                    .to(logstream::get_stream_hot_tier)
+                                    .authorize_for_stream(Action::GetHotTierEnabled),
+                            )
+                            .route(
+                                web::delete()
+                                    .to(logstream::delete_stream_hot_tier)
+                                    .authorize_for_stream(Action::DeleteHotTierEnabled),
+                            ),
                     ),
             )
     }

--- a/server/src/hottier.rs
+++ b/server/src/hottier.rs
@@ -1,0 +1,779 @@
+/*
+ * Parseable Server (C) 2022 - 2024 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use std::{
+    collections::BTreeMap,
+    io,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use crate::{
+    catalog::manifest::{File, Manifest},
+    metadata::{error::stream_info::MetadataError, STREAM_INFO},
+    option::{
+        validation::{bytes_to_human_size, human_size_to_bytes},
+        CONFIG,
+    },
+    storage::{ObjectStorage, ObjectStorageError},
+    utils::extract_datetime,
+    validator::error::HotTierValidationError,
+};
+use chrono::NaiveDate;
+use clokwerk::{AsyncScheduler, Interval, Job};
+use futures::{stream::FuturesUnordered, StreamExt, TryStreamExt};
+use futures_util::TryFutureExt;
+use object_store::{local::LocalFileSystem, ObjectStore};
+use once_cell::sync::OnceCell;
+use parquet::errors::ParquetError;
+use relative_path::RelativePathBuf;
+use std::time::Duration;
+use sysinfo::{Disks, System};
+use tokio::fs::{self, DirEntry};
+use tokio::io::AsyncWriteExt;
+use tokio_stream::wrappers::ReadDirStream;
+
+pub const STREAM_HOT_TIER_FILENAME: &str = ".hot_tier.json";
+pub const MIN_STREAM_HOT_TIER_SIZE_BYTES: u64 = 10737418240; // 10 GiB
+const HOT_TIER_SYNC_DURATION: Interval = clokwerk::Interval::Minutes(1);
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct StreamHotTier {
+    #[serde(rename = "size")]
+    pub size: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub used_size: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub available_size: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oldest_date_time_entry: Option<String>,
+}
+
+pub struct HotTierManager {
+    filesystem: LocalFileSystem,
+    hot_tier_path: PathBuf,
+}
+
+impl HotTierManager {
+    pub fn global() -> Option<&'static HotTierManager> {
+        static INSTANCE: OnceCell<HotTierManager> = OnceCell::new();
+
+        let hot_tier_path = CONFIG.parseable.hot_tier_storage_path.as_ref()?;
+
+        Some(INSTANCE.get_or_init(|| {
+            let hot_tier_path = hot_tier_path.clone();
+            std::fs::create_dir_all(&hot_tier_path).unwrap();
+            HotTierManager {
+                filesystem: LocalFileSystem::new(),
+                hot_tier_path,
+            }
+        }))
+    }
+
+    ///get the total hot tier size for all streams
+    pub async fn get_hot_tiers_size(
+        &self,
+        current_stream: &str,
+    ) -> Result<(u64, u64), HotTierError> {
+        let mut total_hot_tier_size = 0;
+        let mut total_hot_tier_used_size = 0;
+        for stream in STREAM_INFO.list_streams() {
+            if self.check_stream_hot_tier_exists(&stream) && stream != current_stream {
+                let stream_hot_tier = self.get_hot_tier(&stream).await?;
+                total_hot_tier_size += human_size_to_bytes(&stream_hot_tier.size).unwrap();
+                total_hot_tier_used_size +=
+                    human_size_to_bytes(&stream_hot_tier.used_size.unwrap()).unwrap();
+            }
+        }
+        Ok((total_hot_tier_size, total_hot_tier_used_size))
+    }
+
+    /// validate if hot tier size can be fit in the disk
+    /// check disk usage and hot tier size of all other streams
+    /// check if total hot tier size of all streams is less than max disk usage
+    /// delete all the files from hot tier once validation is successful and hot tier is ready to be updated
+    pub async fn validate_hot_tier_size(
+        &self,
+        stream: &str,
+        size: &str,
+    ) -> Result<(), HotTierError> {
+        let mut existing_hot_tier_used_size = 0;
+        if self.check_stream_hot_tier_exists(stream) {
+            //delete existing hot tier if its size is less than the updated hot tier size else return error
+            let existing_hot_tier = self.get_hot_tier(stream).await?;
+            existing_hot_tier_used_size =
+                human_size_to_bytes(&existing_hot_tier.used_size.unwrap()).unwrap();
+            if human_size_to_bytes(size) < human_size_to_bytes(&existing_hot_tier.size) {
+                return Err(HotTierError::ObjectStorageError(ObjectStorageError::Custom(format!(
+                    "The hot tier size for the stream is already set to {} which is greater than the updated hot tier size of {}, reducing the hot tier size is not allowed",
+                    existing_hot_tier.size,
+                    size
+                ))));
+            }
+        }
+
+        let (total_disk_space, available_disk_space, used_disk_space) = get_disk_usage();
+
+        if let (Some(total_disk_space), Some(available_disk_space), Some(used_disk_space)) =
+            (total_disk_space, available_disk_space, used_disk_space)
+        {
+            let stream_hot_tier_size = human_size_to_bytes(size).unwrap();
+            let (total_hot_tier_size, total_hot_tier_used_size) =
+                self.get_hot_tiers_size(stream).await?;
+            let projected_disk_usage = total_hot_tier_size + stream_hot_tier_size + used_disk_space
+                - existing_hot_tier_used_size
+                - total_hot_tier_used_size;
+            let usage_percentage =
+                ((projected_disk_usage as f64 / total_disk_space as f64) * 100.0).round();
+            if usage_percentage > CONFIG.parseable.max_disk_usage {
+                return Err(HotTierError::ObjectStorageError(ObjectStorageError::Custom(format!(
+                    "Including the hot tier size of all the streams, the projected disk usage will be {}% which is above the set threshold of {}%, hence unable to set the hot tier for the stream. Total Disk Size: {}, Available Disk Size: {}, Used Disk Size: {}, Total Hot Tier Size (all other streams): {}",
+                    usage_percentage,
+                    CONFIG.parseable.max_disk_usage,
+                    bytes_to_human_size(total_disk_space),
+                    bytes_to_human_size(available_disk_space),
+                    bytes_to_human_size(used_disk_space),
+                    bytes_to_human_size(total_hot_tier_size)
+                ))));
+            }
+        }
+
+        Ok(())
+    }
+
+    ///get the hot tier metadata file for the stream
+    pub async fn get_hot_tier(&self, stream: &str) -> Result<StreamHotTier, HotTierError> {
+        if !self.check_stream_hot_tier_exists(stream) {
+            return Err(HotTierError::HotTierValidationError(
+                HotTierValidationError::NotFound(stream.to_owned()),
+            ));
+        }
+        let path = hot_tier_file_path(&self.hot_tier_path, stream)?;
+        let res = self
+            .filesystem
+            .get(&path)
+            .and_then(|resp| resp.bytes())
+            .await;
+        match res {
+            Ok(bytes) => {
+                let mut stream_hot_tier: StreamHotTier = serde_json::from_slice(&bytes)?;
+                let oldest_date_time_entry = self.get_oldest_date_time_entry(stream).await?;
+                stream_hot_tier.oldest_date_time_entry = oldest_date_time_entry;
+                Ok(stream_hot_tier)
+            }
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    pub async fn delete_hot_tier(&self, stream: &str) -> Result<(), HotTierError> {
+        if self.check_stream_hot_tier_exists(stream) {
+            let path = self.hot_tier_path.join(stream);
+            fs::remove_dir_all(path).await?;
+            Ok(())
+        } else {
+            Err(HotTierError::HotTierValidationError(
+                HotTierValidationError::NotFound(stream.to_owned()),
+            ))
+        }
+    }
+
+    ///put the hot tier metadata file for the stream
+    /// set the updated_date_range in the hot tier metadata file
+    pub async fn put_hot_tier(
+        &self,
+        stream: &str,
+        hot_tier: &mut StreamHotTier,
+    ) -> Result<(), HotTierError> {
+        let path = hot_tier_file_path(&self.hot_tier_path, stream)?;
+        let bytes = serde_json::to_vec(&hot_tier)?.into();
+        self.filesystem.put(&path, bytes).await?;
+        Ok(())
+    }
+
+    ///schedule the download of the hot tier files from S3 every minute
+    pub fn download_from_s3<'a>(&'a self) -> Result<(), HotTierError>
+    where
+        'a: 'static,
+    {
+        let mut scheduler = AsyncScheduler::new();
+        scheduler
+            .every(HOT_TIER_SYNC_DURATION)
+            .plus(Interval::Seconds(5))
+            .run(move || async {
+                if let Err(err) = self.sync_hot_tier().await {
+                    log::error!("Error in hot tier scheduler: {:?}", err);
+                }
+            });
+
+        tokio::spawn(async move {
+            loop {
+                scheduler.run_pending().await;
+                tokio::time::sleep(Duration::from_secs(10)).await;
+            }
+        });
+        Ok(())
+    }
+
+    ///sync the hot tier files from S3 to the hot tier directory for all streams
+    async fn sync_hot_tier(&self) -> Result<(), HotTierError> {
+        let streams = STREAM_INFO.list_streams();
+        let sync_hot_tier_tasks = FuturesUnordered::new();
+        for stream in streams {
+            if self.check_stream_hot_tier_exists(&stream) {
+                sync_hot_tier_tasks.push(async move { self.process_stream(stream).await });
+                //self.process_stream(stream).await?;
+            }
+        }
+
+        let res: Vec<_> = sync_hot_tier_tasks.collect().await;
+        for res in res {
+            if let Err(err) = res {
+                log::error!("Failed to run hot tier sync task {err:?}");
+                return Err(err);
+            }
+        }
+        Ok(())
+    }
+
+    ///process the hot tier files for the stream
+    /// delete the files from the hot tier directory if the available date range is outside the hot tier range
+    async fn process_stream(&self, stream: String) -> Result<(), HotTierError> {
+        let stream_hot_tier = self.get_hot_tier(&stream).await?;
+        let mut parquet_file_size =
+            human_size_to_bytes(stream_hot_tier.used_size.as_ref().unwrap()).unwrap();
+
+        let object_store = CONFIG.storage().get_object_store();
+        let mut s3_manifest_file_list = object_store.list_manifest_files(&stream).await?;
+        self.process_manifest(
+            &stream,
+            &mut s3_manifest_file_list,
+            &mut parquet_file_size,
+            object_store.clone(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    ///process the hot tier files for the date for the stream
+    /// collect all manifests from S3 for the date, sort the parquet file list
+    /// in order to download the latest files first
+    /// download the parquet files if not present in hot tier directory
+    async fn process_manifest(
+        &self,
+        stream: &str,
+        manifest_files_to_download: &mut BTreeMap<String, Vec<String>>,
+        parquet_file_size: &mut u64,
+        object_store: Arc<dyn ObjectStorage + Send>,
+    ) -> Result<(), HotTierError> {
+        if manifest_files_to_download.is_empty() {
+            return Ok(());
+        }
+        for (str_date, manifest_files) in manifest_files_to_download.iter().rev() {
+            let mut storage_combined_manifest = Manifest::default();
+
+            for manifest_file in manifest_files {
+                let manifest_path: RelativePathBuf = RelativePathBuf::from(manifest_file.clone());
+                let storage_manifest_bytes = object_store.get_object(&manifest_path).await?;
+                let storage_manifest: Manifest = serde_json::from_slice(&storage_manifest_bytes)?;
+                storage_combined_manifest
+                    .files
+                    .extend(storage_manifest.files);
+            }
+
+            storage_combined_manifest
+                .files
+                .sort_by_key(|file| file.file_path.clone());
+
+            while let Some(parquet_file) = storage_combined_manifest.files.pop() {
+                let parquet_file_path = &parquet_file.file_path;
+                let parquet_path = self.hot_tier_path.join(parquet_file_path);
+
+                if !parquet_path.exists() {
+                    if let Ok(date) =
+                        NaiveDate::parse_from_str(str_date.trim_start_matches("date="), "%Y-%m-%d")
+                    {
+                        if !self
+                            .process_parquet_file(
+                                stream,
+                                &parquet_file,
+                                parquet_file_size,
+                                parquet_path,
+                                date,
+                            )
+                            .await?
+                        {
+                            break;
+                        }
+                    } else {
+                        log::warn!("Invalid date format: {}", str_date);
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    ///process the parquet file for the stream
+    /// check if the disk is available to download the parquet file
+    /// if not available, delete the oldest entry from the hot tier directory
+    /// download the parquet file from S3 to the hot tier directory
+    /// update the used and available size in the hot tier metadata
+    /// return true if the parquet file is processed successfully
+    async fn process_parquet_file(
+        &self,
+        stream: &str,
+        parquet_file: &File,
+        parquet_file_size: &mut u64,
+        parquet_path: PathBuf,
+        date: NaiveDate,
+    ) -> Result<bool, HotTierError> {
+        let mut file_processed = false;
+        let mut stream_hot_tier = self.get_hot_tier(stream).await?;
+        if !self.is_disk_available(parquet_file.file_size).await?
+            || human_size_to_bytes(&stream_hot_tier.available_size.clone().unwrap()).unwrap()
+                <= parquet_file.file_size
+        {
+            if !self
+                .cleanup_hot_tier_old_data(
+                    stream,
+                    &mut stream_hot_tier,
+                    &parquet_path,
+                    parquet_file.file_size,
+                )
+                .await?
+            {
+                return Ok(file_processed);
+            }
+            *parquet_file_size =
+                human_size_to_bytes(&stream_hot_tier.used_size.clone().unwrap()).unwrap();
+        }
+        let parquet_file_path = RelativePathBuf::from(parquet_file.file_path.clone());
+        fs::create_dir_all(parquet_path.parent().unwrap()).await?;
+        let mut file = fs::File::create(parquet_path.clone()).await?;
+        let parquet_data = CONFIG
+            .storage()
+            .get_object_store()
+            .get_object(&parquet_file_path)
+            .await?;
+        file.write_all(&parquet_data).await?;
+        *parquet_file_size += parquet_file.file_size;
+        stream_hot_tier.used_size = Some(bytes_to_human_size(*parquet_file_size));
+
+        stream_hot_tier.available_size = Some(bytes_to_human_size(
+            human_size_to_bytes(&stream_hot_tier.available_size.clone().unwrap()).unwrap()
+                - parquet_file.file_size,
+        ));
+        self.put_hot_tier(stream, &mut stream_hot_tier).await?;
+        file_processed = true;
+        let mut hot_tier_manifest = self
+            .get_stream_hot_tier_manifest_for_date(stream, &date)
+            .await?;
+        hot_tier_manifest.files.push(parquet_file.clone());
+        // write the manifest file to the hot tier directory
+        let manifest_path = self
+            .hot_tier_path
+            .join(stream)
+            .join(format!("date={}/hottier.manifest.json", date));
+        fs::create_dir_all(manifest_path.parent().unwrap()).await?;
+        fs::write(manifest_path, serde_json::to_vec(&hot_tier_manifest)?).await?;
+        Ok(file_processed)
+    }
+
+    ///delete the files for the date range given from the hot tier directory for the stream
+    /// update the used and available size in the hot tier metadata
+    pub async fn delete_files_from_hot_tier(
+        &self,
+        stream: &str,
+        dates: &[NaiveDate],
+    ) -> Result<(), HotTierError> {
+        for date in dates.iter() {
+            let path = self.hot_tier_path.join(format!("{}/date={}", stream, date));
+            if path.exists() {
+                fs::remove_dir_all(path.clone()).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    ///fetch the list of dates available in the hot tier directory for the stream and sort them
+    pub async fn fetch_hot_tier_dates(&self, stream: &str) -> Result<Vec<NaiveDate>, HotTierError> {
+        let mut date_list = Vec::new();
+        let path = self.hot_tier_path.join(stream);
+        if path.exists() {
+            let directories = ReadDirStream::new(fs::read_dir(&path).await?);
+            let dates: Vec<DirEntry> = directories.try_collect().await?;
+            for date in dates {
+                if !date.path().is_dir() {
+                    continue;
+                }
+                let date = date.file_name().into_string().unwrap();
+                date_list.push(
+                    NaiveDate::parse_from_str(date.trim_start_matches("date="), "%Y-%m-%d")
+                        .unwrap(),
+                );
+            }
+        }
+        date_list.sort();
+        Ok(date_list)
+    }
+
+    ///get hot tier manifest for the stream and date
+    pub async fn get_stream_hot_tier_manifest_for_date(
+        &self,
+        stream: &str,
+        date: &NaiveDate,
+    ) -> Result<Manifest, HotTierError> {
+        let mut hot_tier_manifest = Manifest::default();
+        let path = self
+            .hot_tier_path
+            .join(stream)
+            .join(format!("date={}", date));
+        if path.exists() {
+            let date_dirs = ReadDirStream::new(fs::read_dir(&path).await?);
+            let manifest_files: Vec<DirEntry> = date_dirs.try_collect().await?;
+            for manifest in manifest_files {
+                if !manifest
+                    .file_name()
+                    .to_string_lossy()
+                    .ends_with(".manifest.json")
+                {
+                    continue;
+                }
+                let file = fs::read(manifest.path()).await?;
+                let manifest: Manifest = serde_json::from_slice(&file)?;
+                hot_tier_manifest.files.extend(manifest.files);
+            }
+        }
+        Ok(hot_tier_manifest)
+    }
+
+    ///get the list of files from all the manifests present in hot tier directory for the stream
+    pub async fn get_hot_tier_manifest_files(
+        &self,
+        stream: &str,
+        manifest_files: Vec<File>,
+    ) -> Result<(Vec<File>, Vec<File>), HotTierError> {
+        let mut hot_tier_files = self.get_hot_tier_parquet_files(stream).await?;
+        hot_tier_files.retain(|file| {
+            manifest_files
+                .iter()
+                .any(|manifest_file| manifest_file.file_path.eq(&file.file_path))
+        });
+        let remaining_files: Vec<File> = manifest_files
+            .into_iter()
+            .filter(|manifest_file| {
+                hot_tier_files
+                    .iter()
+                    .all(|file| !file.file_path.eq(&manifest_file.file_path))
+            })
+            .collect();
+        Ok((hot_tier_files, remaining_files))
+    }
+
+    ///get the list of parquet files from the hot tier directory for the stream
+    pub async fn get_hot_tier_parquet_files(
+        &self,
+        stream: &str,
+    ) -> Result<Vec<File>, HotTierError> {
+        let mut hot_tier_parquet_files: Vec<File> = Vec::new();
+        let date_list = self.fetch_hot_tier_dates(stream).await?;
+        for date in date_list {
+            let manifest = self
+                .get_stream_hot_tier_manifest_for_date(stream, &date)
+                .await?;
+
+            for parquet_file in manifest.files {
+                hot_tier_parquet_files.push(parquet_file.clone());
+            }
+        }
+        Ok(hot_tier_parquet_files)
+    }
+
+    ///check if the hot tier metadata file exists for the stream
+    pub fn check_stream_hot_tier_exists(&self, stream: &str) -> bool {
+        let path = self
+            .hot_tier_path
+            .join(stream)
+            .join(STREAM_HOT_TIER_FILENAME);
+        path.exists()
+    }
+
+    ///delete the parquet file from the hot tier directory for the stream
+    /// loop through all manifests in the hot tier directory for the stream
+    /// loop through all parquet files in the manifest
+    /// check for the oldest entry to delete if the path exists in hot tier
+    /// update the used and available size in the hot tier metadata
+    /// loop if available size is still less than the parquet file size
+    pub async fn cleanup_hot_tier_old_data(
+        &self,
+        stream: &str,
+        stream_hot_tier: &mut StreamHotTier,
+        download_file_path: &Path,
+        parquet_file_size: u64,
+    ) -> Result<bool, HotTierError> {
+        let mut delete_successful = false;
+        let dates = self.fetch_hot_tier_dates(stream).await?;
+        'loop_dates: for date in dates {
+            let date_str = date.to_string();
+            let path = &self
+                .hot_tier_path
+                .join(stream)
+                .join(format!("date={}", date_str));
+            if !path.exists() {
+                continue;
+            }
+
+            let date_dirs = ReadDirStream::new(fs::read_dir(&path).await?);
+            let mut manifest_files: Vec<DirEntry> = date_dirs.try_collect().await?;
+            manifest_files.retain(|manifest| {
+                manifest
+                    .file_name()
+                    .to_string_lossy()
+                    .ends_with(".manifest.json")
+            });
+            for manifest_file in manifest_files {
+                let file = fs::read(manifest_file.path()).await?;
+                let mut manifest: Manifest = serde_json::from_slice(&file)?;
+
+                manifest.files.sort_by_key(|file| file.file_path.clone());
+                manifest.files.reverse();
+
+                'loop_files: while let Some(file_to_delete) = manifest.files.pop() {
+                    let file_size = file_to_delete.file_size;
+                    let path_to_delete = CONFIG
+                        .parseable
+                        .hot_tier_storage_path
+                        .as_ref()
+                        .unwrap()
+                        .join(&file_to_delete.file_path);
+
+                    if path_to_delete.exists() {
+                        if let (Some(download_date_time), Some(delete_date_time)) = (
+                            extract_datetime(download_file_path.to_str().unwrap()),
+                            extract_datetime(path_to_delete.to_str().unwrap()),
+                        ) {
+                            if download_date_time <= delete_date_time {
+                                delete_successful = false;
+                                break 'loop_files;
+                            }
+                        }
+
+                        fs::write(manifest_file.path(), serde_json::to_vec(&manifest)?).await?;
+
+                        fs::remove_dir_all(path_to_delete.parent().unwrap()).await?;
+                        delete_empty_directory_hot_tier(path_to_delete.parent().unwrap()).await?;
+
+                        stream_hot_tier.used_size = Some(bytes_to_human_size(
+                            human_size_to_bytes(&stream_hot_tier.used_size.clone().unwrap())
+                                .unwrap()
+                                - file_size,
+                        ));
+                        stream_hot_tier.available_size = Some(bytes_to_human_size(
+                            human_size_to_bytes(&stream_hot_tier.available_size.clone().unwrap())
+                                .unwrap()
+                                + file_size,
+                        ));
+                        self.put_hot_tier(stream, stream_hot_tier).await?;
+                        delete_successful = true;
+
+                        if human_size_to_bytes(&stream_hot_tier.available_size.clone().unwrap())
+                            .unwrap()
+                            <= parquet_file_size
+                        {
+                            continue 'loop_files;
+                        } else {
+                            break 'loop_dates;
+                        }
+                    } else {
+                        fs::write(manifest_file.path(), serde_json::to_vec(&manifest)?).await?;
+                    }
+                }
+            }
+        }
+
+        Ok(delete_successful)
+    }
+
+    ///check if the disk is available to download the parquet file
+    /// check if the disk usage is above the threshold
+    pub async fn is_disk_available(&self, size_to_download: u64) -> Result<bool, HotTierError> {
+        let (total_disk_space, available_disk_space, used_disk_space) = get_disk_usage();
+
+        if let (Some(total_disk_space), Some(available_disk_space), Some(used_disk_space)) =
+            (total_disk_space, available_disk_space, used_disk_space)
+        {
+            if available_disk_space < size_to_download {
+                return Ok(false);
+            }
+
+            if ((used_disk_space + size_to_download) as f64 * 100.0 / total_disk_space as f64)
+                > CONFIG.parseable.max_disk_usage
+            {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+
+    pub async fn get_oldest_date_time_entry(
+        &self,
+        stream: &str,
+    ) -> Result<Option<String>, HotTierError> {
+        let date_list = self.fetch_hot_tier_dates(stream).await?;
+        if date_list.is_empty() {
+            return Ok(None);
+        }
+
+        for date in date_list {
+            let path = self
+                .hot_tier_path
+                .join(stream)
+                .join(format!("date={}", date));
+
+            let hours_dir = ReadDirStream::new(fs::read_dir(&path).await?);
+            let mut hours: Vec<DirEntry> = hours_dir.try_collect().await?;
+            hours.retain(|entry| {
+                entry.path().is_dir() && entry.file_name().to_string_lossy().starts_with("hour=")
+            });
+            hours.sort_by_key(|entry| entry.file_name().to_string_lossy().to_string());
+
+            for hour in hours {
+                let hour_str = hour
+                    .file_name()
+                    .to_string_lossy()
+                    .trim_start_matches("hour=")
+                    .to_string();
+
+                let minutes_dir = ReadDirStream::new(fs::read_dir(hour.path()).await?);
+                let mut minutes: Vec<DirEntry> = minutes_dir.try_collect().await?;
+                minutes.retain(|entry| {
+                    entry.path().is_dir()
+                        && entry.file_name().to_string_lossy().starts_with("minute=")
+                });
+                minutes.sort_by_key(|entry| entry.file_name().to_string_lossy().to_string());
+
+                if let Some(minute) = minutes.first() {
+                    let minute_str = minute
+                        .file_name()
+                        .to_string_lossy()
+                        .trim_start_matches("minute=")
+                        .to_string();
+                    let oldest_date_time = format!("{} {}:{}:00", date, hour_str, minute_str);
+                    return Ok(Some(oldest_date_time));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+/// get the hot tier file path for the stream
+pub fn hot_tier_file_path(
+    root: impl AsRef<std::path::Path>,
+    stream: &str,
+) -> Result<object_store::path::Path, object_store::path::Error> {
+    let path = root.as_ref().join(stream).join(STREAM_HOT_TIER_FILENAME);
+    object_store::path::Path::from_absolute_path(path)
+}
+
+///get the disk usage for the hot tier storage path
+pub fn get_disk_usage() -> (Option<u64>, Option<u64>, Option<u64>) {
+    let mut sys = System::new_all();
+    sys.refresh_all();
+    let path = CONFIG.parseable.hot_tier_storage_path.as_ref().unwrap();
+
+    let mut disks = Disks::new_with_refreshed_list();
+    disks.sort_by_key(|disk| disk.mount_point().to_str().unwrap().len());
+    disks.reverse();
+
+    for disk in disks.iter() {
+        if path.starts_with(disk.mount_point().to_str().unwrap()) {
+            let total_disk_space = disk.total_space();
+            let available_disk_space = disk.available_space();
+            let used_disk_space = total_disk_space - available_disk_space;
+            return (
+                Some(total_disk_space),
+                Some(available_disk_space),
+                Some(used_disk_space),
+            );
+        }
+    }
+
+    (None, None, None)
+}
+
+async fn delete_empty_directory_hot_tier(path: &Path) -> io::Result<()> {
+    async fn delete_helper(path: &Path) -> io::Result<()> {
+        if path.is_dir() {
+            let mut read_dir = fs::read_dir(path).await?;
+            let mut subdirs = vec![];
+
+            while let Some(entry) = read_dir.next_entry().await? {
+                let entry_path = entry.path();
+                if entry_path.is_dir() {
+                    subdirs.push(entry_path);
+                }
+            }
+            let mut tasks = vec![];
+            for subdir in &subdirs {
+                tasks.push(delete_empty_directory_hot_tier(subdir));
+            }
+            futures::stream::iter(tasks)
+                .buffer_unordered(10)
+                .try_collect::<Vec<_>>()
+                .await?;
+
+            // Re-check the directory after deleting its subdirectories
+            let mut read_dir = fs::read_dir(path).await?;
+            if read_dir.next_entry().await?.is_none() {
+                fs::remove_dir(path).await?;
+            }
+        }
+        Ok(())
+    }
+    delete_helper(path).await
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum HotTierError {
+    #[error("{0}")]
+    Serde(#[from] serde_json::Error),
+    #[error("{0}")]
+    IOError(#[from] io::Error),
+    #[error("{0}")]
+    MoveError(#[from] fs_extra::error::Error),
+    #[error("{0}")]
+    ObjectStoreError(#[from] object_store::Error),
+    #[error("{0}")]
+    ObjectStorePathError(#[from] object_store::path::Error),
+    #[error("{0}")]
+    ObjectStorageError(#[from] ObjectStorageError),
+    #[error("{0}")]
+    ParquetError(#[from] ParquetError),
+    #[error("{0}")]
+    MetadataError(#[from] MetadataError),
+    #[error("{0}")]
+    HotTierValidationError(#[from] HotTierValidationError),
+    #[error("{0}")]
+    Anyhow(#[from] anyhow::Error),
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -24,6 +24,7 @@ mod catalog;
 mod cli;
 mod event;
 mod handlers;
+mod hottier;
 mod livetail;
 mod localcache;
 mod metadata;

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -28,7 +28,8 @@ use parquet::basic::{BrotliLevel, GzipLevel, ZstdLevel};
 use std::env;
 use std::path::PathBuf;
 use std::sync::Arc;
-pub const MIN_CACHE_SIZE_BYTES: u64 = 1000u64.pow(3); // 1 GiB
+pub const MIN_CACHE_SIZE_BYTES: u64 = 1073741824; // 1 GiB
+
 pub const JOIN_COMMUNITY: &str =
     "Join us on Parseable Slack community for questions : https://logg.ing/community";
 pub static CONFIG: Lazy<Arc<Config>> = Lazy::new(|| Arc::new(Config::new()));
@@ -328,7 +329,7 @@ pub mod validation {
         url::Url::parse(s).map_err(|_| "Invalid URL provided".to_string())
     }
 
-    fn human_size_to_bytes(s: &str) -> Result<u64, String> {
+    pub fn human_size_to_bytes(s: &str) -> Result<u64, String> {
         fn parse_and_map<T: human_size::Multiple>(
             s: &str,
         ) -> Result<u64, human_size::ParsingError> {
@@ -342,23 +343,51 @@ pub mod validation {
             .or(parse_and_map::<multiples::Tebibyte>(s))
             .or(parse_and_map::<multiples::Terabyte>(s))
             .map_err(|_| "Could not parse given size".to_string())?;
-
-        if size < MIN_CACHE_SIZE_BYTES {
-            return Err(
-                "Specified value of cache size is smaller than current minimum of 1GiB".to_string(),
-            );
-        }
-
         Ok(size)
+    }
+
+    pub fn bytes_to_human_size(bytes: u64) -> String {
+        const KIB: u64 = 1024;
+        const MIB: u64 = KIB * 1024;
+        const GIB: u64 = MIB * 1024;
+        const TIB: u64 = GIB * 1024;
+        const PIB: u64 = TIB * 1024;
+
+        if bytes < KIB {
+            format!("{} B", bytes)
+        } else if bytes < MIB {
+            format!("{:.2} KB", bytes as f64 / KIB as f64)
+        } else if bytes < GIB {
+            format!("{:.2} MiB", bytes as f64 / MIB as f64)
+        } else if bytes < TIB {
+            format!("{:.2} GiB", bytes as f64 / GIB as f64)
+        } else if bytes < PIB {
+            format!("{:.2} TiB", bytes as f64 / TIB as f64)
+        } else {
+            format!("{:.2} PiB", bytes as f64 / PIB as f64)
+        }
     }
 
     pub fn cache_size(s: &str) -> Result<u64, String> {
         let size = human_size_to_bytes(s)?;
         if size < MIN_CACHE_SIZE_BYTES {
-            return Err(
-                "Specified value of cache size is smaller than current minimum of 1GiB".to_string(),
-            );
+            return Err(format!(
+                "Specified value of cache size is smaller than current minimum of {}",
+                human_size_to_bytes(&MIN_CACHE_SIZE_BYTES.to_string()).unwrap()
+            ));
         }
         Ok(size)
+    }
+
+    pub fn validate_disk_usage(max_disk_usage: &str) -> Result<f64, String> {
+        if let Ok(max_disk_usage) = max_disk_usage.parse::<f64>() {
+            if (0.0..=100.0).contains(&max_disk_usage) {
+                Ok(max_disk_usage)
+            } else {
+                Err("Invalid value for max disk usage. It should be between 0 and 100".to_string())
+            }
+        } else {
+            Err("Invalid value for max disk usage. It should be given as 90.0 for 90%".to_string())
+        }
     }
 }

--- a/server/src/query.rs
+++ b/server/src/query.rs
@@ -190,7 +190,7 @@ impl TableScanVisitor {
     }
 }
 
-impl TreeNodeVisitor for TableScanVisitor {
+impl TreeNodeVisitor<'_> for TableScanVisitor {
     type Node = LogicalPlan;
 
     fn f_down(&mut self, node: &Self::Node) -> Result<TreeNodeRecursion, DataFusionError> {
@@ -232,13 +232,13 @@ fn transform(
                         _start_time_filter =
                             PartialTimeFilter::Low(std::ops::Bound::Included(start_time))
                                 .binary_expr(Expr::Column(Column::new(
-                                    Some(table.table_name.to_owned_reference()),
+                                    Some(table.table_name.to_owned()),
                                     time_partition.clone(),
                                 )));
                         _end_time_filter =
                             PartialTimeFilter::High(std::ops::Bound::Excluded(end_time))
                                 .binary_expr(Expr::Column(Column::new(
-                                    Some(table.table_name.to_owned_reference()),
+                                    Some(table.table_name.to_owned()),
                                     time_partition,
                                 )));
                     }
@@ -246,13 +246,13 @@ fn transform(
                         _start_time_filter =
                             PartialTimeFilter::Low(std::ops::Bound::Included(start_time))
                                 .binary_expr(Expr::Column(Column::new(
-                                    Some(table.table_name.to_owned_reference()),
+                                    Some(table.table_name.to_owned()),
                                     event::DEFAULT_TIMESTAMP_KEY,
                                 )));
                         _end_time_filter =
                             PartialTimeFilter::High(std::ops::Bound::Excluded(end_time))
                                 .binary_expr(Expr::Column(Column::new(
-                                    Some(table.table_name.to_owned_reference()),
+                                    Some(table.table_name.to_owned()),
                                     event::DEFAULT_TIMESTAMP_KEY,
                                 )));
                     }

--- a/server/src/query/filter_optimizer.rs
+++ b/server/src/query/filter_optimizer.rs
@@ -112,6 +112,7 @@ impl OptimizerRule for FilterOptimizerRule {
         // If we didn't find anything then recurse as normal and build the result.
         
         // TODO: replace `optimize_children()` since it will be removed
+        // But it is not being used anywhere, so might as well just let it be for now
         optimize_children(self, plan, config)
     }
 

--- a/server/src/query/stream_schema_provider.rs
+++ b/server/src/query/stream_schema_provider.rs
@@ -446,18 +446,26 @@ impl TableProvider for StandardTableProvider {
         )?)
     }
 
-    fn supports_filter_pushdown(
+    /*
+    Updated the function signature (and name)
+    Now it handles multiple filters
+    */
+    fn supports_filters_pushdown(
         &self,
-        filter: &Expr,
-    ) -> Result<TableProviderFilterPushDown, DataFusionError> {
-        if expr_in_boundary(filter) {
-            // if filter can be handled by time partiton pruning, it is exact
-            Ok(TableProviderFilterPushDown::Exact)
-        } else {
-            // otherwise, we still might be able to handle the filter with file
-            // level mechanisms such as Parquet row group pruning.
-            Ok(TableProviderFilterPushDown::Inexact)
-        }
+        filters: &[&Expr],
+    ) -> Result<Vec<TableProviderFilterPushDown>, DataFusionError> {
+        let res_vec = filters.into_iter()
+            .map(|filter| {
+                if expr_in_boundary(filter) {
+                    // if filter can be handled by time partiton pruning, it is exact
+                    TableProviderFilterPushDown::Exact
+                } else {
+                    // otherwise, we still might be able to handle the filter with file
+                    // level mechanisms such as Parquet row group pruning.
+                    TableProviderFilterPushDown::Inexact
+                }
+            }).collect_vec();
+        Ok(res_vec)
     }
 }
 
@@ -677,11 +685,12 @@ fn extract_from_lit(expr: BinaryExpr, time_partition: Option<String>) -> Option<
     }
 }
 
+/* `BinaryExp` doesn't implement `Copy` */
 fn extract_timestamp_bound(
     binexpr: BinaryExpr,
     time_partition: Option<String>,
 ) -> Option<(Operator, NaiveDateTime)> {
-    Some((binexpr.op, extract_from_lit(binexpr, time_partition)?))
+    Some((binexpr.op.clone(), extract_from_lit(binexpr, time_partition)?))
 }
 
 async fn collect_manifest_files(
@@ -751,7 +760,8 @@ trait ManifestExt: ManifestFile {
             let Expr::Literal(value) = &*expr.right else {
                 return None;
             };
-            Some((expr.op, value))
+            /* `BinaryExp` doesn't implement `Copy` */
+            Some((expr.op.clone(), value))
         }
 
         let Some(col) = self.find_matching_column(partial_filter) else {

--- a/server/src/query/stream_schema_provider.rs
+++ b/server/src/query/stream_schema_provider.rs
@@ -16,6 +16,7 @@
  *
  */
 
+use crate::hottier::HotTierManager;
 use crate::Mode;
 use crate::{
     catalog::snapshot::{self, Snapshot},
@@ -293,6 +294,7 @@ impl TableProvider for StandardTableProvider {
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
         let mut memory_exec = None;
         let mut cache_exec = None;
+        let mut hot_tier_exec = None;
         let object_store = state
             .runtime_env()
             .object_store_registry
@@ -416,10 +418,53 @@ impl TableProvider for StandardTableProvider {
             cache_exec = Some(plan)
         }
 
+        // Hot tier data fetch
+        if let Some(hot_tier_manager) = HotTierManager::global() {
+            if hot_tier_manager.check_stream_hot_tier_exists(&self.stream) {
+                let (hot_tier_files, remainder) = hot_tier_manager
+                    .get_hot_tier_manifest_files(&self.stream, manifest_files)
+                    .await
+                    .map_err(|err| DataFusionError::External(Box::new(err)))?;
+                // Assign remaining entries back to manifest list
+                // This is to be used for remote query
+                manifest_files = remainder;
+
+                let hot_tier_files = hot_tier_files
+                    .into_iter()
+                    .map(|mut file| {
+                        let path = CONFIG
+                            .parseable
+                            .hot_tier_storage_path
+                            .as_ref()
+                            .unwrap()
+                            .join(&file.file_path);
+                        file.file_path = path.to_str().unwrap().to_string();
+                        file
+                    })
+                    .collect();
+
+                let (partitioned_files, statistics) =
+                    partitioned_files(hot_tier_files, &self.schema, 1);
+                let plan = create_parquet_physical_plan(
+                    ObjectStoreUrl::parse("file:///").unwrap(),
+                    partitioned_files,
+                    statistics,
+                    self.schema.clone(),
+                    projection,
+                    filters,
+                    limit,
+                    state,
+                    time_partition.clone(),
+                )
+                .await?;
+
+                hot_tier_exec = Some(plan)
+            }
+        }
         if manifest_files.is_empty() {
             QUERY_CACHE_HIT.with_label_values(&[&self.stream]).inc();
             return final_plan(
-                vec![memory_exec, cache_exec],
+                vec![memory_exec, cache_exec, hot_tier_exec],
                 projection,
                 self.schema.clone(),
             );
@@ -440,7 +485,7 @@ impl TableProvider for StandardTableProvider {
         .await?;
 
         Ok(final_plan(
-            vec![memory_exec, cache_exec, Some(remote_exec)],
+            vec![memory_exec, cache_exec, hot_tier_exec, Some(remote_exec)],
             projection,
             self.schema.clone(),
         )?)

--- a/server/src/rbac/role.rs
+++ b/server/src/rbac/role.rs
@@ -32,6 +32,9 @@ pub enum Action {
     PutRetention,
     GetCacheEnabled,
     PutCacheEnabled,
+    PutHotTierEnabled,
+    GetHotTierEnabled,
+    DeleteHotTierEnabled,
     PutAlert,
     GetAlert,
     PutUser,
@@ -117,6 +120,9 @@ impl RoleBuilder {
                 | Action::ListCluster
                 | Action::ListClusterMetrics
                 | Action::Deleteingestor
+                | Action::PutHotTierEnabled
+                | Action::GetHotTierEnabled
+                | Action::DeleteHotTierEnabled
                 | Action::ListDashboard
                 | Action::GetDashboard
                 | Action::CreateDashboard
@@ -206,6 +212,9 @@ pub mod model {
                 Action::PutRetention,
                 Action::PutCacheEnabled,
                 Action::GetCacheEnabled,
+                Action::PutHotTierEnabled,
+                Action::GetHotTierEnabled,
+                Action::DeleteHotTierEnabled,
                 Action::PutAlert,
                 Action::GetAlert,
                 Action::GetAbout,
@@ -249,6 +258,7 @@ pub mod model {
                 Action::GetAbout,
                 Action::QueryLLM,
                 Action::ListCluster,
+                Action::GetHotTierEnabled,
             ],
             stream: None,
             tag: None,

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -100,6 +100,8 @@ pub struct ObjectStoreFormat {
     pub custom_partition: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub static_schema_flag: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hot_tier_enabled: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -167,6 +169,7 @@ impl Default for ObjectStoreFormat {
             time_partition_limit: None,
             custom_partition: None,
             static_schema_flag: None,
+            hot_tier_enabled: None,
         }
     }
 }

--- a/server/src/storage/localfs.rs
+++ b/server/src/storage/localfs.rs
@@ -17,6 +17,7 @@
  */
 
 use std::{
+    collections::BTreeMap,
     path::{Path, PathBuf},
     sync::Arc,
     time::Instant,
@@ -409,6 +410,14 @@ impl ObjectStorage for LocalFS {
         let dates: Vec<_> = FuturesUnordered::from_iter(entries).try_collect().await?;
 
         Ok(dates.into_iter().flatten().collect())
+    }
+
+    async fn list_manifest_files(
+        &self,
+        _stream_name: &str,
+    ) -> Result<BTreeMap<String, Vec<String>>, ObjectStorageError> {
+        //unimplemented
+        Ok(BTreeMap::new())
     }
 
     async fn upload_file(&self, key: &str, path: &Path) -> Result<(), ObjectStorageError> {

--- a/server/src/storage/metrics_layer.rs
+++ b/server/src/storage/metrics_layer.rs
@@ -26,8 +26,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures_util::{stream::BoxStream, Stream, StreamExt};
 use object_store::{
-    path::Path, GetOptions, GetResult, ListResult, MultipartId, ObjectMeta, ObjectStore,
-    PutOptions, PutResult, Result as ObjectStoreResult,
+    path::Path, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore, PutMultipartOpts, PutOptions, PutPayload, PutResult, Result as ObjectStoreResult
 };
 use tokio::io::AsyncWrite;
 
@@ -60,7 +59,7 @@ impl<T: ObjectStore> ObjectStore for MetricLayer<T> {
     async fn put(
         &self,
         location: &Path,
-        bytes: Bytes, /* PutPayload */
+        bytes: PutPayload, /* PutPayload */
     ) -> ObjectStoreResult<PutResult> {
         let time = time::Instant::now();
         let put_result = self.inner.put(location, bytes).await?;
@@ -74,7 +73,7 @@ impl<T: ObjectStore> ObjectStore for MetricLayer<T> {
     async fn put_opts(
         &self,
         location: &Path,
-        payload: Bytes, /* PutPayload */
+        payload: PutPayload, /* PutPayload */
         opts: PutOptions,
     ) -> ObjectStoreResult<PutResult> {
         let time = time::Instant::now();
@@ -86,22 +85,22 @@ impl<T: ObjectStore> ObjectStore for MetricLayer<T> {
         return Ok(put_result);
     }
 
-    // ! removed in object_store 0.10.0
-    async fn abort_multipart(
-        &self,
-        location: &Path,
-        multipart_id: &MultipartId,
-    ) -> object_store::Result<()> {
-        let time = time::Instant::now();
-        let elapsed = time.elapsed().as_secs_f64();
-        self.inner.abort_multipart(location, multipart_id).await?;
-        QUERY_LAYER_STORAGE_REQUEST_RESPONSE_TIME
-            .with_label_values(&["PUT_MULTIPART_ABORT", "200"])
-            .observe(elapsed);
-        Ok(())
-    }
+    // // ! removed in object_store 0.10.0
+    // async fn abort_multipart(
+    //     &self,
+    //     location: &Path,
+    //     multipart_id: &MultipartId,
+    // ) -> object_store::Result<()> {
+    //     let time = time::Instant::now();
+    //     let elapsed = time.elapsed().as_secs_f64();
+    //     self.inner.abort_multipart(location, multipart_id).await?;
+    //     QUERY_LAYER_STORAGE_REQUEST_RESPONSE_TIME
+    //         .with_label_values(&["PUT_MULTIPART_ABORT", "200"])
+    //         .observe(elapsed);
+    //     Ok(())
+    // }
 
-    /* Keep for easier migration to object_store 0.10.0
+    /* Keep for easier migration to object_store 0.10.0 */
     async fn put_multipart_opts(
         &self,
         location: &Path,
@@ -115,13 +114,13 @@ impl<T: ObjectStore> ObjectStore for MetricLayer<T> {
             .observe(elapsed);
 
         Ok(multipart_upload)
-    } */
+    }
 
     // todo completly tracking multipart upload
     async fn put_multipart(
         &self,
         location: &Path,
-    ) -> ObjectStoreResult<(MultipartId, Box<dyn AsyncWrite + Unpin + Send>)> /* ObjectStoreResult<Box<dyn MultipartUpload>> */
+    ) -> ObjectStoreResult<Box<dyn MultipartUpload>> /* ObjectStoreResult<(MultipartId, Box<dyn AsyncWrite + Unpin + Send>)> */
     {
         let time = time::Instant::now();
         let multipart_upload = self.inner.put_multipart(location).await?;

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -49,6 +49,7 @@ use itertools::Itertools;
 use relative_path::RelativePath;
 use relative_path::RelativePathBuf;
 
+use std::collections::BTreeMap;
 use std::{
     collections::HashMap,
     fs,
@@ -87,6 +88,10 @@ pub trait ObjectStorage: Sync + 'static {
     async fn get_all_saved_filters(&self) -> Result<Vec<Bytes>, ObjectStorageError>;
     async fn get_all_dashboards(&self) -> Result<Vec<Bytes>, ObjectStorageError>;
     async fn list_dates(&self, stream_name: &str) -> Result<Vec<String>, ObjectStorageError>;
+    async fn list_manifest_files(
+        &self,
+        stream_name: &str,
+    ) -> Result<BTreeMap<String, Vec<String>>, ObjectStorageError>;
     async fn upload_file(&self, key: &str, path: &Path) -> Result<(), ObjectStorageError>;
     async fn delete_object(&self, path: &RelativePath) -> Result<(), ObjectStorageError>;
     async fn get_ingestor_meta_file_paths(

--- a/server/src/storage/s3.rs
+++ b/server/src/storage/s3.rs
@@ -346,10 +346,14 @@ impl S3 {
     async fn _upload_file(&self, key: &str, path: &StdPath) -> Result<(), ObjectStorageError> {
         let instant = Instant::now();
 
-        let should_multipart = std::fs::metadata(path)?.len() > MULTIPART_UPLOAD_SIZE as u64;
+        // // TODO: Uncomment this when multipart is fixed
+        // let should_multipart = std::fs::metadata(path)?.len() > MULTIPART_UPLOAD_SIZE as u64;
+
+        let should_multipart = false;
 
         let res = if should_multipart {
-            self._upload_multipart(key, path).await
+            todo!();
+            // self._upload_multipart(key, path).await
         } else {
             let bytes = tokio::fs::read(path).await?;
             let result = self.client.put(&key.into(), bytes.into()).await?;
@@ -366,47 +370,48 @@ impl S3 {
         res
     }
 
-    async fn _upload_multipart(&self, key: &str, path: &StdPath) -> Result<(), ObjectStorageError> {
-        let mut buf = vec![0u8; MULTIPART_UPLOAD_SIZE / 2];
-        let mut file = OpenOptions::new().read(true).open(path).await?;
+    // TODO: introduce parallel, multipart-uploads if required
+    // async fn _upload_multipart(&self, key: &str, path: &StdPath) -> Result<(), ObjectStorageError> {
+    //     let mut buf = vec![0u8; MULTIPART_UPLOAD_SIZE / 2];
+    //     let mut file = OpenOptions::new().read(true).open(path).await?;
 
-        // let (multipart_id, mut async_writer) = self.client.put_multipart(&key.into()).await?;
-        let mut async_writer = self.client.put_multipart(&key.into()).await?;
+    //     // let (multipart_id, mut async_writer) = self.client.put_multipart(&key.into()).await?;
+    //     let mut async_writer = self.client.put_multipart(&key.into()).await?;
 
-        /* `abort_multipart()` has been removed */
-        // let close_multipart = |err| async move {
-        //     log::error!("multipart upload failed. {:?}", err);
-        //     self.client
-        //         .abort_multipart(&key.into(), &multipart_id)
-        //         .await
-        // };
+    //     /* `abort_multipart()` has been removed */
+    //     // let close_multipart = |err| async move {
+    //     //     log::error!("multipart upload failed. {:?}", err);
+    //     //     self.client
+    //     //         .abort_multipart(&key.into(), &multipart_id)
+    //     //         .await
+    //     // };
 
-        loop {
-            match file.read(&mut buf).await {
-                Ok(len) => {
-                    if len == 0 {
-                        break;
-                    }
-                    if let Err(err) = async_writer.write_all(&buf[0..len]).await {
-                        // close_multipart(err).await?;
-                        break;
-                    }
-                    if let Err(err) = async_writer.flush().await {
-                        // close_multipart(err).await?;
-                        break;
-                    }
-                }
-                Err(err) => {
-                    // close_multipart(err).await?;
-                    break;
-                }
-            }
-        }
+    //     loop {
+    //         match file.read(&mut buf).await {
+    //             Ok(len) => {
+    //                 if len == 0 {
+    //                     break;
+    //                 }
+    //                 if let Err(err) = async_writer.write_all(&buf[0..len]).await {
+    //                     // close_multipart(err).await?;
+    //                     break;
+    //                 }
+    //                 if let Err(err) = async_writer.flush().await {
+    //                     // close_multipart(err).await?;
+    //                     break;
+    //                 }
+    //             }
+    //             Err(err) => {
+    //                 // close_multipart(err).await?;
+    //                 break;
+    //             }
+    //         }
+    //     }
 
-        async_writer.shutdown().await?;
+    //     async_writer.shutdown().await?;
 
-        Ok(())
-    }
+    //     Ok(())
+    // }
 }
 
 #[async_trait]

--- a/server/src/storage/s3.rs
+++ b/server/src/storage/s3.rs
@@ -33,6 +33,7 @@ use relative_path::{RelativePath, RelativePathBuf};
 use tokio::fs::OpenOptions;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
+use std::collections::BTreeMap;
 use std::iter::Iterator;
 use std::path::Path as StdPath;
 use std::sync::Arc;
@@ -343,6 +344,36 @@ impl S3 {
         Ok(dates)
     }
 
+    async fn _list_manifest_files(
+        &self,
+        stream: &str,
+    ) -> Result<BTreeMap<String, Vec<String>>, ObjectStorageError> {
+        let mut result_file_list: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        let resp = self
+            .client
+            .list_with_delimiter(Some(&(stream.into())))
+            .await?;
+
+        let dates = resp
+            .common_prefixes
+            .iter()
+            .flat_map(|path| path.parts())
+            .filter(|name| name.as_ref() != stream && name.as_ref() != STREAM_ROOT_DIRECTORY)
+            .map(|name| name.as_ref().to_string())
+            .collect::<Vec<_>>();
+        for date in dates {
+            let date_path = object_store::path::Path::from(format!("{}/{}", stream, &date));
+            let resp = self.client.list_with_delimiter(Some(&date_path)).await?;
+            let manifests: Vec<String> = resp
+                .objects
+                .iter()
+                .filter(|name| name.location.filename().unwrap().ends_with("manifest.json"))
+                .map(|name| name.location.to_string())
+                .collect();
+            result_file_list.entry(date).or_default().extend(manifests);
+        }
+        Ok(result_file_list)
+    }
     async fn _upload_file(&self, key: &str, path: &StdPath) -> Result<(), ObjectStorageError> {
         let instant = Instant::now();
 
@@ -609,6 +640,15 @@ impl ObjectStorage for S3 {
         let streams = self._list_dates(stream_name).await?;
 
         Ok(streams)
+    }
+
+    async fn list_manifest_files(
+        &self,
+        stream_name: &str,
+    ) -> Result<BTreeMap<String, Vec<String>>, ObjectStorageError> {
+        let files = self._list_manifest_files(stream_name).await?;
+
+        Ok(files)
     }
 
     async fn upload_file(&self, key: &str, path: &StdPath) -> Result<(), ObjectStorageError> {


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes `object_store` + `datafusion` upgrade

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

The following crates have been upgraded (version reference taken from `InfluxDB` Cargo.toml)
arrow-schema = 51.0.0 -> 52.1.0
arrow-array = 51.0.0 -> 52.1.0
arrow-json = 51.0.0 -> 52.1.0
arrow-ipc = 51.0.0 -> 52.1.0
arrow-select = 51.0.0 -> 52.1.0
datafusion = 37.1.0 -> rev = "a64df83502821f18067fb4ff65dd217815b305c9" (InfluxDB is using the same rev with `object-store` 0.10.2 for now)
object_store = 0.9.1 -> 0.10.2
parquet = 51.0.0 -> 52.1.0
arrow-flight = 51.0.0 -> 52.1.0

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
