### PR TITLE
Fix LB timeout in `QueryServer`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ parseable
 parseable_*
 parseable-env-secret
 cache
-
+query-cache/

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -109,6 +109,8 @@ pub struct Cli {
     pub max_disk_usage: f64,
 
     pub ms_clarity_tag: Option<String>,
+
+    pub proxy_timeout: u64
 }
 
 impl Cli {
@@ -145,6 +147,7 @@ impl Cli {
     pub const HOT_TIER_PATH: &'static str = "hot-tier-path";
     pub const MAX_DISK_USAGE: &'static str = "max-disk-usage";
     pub const MS_CLARITY_TAG: &'static str = "ms-clarity-tag";
+    pub const PROXY_TIMEOUT: &'static str = "proxy-timeout";
 
     pub fn local_stream_data_path(&self, stream_name: &str) -> PathBuf {
         self.local_staging_path.join(stream_name)
@@ -434,6 +437,16 @@ impl Cli {
                     .required(false)
                     .help("Tag for MS Clarity"),
             )
+            .arg(
+                Arg::new(Self::PROXY_TIMEOUT)
+                    .long(Self::PROXY_TIMEOUT)
+                    .env("P_PROXY_TIMEOUT")
+                    .value_name("NUMBER")
+                    .required(false)
+                    .default_value("60")
+                    .value_parser(value_parser!(u64))
+                    .help("Time to wait before responding to a query request.")
+            )
             .group(
                 ArgGroup::new("oidc")
                     .args([Self::OPENID_CLIENT_ID, Self::OPENID_CLIENT_SECRET, Self::OPENID_ISSUER])
@@ -578,6 +591,7 @@ impl FromArgMatches for Cli {
             .expect("default for max disk usage");
 
         self.ms_clarity_tag = m.get_one::<String>(Self::MS_CLARITY_TAG).cloned();
+        self.proxy_timeout = m.get_one::<u64>(Self::PROXY_TIMEOUT).cloned().expect("Please specify a default timeout for query requests.");
 
         Ok(())
     }

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -94,7 +94,7 @@ pub struct Cli {
     pub flight_port: u16,
 
     /// to query cached data
-    pub query_cache_path: Option<PathBuf>,
+    pub query_cache_path: PathBuf,
 
     /// Size for local cache
     pub query_cache_size: u64,
@@ -222,6 +222,7 @@ impl Cli {
                     .long(Self::QUERY_CACHE)
                     .env("P_QUERY_CACHE_DIR")
                     .value_name("DIR")
+                    .default_value("./query-cache")
                     .value_parser(validation::canonicalize_path)
                     .help("Local path on this device to be used for caching data")
                     .next_line_help(true),
@@ -465,7 +466,6 @@ impl FromArgMatches for Cli {
 
     fn update_from_arg_matches(&mut self, m: &clap::ArgMatches) -> Result<(), clap::Error> {
         self.local_cache_path = m.get_one::<PathBuf>(Self::CACHE).cloned();
-        self.query_cache_path = m.get_one::<PathBuf>(Self::QUERY_CACHE).cloned();
         self.tls_cert_path = m.get_one::<PathBuf>(Self::TLS_CERT).cloned();
         self.tls_key_path = m.get_one::<PathBuf>(Self::TLS_KEY).cloned();
         self.domain_address = m.get_one::<Url>(Self::DOMAIN_URI).cloned();
@@ -492,6 +492,10 @@ impl FromArgMatches for Cli {
             .get_one(Self::QUERY_CACHE_SIZE)
             .cloned()
             .expect("default value for query cache size");
+        self.query_cache_path = m
+            .get_one(Self::QUERY_CACHE)
+            .cloned()
+            .expect("default value foor query cache directory");
         self.username = m
             .get_one::<String>(Self::USERNAME)
             .cloned()

--- a/server/src/handlers/airplane.rs
+++ b/server/src/handlers/airplane.rs
@@ -155,9 +155,9 @@ impl FlightService for AirServiceImpl {
 
         let streams = visitor.into_inner();
 
-        let query_cache_manager = QueryCacheManager::global(CONFIG.parseable.query_cache_size)
-            .await
-            .unwrap_or(None);
+        // let query_cache_manager = QueryCacheManager::global(CONFIG.parseable.query_cache_size)
+        //     .await
+        //     .unwrap_or(None);
 
         let cache_results = req
             .metadata()
@@ -179,21 +179,21 @@ impl FlightService for AirServiceImpl {
             .to_owned();
 
         // send the cached results
-        if let Ok(cache_results) = get_results_from_cache(
-            show_cached,
-            query_cache_manager,
-            &stream_name,
-            user_id,
-            &ticket.start_time,
-            &ticket.end_time,
-            &ticket.query,
-            ticket.send_null,
-            ticket.fields,
-        )
-        .await
-        {
-            return cache_results.into_flight();
-        }
+        // if let Ok(cache_results) = get_results_from_cache(
+        //     show_cached,
+        //     query_cache_manager,
+        //     &stream_name,
+        //     user_id,
+        //     &ticket.start_time,
+        //     &ticket.end_time,
+        //     &ticket.query,
+        //     ticket.send_null,
+        //     ticket.fields,
+        // )
+        // .await
+        // {
+        //     return cache_results.into_flight();
+        // }
 
         update_schema_when_distributed(streams)
             .await
@@ -257,20 +257,20 @@ impl FlightService for AirServiceImpl {
             .await
             .map_err(|err| Status::internal(err.to_string()))?;
 
-        if let Err(err) = put_results_in_cache(
-            cache_results,
-            user_id,
-            query_cache_manager,
-            &stream_name,
-            &records,
-            query.start.to_rfc3339(),
-            query.end.to_rfc3339(),
-            ticket.query,
-        )
-        .await
-        {
-            log::error!("{}", err);
-        };
+        // if let Err(err) = put_results_in_cache(
+        //     cache_results,
+        //     user_id,
+        //     query_cache_manager,
+        //     &stream_name,
+        //     &records,
+        //     query.start.to_rfc3339(),
+        //     query.end.to_rfc3339(),
+        //     ticket.query,
+        // )
+        // .await
+        // {
+        //     log::error!("{}", err);
+        // };
 
         /*
         * INFO: No returning the schema with the data.

--- a/server/src/handlers/http/cache.rs
+++ b/server/src/handlers/http/cache.rs
@@ -40,30 +40,33 @@ pub async fn list(req: HttpRequest) -> Result<impl Responder, PostError> {
         .get("user_id")
         .ok_or_else(|| PostError::Invalid(anyhow!("Invalid User ID not in Resource path")))?;
 
-    let query_cache_manager = QueryCacheManager::global(CONFIG.parseable.query_cache_size)
-        .await
-        .unwrap_or(None);
+    // let query_cache_manager = QueryCacheManager::global(CONFIG.parseable.query_cache_size)
+    //     .await
+    //     .unwrap_or(None);
 
-    if let Some(query_cache_manager) = query_cache_manager {
-        let cache = query_cache_manager
-            .get_cache(stream, user_id)
-            .await
-            .map_err(PostError::CacheError)?;
+    // if let Some(query_cache_manager) = query_cache_manager {
+    //     let cache = query_cache_manager
+    //         .get_cache(stream, user_id)
+    //         .await
+    //         .map_err(PostError::CacheError)?;
 
-        let size = cache.used_cache_size();
-        let queries = cache.queries();
+    //     let size = cache.used_cache_size();
+    //     let queries = cache.queries();
 
-        let out = json!({
-            "used_capacity": size,
-            "cache": queries
-        });
+    //     let out = json!({
+    //         "used_capacity": size,
+    //         "cache": queries
+    //     });
 
-        Ok((web::Json(out), StatusCode::OK))
-    } else {
-        Err(PostError::Invalid(anyhow!(
-            "Query Caching is not active on server "
-        )))
-    }
+    //     Ok((web::Json(out), StatusCode::OK))
+    // } else {
+    //     Err(PostError::Invalid(anyhow!(
+    //         "Query Caching is not active on server "
+    //     )))
+    // }
+
+    Ok(HttpResponse::Ok().finish())
+
 }
 
 pub async fn remove(req: HttpRequest, body: Bytes) -> Result<impl Responder, PostError> {
@@ -79,17 +82,19 @@ pub async fn remove(req: HttpRequest, body: Bytes) -> Result<impl Responder, Pos
 
     let query = serde_json::from_slice::<CacheMetadata>(&body)?;
 
-    let query_cache_manager = QueryCacheManager::global(CONFIG.parseable.query_cache_size)
-        .await
-        .unwrap_or(None);
+    // let query_cache_manager = QueryCacheManager::global(CONFIG.parseable.query_cache_size)
+    //     .await
+    //     .unwrap_or(None);
 
-    if let Some(query_cache_manager) = query_cache_manager {
-        query_cache_manager
-            .remove_from_cache(query, stream, user_id)
-            .await?;
+    // if let Some(query_cache_manager) = query_cache_manager {
+    //     query_cache_manager
+    //         .remove_from_cache(query, stream, user_id)
+    //         .await?;
 
-        Ok(HttpResponse::Ok().finish())
-    } else {
-        Err(PostError::Invalid(anyhow!("Query Caching is not enabled")))
-    }
+    //     Ok(HttpResponse::Ok().finish())
+    // } else {
+    //     Err(PostError::Invalid(anyhow!("Query Caching is not enabled")))
+    // }
+
+    Ok(HttpResponse::Ok().finish())
 }

--- a/server/src/handlers/http/modal/query_server.rs
+++ b/server/src/handlers/http/modal/query_server.rs
@@ -32,7 +32,7 @@ use actix_web::web::ServiceConfig;
 use actix_web::{App, HttpServer};
 use async_trait::async_trait;
 use tokio::sync::Mutex;
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -69,7 +69,7 @@ impl ParseableServer for QueryServer {
         )?;
 
         let create_app_fn = move || {
-            let query_set: query::QuerySet = Arc::new(Mutex::new(HashSet::new()));
+            let query_set: query::QueryMap = Arc::new(Mutex::new(HashMap::new()));
 
             App::new()
                 .app_data(Data::new(query_set))

--- a/server/src/handlers/http/modal/query_server.rs
+++ b/server/src/handlers/http/modal/query_server.rs
@@ -32,6 +32,7 @@ use actix_web::web::ServiceConfig;
 use actix_web::{App, HttpServer};
 use async_trait::async_trait;
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::option::CONFIG;
 
@@ -74,8 +75,10 @@ impl ParseableServer for QueryServer {
                 .wrap(cross_origin_config())
         };
 
+        let keep_alive_timeout = 120;
+
         // concurrent workers equal to number of cores on the cpu
-        let http_server = HttpServer::new(create_app_fn).workers(num_cpus::get());
+        let http_server = HttpServer::new(create_app_fn).workers(num_cpus::get()).keep_alive(Duration::from_secs(keep_alive_timeout));
         if let Some(config) = ssl {
             http_server
                 .bind_rustls_0_22(&CONFIG.parseable.address, config)?

--- a/server/src/handlers/http/modal/server.rs
+++ b/server/src/handlers/http/modal/server.rs
@@ -228,7 +228,7 @@ impl Server {
 
     // get the query factory
     pub fn get_query_factory() -> Resource {
-        web::resource("/query").route(web::post().to(query::query_keep_alive).authorize(Action::Query))
+        web::resource("/query").route(web::post().to(query::query).authorize(Action::Query))
     }
 
     pub fn get_cache_webscope() -> Scope {

--- a/server/src/handlers/http/modal/server.rs
+++ b/server/src/handlers/http/modal/server.rs
@@ -36,7 +36,7 @@ use crate::storage;
 use crate::sync;
 use crate::users::dashboards::DASHBOARDS;
 use crate::users::filters::FILTERS;
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -86,7 +86,7 @@ impl ParseableServer for Server {
         };
 
         let create_app_fn = move || {
-            let query_set: query::QuerySet = Arc::new(Mutex::new(HashSet::new()));
+            let query_set: query::QueryMap = Arc::new(Mutex::new(HashMap::new()));
 
             App::new()
                 .app_data(Data::new(query_set))

--- a/server/src/handlers/http/modal/server.rs
+++ b/server/src/handlers/http/modal/server.rs
@@ -37,6 +37,7 @@ use crate::sync;
 use crate::users::dashboards::DASHBOARDS;
 use crate::users::filters::FILTERS;
 use std::sync::Arc;
+use std::time::Duration;
 
 use actix_web::web::resource;
 use actix_web::Resource;
@@ -96,8 +97,10 @@ impl ParseableServer for Server {
             &CONFIG.parseable.tls_key_path,
         )?;
 
+        let keep_alive_timeout = 120;
+
         // concurrent workers equal to number of cores on the cpu
-        let http_server = HttpServer::new(create_app_fn).workers(num_cpus::get());
+        let http_server = HttpServer::new(create_app_fn).workers(num_cpus::get()).keep_alive(Duration::from_secs(keep_alive_timeout));
         if let Some(config) = ssl {
             http_server
                 .bind_rustls_0_22(&CONFIG.parseable.address, config)?

--- a/server/src/handlers/http/modal/server.rs
+++ b/server/src/handlers/http/modal/server.rs
@@ -36,7 +36,7 @@ use crate::storage;
 use crate::sync;
 use crate::users::dashboards::DASHBOARDS;
 use crate::users::filters::FILTERS;
-use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -86,10 +86,10 @@ impl ParseableServer for Server {
         };
 
         let create_app_fn = move || {
-            let query_map: query::QueryMap = Arc::new(Mutex::new(HashMap::new()));
-            
+            let query_set: query::QuerySet = Arc::new(Mutex::new(HashSet::new()));
+
             App::new()
-                .app_data(Data::new(query_map))
+                .app_data(Data::new(query_set))
                 .wrap(prometheus.clone())
                 .configure(|cfg| Server::configure_routes(cfg, oidc_client.clone()))
                 .wrap(actix_web::middleware::Logger::default())

--- a/server/src/handlers/http/modal/server.rs
+++ b/server/src/handlers/http/modal/server.rs
@@ -228,7 +228,7 @@ impl Server {
 
     // get the query factory
     pub fn get_query_factory() -> Resource {
-        web::resource("/query").route(web::post().to(query::query).authorize(Action::Query))
+        web::resource("/query").route(web::post().to(query::query_keep_alive).authorize(Action::Query))
     }
 
     pub fn get_cache_webscope() -> Scope {

--- a/server/src/handlers/http/query.rs
+++ b/server/src/handlers/http/query.rs
@@ -73,7 +73,7 @@ pub struct Query {
 
 pub async fn query_keep_alive(
     req: HttpRequest,
-    query_request: web::Json<Query>,
+    query_request: Query,
 ) -> Result<HttpResponse, Error> {
     let (mut tx, rx) = mpsc::channel::<Result<Bytes, Error>>(10);
 
@@ -92,7 +92,7 @@ pub async fn query_keep_alive(
         }
 
         // Execute the query
-        match query(req.clone(), query_request.into_inner()).await {
+        match query(req.clone(), query_request).await {
             Ok(response) => {
                 if let Ok(res_body) = response.respond_to(&req).into_body().try_into_bytes() {
                     let _ = tx.send(Ok(res_body)).await;

--- a/server/src/handlers/http/query.rs
+++ b/server/src/handlers/http/query.rs
@@ -93,8 +93,8 @@ pub async fn query(
         if let Some(status) = query_map.get(&hash) {
             match status {
                 QueryStatus::Processing => {
-                    // Wait for 55 seconds and check again
-                    sleep(Duration::from_secs(55)).await;
+                    // Wait and check again
+                    sleep(Duration::from_secs(CONFIG.parseable.proxy_timeout)).await;
                     if let Some(QueryStatus::Result(response)) = query_map.get(&hash) {
                         return Ok(response.clone().to_http()?);
                     } else {
@@ -142,8 +142,8 @@ pub async fn query(
         }
     });
 
-    // Wait for 55 seconds and respond with HTTP 202
-    sleep(Duration::from_secs(55)).await;
+    // Wait and respond with HTTP 202
+    sleep(Duration::from_secs(CONFIG.parseable.proxy_timeout)).await;
     Ok(HttpResponse::Accepted().finish())
 }
 

--- a/server/src/query.rs
+++ b/server/src/query.rs
@@ -185,6 +185,8 @@ impl TableScanVisitor {
     pub fn into_inner(self) -> Vec<String> {
         self.tables
     }
+
+    #[allow(dead_code)]
     pub fn top(&self) -> Option<&str> {
         self.tables.first().map(|s| s.as_ref())
     }

--- a/server/src/query.rs
+++ b/server/src/query.rs
@@ -176,7 +176,7 @@ impl Query {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub(crate) struct TableScanVisitor {
     tables: Vec<String>,
 }

--- a/server/src/querycache.rs
+++ b/server/src/querycache.rs
@@ -390,7 +390,7 @@ impl QueryCacheManager {
     }
 }
 
-fn generate_hash(start: &str, end: &str, query: &str) -> u64 {
+pub fn generate_hash(start: &str, end: &str, query: &str) -> u64 {
     let mut hasher = DefaultHasher::new();
     start.hash(&mut hasher);
     end.hash(&mut hasher);

--- a/server/src/response.rs
+++ b/server/src/response.rs
@@ -23,12 +23,13 @@ use crate::{
         record_batches_to_json,
     },
 };
-use actix_web::{web, Responder};
+use actix_web::HttpResponse;
 use datafusion::arrow::record_batch::RecordBatch;
 use itertools::Itertools;
 use serde_json::{json, Value};
 use tonic::{Response, Status};
 
+#[derive(Clone)]
 pub struct QueryResponse {
     pub records: Vec<RecordBatch>,
     pub fields: Vec<String>,
@@ -37,7 +38,7 @@ pub struct QueryResponse {
 }
 
 impl QueryResponse {
-    pub fn to_http(&self) -> Result<impl Responder, QueryError> {
+    pub fn to_http(&self) -> Result<HttpResponse, QueryError> {
         log::info!("{}", "Returning query results");
         let records: Vec<&RecordBatch> = self.records.iter().collect();
         let mut json_records = record_batches_to_json(&records)?;
@@ -62,7 +63,7 @@ impl QueryResponse {
             Value::Array(values)
         };
 
-        Ok(web::Json(response))
+        Ok(HttpResponse::Ok().json(response))
     }
 
     pub fn into_flight(self) -> Result<Response<DoGetStream>, Status> {


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

The query server takes quite a while to process incoming requests. But, most load balancers timeout before the computation can be completed. 

As a temporary fix, this PR configures the query handler to send a one byte HTTP 202 response after waiting for `P_PROXY_TIMEOUT - 5` seconds if the computation hasn't finished. The client can then reach back out with the same query after a while. If the results are ready, the server responds, or it times out again. The result persists in the cache and can be reused for the same query later.

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.
