### PR TITLE
fix: query on stream with time partition

### DIFF
--- a/server/src/query/stream_schema_provider.rs
+++ b/server/src/query/stream_schema_provider.rs
@@ -718,6 +718,9 @@ fn extract_from_lit(expr: BinaryExpr, time_partition: Option<String>) -> Option<
             ScalarValue::TimestampMillisecond(Some(value), _) => {
                 Some(DateTime::from_timestamp_millis(value).unwrap().naive_utc())
             }
+            ScalarValue::TimestampNanosecond(Some(value), _) => {
+                Some(DateTime::from_timestamp_nanos(value).naive_utc())
+            }
             ScalarValue::Utf8(Some(str_value)) => {
                 if time_partition.is_some() && column_name == time_partition.unwrap() {
                     Some(str_value.parse::<NaiveDateTime>().unwrap())


### PR DESCRIPTION
version v.0.9.0 - time partition was stored as Utf-8 in version 1.3.0 onwards - time partition is now stored as TimestampMillisecond

after migration, time partition gets converted from Utf-8 to TimestmapNanosecond

fix is to match TimestampNanosecond to create the time filters for query

