### PR TITLE
fix: validation error messages and update hot tier

### DIFF
--- a/server/src/handlers/http/logstream.rs
+++ b/server/src/handlers/http/logstream.rs
@@ -30,6 +30,7 @@ use crate::handlers::{
 use crate::hottier::{HotTierManager, StreamHotTier};
 use crate::metadata::STREAM_INFO;
 use crate::metrics::{EVENTS_INGESTED_DATE, EVENTS_INGESTED_SIZE_DATE, EVENTS_STORAGE_SIZE_DATE};
+use crate::option::validation::bytes_to_human_size;
 use crate::option::{Mode, CONFIG};
 use crate::static_schema::{convert_static_schema_to_arrow_schema, StaticSchema};
 use crate::stats::{event_labels_date, storage_size_labels_date, Stats};
@@ -960,10 +961,10 @@ pub async fn put_stream_hot_tier(
 
     STREAM_INFO.set_hot_tier(&stream_name, true)?;
     if let Some(hot_tier_manager) = HotTierManager::global() {
-        hot_tier_manager
+        let existing_hot_tier_used_size = hot_tier_manager
             .validate_hot_tier_size(&stream_name, &hottier.size)
             .await?;
-        hottier.used_size = Some("0GiB".to_string());
+        hottier.used_size = Some(bytes_to_human_size(existing_hot_tier_used_size));
         hottier.available_size = Some(hottier.size.clone());
         hot_tier_manager
             .put_hot_tier(&stream_name, &mut hottier)

--- a/server/src/validator.rs
+++ b/server/src/validator.rs
@@ -150,9 +150,7 @@ pub fn user_name(username: &str) -> Result<(), UsernameValidationError> {
 
 pub fn hot_tier(size: &str) -> Result<(), HotTierValidationError> {
     if human_size_to_bytes(size).is_err() {
-        return Err(HotTierValidationError::Size(bytes_to_human_size(
-            MIN_STREAM_HOT_TIER_SIZE_BYTES,
-        )));
+        return Err(HotTierValidationError::InvalidFormat);
     }
 
     if human_size_to_bytes(size).unwrap() < MIN_STREAM_HOT_TIER_SIZE_BYTES {
@@ -213,7 +211,10 @@ pub mod error {
 
     #[derive(Debug, thiserror::Error)]
     pub enum HotTierValidationError {
-        #[error("Invalid size given for hot tier, please provide size in human readable format, e.g 1GiB, 2GiB, minimum {0}")]
+        #[error("Please provide size in human readable format, e.g 10GiB, 20GiB")]
+        InvalidFormat,
+
+        #[error("Stream should have atleast {0} size")]
         Size(String),
 
         #[error("While generating times for 'now' failed to parse duration")]


### PR DESCRIPTION
applied below fixes-
1. fetch used size from existing hot tier while updating the hot tier
2. refine the error messages for validation failures in hot tier

