### PR TITLE
increase s3 client connect timeout

### DIFF
--- a/server/src/storage/s3.rs
+++ b/server/src/storage/s3.rs
@@ -50,7 +50,7 @@ use super::{
 #[allow(dead_code)]
 // in bytes
 const MULTIPART_UPLOAD_SIZE: usize = 1024 * 1024 * 100;
-const CONNECT_TIMEOUT_SECS: u64 = 5;
+const CONNECT_TIMEOUT_SECS: u64 = 300;
 const AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: &str = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
 
 #[derive(Debug, Clone, clap::Args)]


### PR DESCRIPTION
increase connection timeout from 5 secs to 300 secs required in case of get object of large files
otherwise server panics with below error -

`
 Generic { store: "S3", source: reqwest::Error { kind: Decode, source: reqwest::Error { kind: Body, source: TimedOut } } }
`

