### PR TITLE
enhancement: change sizes to bytes in hot tier

### DIFF
--- a/server/src/handlers/http/logstream.rs
+++ b/server/src/handlers/http/logstream.rs
@@ -1029,7 +1029,10 @@ pub async fn get_stream_hot_tier(req: HttpRequest) -> Result<impl Responder, Str
     }
 
     if let Some(hot_tier_manager) = HotTierManager::global() {
-        let hot_tier = hot_tier_manager.get_hot_tier(&stream_name).await?;
+        let mut hot_tier = hot_tier_manager.get_hot_tier(&stream_name).await?;
+        hot_tier.size = format!("{} {}", hot_tier.size, "Bytes");
+        hot_tier.used_size = Some(format!("{} {}", hot_tier.used_size.unwrap(), "Bytes"));
+        hot_tier.available_size = Some(format!("{} {}", hot_tier.available_size.unwrap(), "Bytes"));
         Ok((web::Json(hot_tier), StatusCode::OK))
     } else {
         Err(StreamError::Custom {

--- a/server/src/handlers/http/logstream.rs
+++ b/server/src/handlers/http/logstream.rs
@@ -29,7 +29,7 @@ use crate::handlers::{
     CUSTOM_PARTITION_KEY, STATIC_SCHEMA_FLAG, STREAM_TYPE_KEY, TIME_PARTITION_KEY,
     TIME_PARTITION_LIMIT_KEY, UPDATE_STREAM_KEY,
 };
-use crate::hottier::{HotTierManager, StreamHotTier};
+use crate::hottier::{HotTierManager, StreamHotTier, CURRENT_HOT_TIER_VERSION};
 use crate::metadata::STREAM_INFO;
 use crate::metrics::{EVENTS_INGESTED_DATE, EVENTS_INGESTED_SIZE_DATE, EVENTS_STORAGE_SIZE_DATE};
 use crate::option::{Mode, CONFIG};
@@ -993,6 +993,7 @@ pub async fn put_stream_hot_tier(
             .await?;
         hottier.used_size = Some(existing_hot_tier_used_size.to_string());
         hottier.available_size = Some(hottier.size.clone());
+        hottier.version = Some(CURRENT_HOT_TIER_VERSION.to_string());
         hot_tier_manager
             .put_hot_tier(&stream_name, &mut hottier)
             .await?;

--- a/server/src/handlers/http/logstream.rs
+++ b/server/src/handlers/http/logstream.rs
@@ -32,7 +32,6 @@ use crate::handlers::{
 use crate::hottier::{HotTierManager, StreamHotTier};
 use crate::metadata::STREAM_INFO;
 use crate::metrics::{EVENTS_INGESTED_DATE, EVENTS_INGESTED_SIZE_DATE, EVENTS_STORAGE_SIZE_DATE};
-use crate::option::validation::bytes_to_human_size;
 use crate::option::{Mode, CONFIG};
 use crate::static_schema::{convert_static_schema_to_arrow_schema, StaticSchema};
 use crate::stats::{event_labels_date, storage_size_labels_date, Stats};
@@ -992,7 +991,7 @@ pub async fn put_stream_hot_tier(
         let existing_hot_tier_used_size = hot_tier_manager
             .validate_hot_tier_size(&stream_name, &hottier.size)
             .await?;
-        hottier.used_size = Some(bytes_to_human_size(existing_hot_tier_used_size));
+        hottier.used_size = Some(existing_hot_tier_used_size.to_string());
         hottier.available_size = Some(hottier.size.clone());
         hot_tier_manager
             .put_hot_tier(&stream_name, &mut hottier)
@@ -1172,7 +1171,7 @@ pub mod error {
         HotTierNotEnabled(String),
         #[error("failed to enable hottier due to err: {0}")]
         InvalidHotTierConfig(serde_json::Error),
-        #[error("Hot tier validation failed due to {0}")]
+        #[error("Hot tier validation failed: {0}")]
         HotTierValidation(#[from] HotTierValidationError),
         #[error("{0}")]
         HotTierError(#[from] HotTierError),

--- a/server/src/hottier.rs
+++ b/server/src/hottier.rs
@@ -714,7 +714,7 @@ impl HotTierManager {
                         .to_string_lossy()
                         .trim_start_matches("minute=")
                         .to_string();
-                    let oldest_date_time = format!("{} {}:{}:00", date, hour_str, minute_str);
+                    let oldest_date_time = format!("{}T{}:{}:00.000Z", date, hour_str, minute_str);
                     return Ok(Some(oldest_date_time));
                 }
             }

--- a/server/src/hottier.rs
+++ b/server/src/hottier.rs
@@ -50,9 +50,10 @@ pub const STREAM_HOT_TIER_FILENAME: &str = ".hot_tier.json";
 pub const MIN_STREAM_HOT_TIER_SIZE_BYTES: u64 = 10737418240; // 10 GiB
 const HOT_TIER_SYNC_DURATION: Interval = clokwerk::Interval::Minutes(1);
 pub const INTERNAL_STREAM_HOT_TIER_SIZE_BYTES: u64 = 10485760; //10 MiB
-
+pub const CURRENT_HOT_TIER_VERSION: &str = "v2";
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct StreamHotTier {
+    pub version: Option<String>,
     #[serde(rename = "size")]
     pub size: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -728,6 +729,7 @@ impl HotTierManager {
             && !self.check_stream_hot_tier_exists(INTERNAL_STREAM_NAME)
         {
             let mut stream_hot_tier = StreamHotTier {
+                version: Some(CURRENT_HOT_TIER_VERSION.to_string()),
                 size: INTERNAL_STREAM_HOT_TIER_SIZE_BYTES.to_string(),
                 used_size: Some("0".to_string()),
                 available_size: Some(INTERNAL_STREAM_HOT_TIER_SIZE_BYTES.to_string()),


### PR DESCRIPTION
in PUT /logstream/{logstream}/hottier
request body:

`
{
    "size": "10737418240"
}
`
the size is expected to be in bytes

GET /logstream/{logstream}/hottier
response body:
{
    "size": "1073741824",
    "used_size": "121798121",
    "available_size": "951943703",
    "oldest_date_time_entry": "2024-08-10 11:45:00"
}

size, used_size, available_size are sent in bytes
