### PR TITLE
Update Helm Identation issue

### DIFF
--- a/helm/templates/standalone-deployment.yaml
+++ b/helm/templates/standalone-deployment.yaml
@@ -18,7 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- .Values.parseable.podLabels | toYaml | nindent 4 }}
+        {{- .Values.parseable.podLabels | toYaml | nindent 8 }}
         {{- include "parseable.labelsSelector" . | nindent 8 }}
     spec:
       {{- with .Values.parseable.imagePullSecrets }}


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Error

```
Error: YAML parse error on parseable/templates/standalone-deployment.yaml: error converting YAML to JSON: yaml: line 27: mapping values are not allowed in this context
helm.go:84: [debug] error converting YAML to JSON: yaml: line 27: mapping values are not allowed in this context
YAML parse error on parseable/templates/standalone-deployment.yaml
```

Label identation issue with --debug

```
  template:
    metadata:
      annotations:
        prometheus.io/path: /api/v1/metrics
        prometheus.io/port: "80"
        prometheus.io/scrape: "true"
      labels:
    app: parseable
    component: query
        app.kubernetes.io/name: parseable
        app.kubernetes.io/instance: release-name
    spec:
```

Identation Fixed

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
