### PR TITLE
Helm: Add emptyDir for the querier staging path

### DIFF
--- a/helm/templates/querier-statefulset.yaml
+++ b/helm/templates/querier-statefulset.yaml
@@ -68,11 +68,16 @@ spec:
           - containerPort: 8000
         resources:
           {{- toYaml .Values.parseable.resources | nindent 12 }}
-        {{- if .Values.parseable.persistence.querier.enabled }}
         volumeMounts:
+        - mountPath: "/parseable/staging"
+          name: stage-volume
+        {{- if .Values.parseable.persistence.querier.enabled }}
         - mountPath: "/parseable/hot-tier"
           name: hot-tier-volume
         {{- end }}
+      volumes:
+      - emptyDir: {}
+        name: stage-volume
   volumeClaimTemplates:
   {{- if .Values.parseable.persistence.querier.enabled }}
   - metadata:


### PR DESCRIPTION

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #880.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

This commit fixes querier startup on k8s with `readOnlyRootFilesystem`.

<hr>

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
