### PR TITLE
server side fixes

### DIFF
--- a/server/src/handlers/http/ingest.rs
+++ b/server/src/handlers/http/ingest.rs
@@ -417,9 +417,11 @@ fn into_event_batch(
 pub async fn create_stream_if_not_exists(
     stream_name: &str,
     stream_type: &str,
-) -> Result<(), PostError> {
+) -> Result<bool, PostError> {
+    let mut stream_exists = false;
     if STREAM_INFO.stream_exists(stream_name) {
-        return Ok(());
+        stream_exists = true;
+        return Ok(stream_exists);
     }
     match &CONFIG.parseable.mode {
         Mode::All | Mode::Query => {
@@ -459,7 +461,7 @@ pub async fn create_stream_if_not_exists(
                 .map_err(|_| PostError::StreamNotFound(stream_name.to_owned()))?;
         }
     }
-    Ok(())
+    Ok(stream_exists)
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -102,7 +102,7 @@ pub struct ObjectStoreFormat {
     pub static_schema_flag: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hot_tier_enabled: Option<bool>,
-    pub stream_type: String,
+    pub stream_type: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -122,7 +122,7 @@ pub struct StreamInfo {
     pub custom_partition: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub static_schema_flag: Option<String>,
-    pub stream_type: String,
+    pub stream_type: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
@@ -175,7 +175,7 @@ impl Default for ObjectStoreFormat {
         Self {
             version: CURRENT_SCHEMA_VERSION.to_string(),
             objectstore_format: CURRENT_OBJECT_STORE_VERSION.to_string(),
-            stream_type: StreamType::UserDefined.to_string(),
+            stream_type: Some(StreamType::UserDefined.to_string()),
             created_at: Local::now().to_rfc3339(),
             first_event_at: None,
             owner: Owner::new("".to_string(), "".to_string()),

--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -147,7 +147,7 @@ pub trait ObjectStorage: Sync + 'static {
         let permission = Permisssion::new(CONFIG.parseable.username.clone());
         format.permissions = vec![permission];
         format.created_at = Local::now().to_rfc3339();
-        format.stream_type = stream_type.to_string();
+        format.stream_type = Some(stream_type.to_string());
         if time_partition.is_empty() {
             format.time_partition = None;
         } else {


### PR DESCRIPTION
1. make stream_type optional
required because offline ingestors will not get upgraded and querier needs to read the stats from all ingestors' stream.json

2. internal stream creation to happen only once and stream creation request sync should not happen every time server restarts
required because currently everytime internal stream creation request gets forwarded to ingestors which returns error as stream already exists

3. time partition field data type change from Utf-8 to Timestamp to happen only when schema has the time partition field
required because if stream is created with time partition but no event has been ingested, so no schema exists and if server restarts, it panics because it could not find time partition field in the schema
