### PR TITLE
fix: remove user_id from API requests in Dashboards and Filters

### DIFF
--- a/server/src/handlers/http/modal/server.rs
+++ b/server/src/handlers/http/modal/server.rs
@@ -197,40 +197,35 @@ impl Server {
     pub fn get_dashboards_webscope() -> Scope {
         web::scope("/dashboards")
             .service(
-                web::resource("").route(
-                    web::post()
-                        .to(dashboards::post)
-                        .authorize(Action::CreateDashboard),
-                ),
-            )
-            .service(
-                web::scope("/dashboard").service(
-                    web::resource("/{dashboard_id}")
-                        .route(
-                            web::get()
-                                .to(dashboards::get)
-                                .authorize(Action::GetDashboard),
-                        )
-                        .route(
-                            web::delete()
-                                .to(dashboards::delete)
-                                .authorize(Action::DeleteDashboard),
-                        )
-                        .route(
-                            web::put()
-                                .to(dashboards::update)
-                                .authorize(Action::CreateDashboard),
-                        ),
-                ),
-            )
-            .service(
-                web::scope("/{user_id}").service(
-                    web::resource("").route(
+                web::resource("")
+                    .route(
+                        web::post()
+                            .to(dashboards::post)
+                            .authorize(Action::CreateDashboard),
+                    )
+                    .route(
                         web::get()
                             .to(dashboards::list)
                             .authorize(Action::ListDashboard),
                     ),
-                ),
+            )
+            .service(
+                web::resource("/{dashboard_id}")
+                    .route(
+                        web::get()
+                            .to(dashboards::get)
+                            .authorize(Action::GetDashboard),
+                    )
+                    .route(
+                        web::delete()
+                            .to(dashboards::delete)
+                            .authorize(Action::DeleteDashboard),
+                    )
+                    .route(
+                        web::put()
+                            .to(dashboards::update)
+                            .authorize(Action::CreateDashboard),
+                    ),
             )
     }
 
@@ -238,31 +233,28 @@ impl Server {
     pub fn get_filters_webscope() -> Scope {
         web::scope("/filters")
             .service(
-                web::resource("").route(
-                    web::post()
-                        .to(filters::post)
-                        .authorize(Action::CreateFilter),
-                ),
+                web::resource("")
+                    .route(
+                        web::post()
+                            .to(filters::post)
+                            .authorize(Action::CreateFilter),
+                    )
+                    .route(web::get().to(filters::list).authorize(Action::ListFilter)),
             )
             .service(
-                web::scope("/filter").service(
-                    web::resource("/{filter_id}")
-                        .route(web::get().to(filters::get).authorize(Action::GetFilter))
-                        .route(
-                            web::delete()
-                                .to(filters::delete)
-                                .authorize(Action::DeleteFilter),
-                        )
-                        .route(
-                            web::put()
-                                .to(filters::update)
-                                .authorize(Action::CreateFilter),
-                        ),
-                ),
+                web::resource("/{filter_id}")
+                    .route(web::get().to(filters::get).authorize(Action::GetFilter))
+                    .route(
+                        web::delete()
+                            .to(filters::delete)
+                            .authorize(Action::DeleteFilter),
+                    )
+                    .route(
+                        web::put()
+                            .to(filters::update)
+                            .authorize(Action::CreateFilter),
+                    ),
             )
-            .service(web::scope("/{user_id}").service(
-                web::resource("").route(web::get().to(filters::list).authorize(Action::ListFilter)),
-            ))
     }
 
     // get the query factory

--- a/server/src/handlers/http/users/dashboards.rs
+++ b/server/src/handlers/http/users/dashboards.rs
@@ -17,10 +17,11 @@
  */
 
 use crate::{
-    handlers::http::ingest::PostError,
+    handlers::http::rbac::RBACError,
     option::CONFIG,
     storage::{object_storage::dashboard_path, ObjectStorageError},
     users::dashboards::{Dashboard, CURRENT_DASHBOARD_VERSION, DASHBOARDS},
+    utils::{get_hash, get_user_from_request},
 };
 use actix_web::{http::header::ContentType, web, HttpRequest, HttpResponse, Responder};
 use bytes::Bytes;
@@ -30,11 +31,8 @@ use http::StatusCode;
 use serde_json::Error as SerdeError;
 
 pub async fn list(req: HttpRequest) -> Result<impl Responder, DashboardError> {
-    let user_id = req
-        .match_info()
-        .get("user_id")
-        .ok_or(DashboardError::Metadata("No User Id Provided"))?;
-    let dashboards = DASHBOARDS.list_dashboards_by_user(user_id);
+    let user_id = get_user_from_request(&req)?;
+    let dashboards = DASHBOARDS.list_dashboards_by_user(&get_hash(&user_id));
 
     Ok((web::Json(dashboards), StatusCode::OK))
 }
@@ -52,21 +50,19 @@ pub async fn get(req: HttpRequest) -> Result<impl Responder, DashboardError> {
     Err(DashboardError::Metadata("Dashboard does not exist"))
 }
 
-pub async fn post(body: Bytes) -> Result<impl Responder, PostError> {
+pub async fn post(req: HttpRequest, body: Bytes) -> Result<impl Responder, DashboardError> {
+    let user_id = get_user_from_request(&req)?;
     let mut dashboard: Dashboard = serde_json::from_slice(&body)?;
-    let dashboard_id = format!("{}.{}", &dashboard.user_id, Utc::now().timestamp_millis());
+    let dashboard_id = get_hash(Utc::now().timestamp_micros().to_string().as_str());
     dashboard.dashboard_id = Some(dashboard_id.clone());
     dashboard.version = Some(CURRENT_DASHBOARD_VERSION.to_string());
+    dashboard.user_id = Some(get_hash(&user_id));
     for tile in dashboard.tiles.iter_mut() {
-        tile.tile_id = Some(format!(
-            "{}.{}",
-            &dashboard.user_id,
-            Utc::now().timestamp_micros()
-        ));
+        tile.tile_id = Some(get_hash(Utc::now().timestamp_micros().to_string().as_str()));
     }
     DASHBOARDS.update(&dashboard);
 
-    let path = dashboard_path(&dashboard.user_id, &format!("{}.json", dashboard_id));
+    let path = dashboard_path(&user_id, &format!("{}.json", dashboard_id));
 
     let store = CONFIG.storage().get_object_store();
     let dashboard_bytes = serde_json::to_vec(&dashboard)?;
@@ -77,31 +73,26 @@ pub async fn post(body: Bytes) -> Result<impl Responder, PostError> {
     Ok((web::Json(dashboard), StatusCode::OK))
 }
 
-pub async fn update(req: HttpRequest, body: Bytes) -> Result<impl Responder, PostError> {
+pub async fn update(req: HttpRequest, body: Bytes) -> Result<impl Responder, DashboardError> {
+    let user_id = get_user_from_request(&req)?;
     let dashboard_id = req
         .match_info()
         .get("dashboard_id")
         .ok_or(DashboardError::Metadata("No Dashboard Id Provided"))?;
     if DASHBOARDS.get_dashboard(dashboard_id).is_none() {
-        return Err(PostError::DashboardError(DashboardError::Metadata(
-            "Dashboard does not exist",
-        )));
+        return Err(DashboardError::Metadata("Dashboard does not exist"));
     }
     let mut dashboard: Dashboard = serde_json::from_slice(&body)?;
     dashboard.dashboard_id = Some(dashboard_id.to_string());
     dashboard.version = Some(CURRENT_DASHBOARD_VERSION.to_string());
     for tile in dashboard.tiles.iter_mut() {
         if tile.tile_id.is_none() {
-            tile.tile_id = Some(format!(
-                "{}.{}",
-                &dashboard.user_id,
-                Utc::now().timestamp_micros()
-            ));
+            tile.tile_id = Some(get_hash(Utc::now().timestamp_micros().to_string().as_str()));
         }
     }
     DASHBOARDS.update(&dashboard);
 
-    let path = dashboard_path(&dashboard.user_id, &format!("{}.json", dashboard_id));
+    let path = dashboard_path(&user_id, &format!("{}.json", dashboard_id));
 
     let store = CONFIG.storage().get_object_store();
     let dashboard_bytes = serde_json::to_vec(&dashboard)?;
@@ -112,16 +103,13 @@ pub async fn update(req: HttpRequest, body: Bytes) -> Result<impl Responder, Pos
     Ok((web::Json(dashboard), StatusCode::OK))
 }
 
-pub async fn delete(req: HttpRequest) -> Result<HttpResponse, PostError> {
+pub async fn delete(req: HttpRequest) -> Result<HttpResponse, DashboardError> {
+    let user_id = get_user_from_request(&req)?;
     let dashboard_id = req
         .match_info()
         .get("dashboard_id")
         .ok_or(DashboardError::Metadata("No Dashboard Id Provided"))?;
-    let dashboard = DASHBOARDS
-        .get_dashboard(dashboard_id)
-        .ok_or(DashboardError::Metadata("Dashboard does not exist"))?;
-
-    let path = dashboard_path(&dashboard.user_id, &format!("{}.json", dashboard_id));
+    let path = dashboard_path(&user_id, &format!("{}.json", dashboard_id));
     let store = CONFIG.storage().get_object_store();
     store.delete_object(&path).await?;
 
@@ -138,6 +126,8 @@ pub enum DashboardError {
     Serde(#[from] SerdeError),
     #[error("Cannot perform this operation: {0}")]
     Metadata(&'static str),
+    #[error("User does not exist")]
+    UserDoesNotExist(#[from] RBACError),
 }
 
 impl actix_web::ResponseError for DashboardError {
@@ -146,6 +136,7 @@ impl actix_web::ResponseError for DashboardError {
             Self::ObjectStorage(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Self::Serde(_) => StatusCode::BAD_REQUEST,
             Self::Metadata(_) => StatusCode::BAD_REQUEST,
+            Self::UserDoesNotExist(_) => StatusCode::NOT_FOUND,
         }
     }
 

--- a/server/src/handlers/http/users/filters.rs
+++ b/server/src/handlers/http/users/filters.rs
@@ -17,10 +17,11 @@
  */
 
 use crate::{
-    handlers::http::ingest::PostError,
+    handlers::http::rbac::RBACError,
     option::CONFIG,
     storage::{object_storage::filter_path, ObjectStorageError},
     users::filters::{Filter, CURRENT_FILTER_VERSION, FILTERS},
+    utils::{get_hash, get_user_from_request},
 };
 use actix_web::{http::header::ContentType, web, HttpRequest, HttpResponse, Responder};
 use bytes::Bytes;
@@ -29,12 +30,8 @@ use http::StatusCode;
 use serde_json::Error as SerdeError;
 
 pub async fn list(req: HttpRequest) -> Result<impl Responder, FiltersError> {
-    let user_id = req
-        .match_info()
-        .get("user_id")
-        .ok_or(FiltersError::Metadata("No User Id Provided"))?;
-    let filters = FILTERS.list_filters_by_user(user_id);
-
+    let user_id = get_user_from_request(&req)?;
+    let filters = FILTERS.list_filters_by_user(&get_hash(&user_id));
     Ok((web::Json(filters), StatusCode::OK))
 }
 
@@ -51,20 +48,17 @@ pub async fn get(req: HttpRequest) -> Result<impl Responder, FiltersError> {
     Err(FiltersError::Metadata("Filter does not exist"))
 }
 
-pub async fn post(body: Bytes) -> Result<impl Responder, PostError> {
+pub async fn post(req: HttpRequest, body: Bytes) -> Result<impl Responder, FiltersError> {
+    let user_id = get_user_from_request(&req)?;
     let mut filter: Filter = serde_json::from_slice(&body)?;
-    let filter_id = format!(
-        "{}.{}.{}",
-        &filter.user_id,
-        &filter.stream_name,
-        Utc::now().timestamp_millis()
-    );
+    let filter_id = get_hash(Utc::now().timestamp_micros().to_string().as_str());
     filter.filter_id = Some(filter_id.clone());
+    filter.user_id = Some(get_hash(&user_id));
     filter.version = Some(CURRENT_FILTER_VERSION.to_string());
     FILTERS.update(&filter);
 
     let path = filter_path(
-        &filter.user_id,
+        &user_id,
         &filter.stream_name,
         &format!("{}.json", filter_id),
     );
@@ -76,15 +70,14 @@ pub async fn post(body: Bytes) -> Result<impl Responder, PostError> {
     Ok((web::Json(filter), StatusCode::OK))
 }
 
-pub async fn update(req: HttpRequest, body: Bytes) -> Result<HttpResponse, PostError> {
+pub async fn update(req: HttpRequest, body: Bytes) -> Result<HttpResponse, FiltersError> {
+    let user_id = get_user_from_request(&req)?;
     let filter_id = req
         .match_info()
         .get("filter_id")
         .ok_or(FiltersError::Metadata("No Filter Id Provided"))?;
     if FILTERS.get_filter(filter_id).is_none() {
-        return Err(PostError::FiltersError(FiltersError::Metadata(
-            "Filter does not exist",
-        )));
+        return Err(FiltersError::Metadata("Filter does not exist"));
     }
     let mut filter: Filter = serde_json::from_slice(&body)?;
     filter.filter_id = Some(filter_id.to_string());
@@ -92,7 +85,7 @@ pub async fn update(req: HttpRequest, body: Bytes) -> Result<HttpResponse, PostE
     FILTERS.update(&filter);
 
     let path = filter_path(
-        &filter.user_id,
+        &user_id,
         &filter.stream_name,
         &format!("{}.json", filter_id),
     );
@@ -104,7 +97,8 @@ pub async fn update(req: HttpRequest, body: Bytes) -> Result<HttpResponse, PostE
     Ok(HttpResponse::Ok().finish())
 }
 
-pub async fn delete(req: HttpRequest) -> Result<HttpResponse, PostError> {
+pub async fn delete(req: HttpRequest) -> Result<HttpResponse, FiltersError> {
+    let user_id = get_user_from_request(&req)?;
     let filter_id = req
         .match_info()
         .get("filter_id")
@@ -114,7 +108,7 @@ pub async fn delete(req: HttpRequest) -> Result<HttpResponse, PostError> {
         .ok_or(FiltersError::Metadata("Filter does not exist"))?;
 
     let path = filter_path(
-        &filter.user_id,
+        &user_id,
         &filter.stream_name,
         &format!("{}.json", filter_id),
     );
@@ -134,6 +128,8 @@ pub enum FiltersError {
     Serde(#[from] SerdeError),
     #[error("Operation cannot be performed: {0}")]
     Metadata(&'static str),
+    #[error("User does not exist")]
+    UserDoesNotExist(#[from] RBACError),
 }
 
 impl actix_web::ResponseError for FiltersError {
@@ -142,6 +138,7 @@ impl actix_web::ResponseError for FiltersError {
             Self::ObjectStorage(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Self::Serde(_) => StatusCode::BAD_REQUEST,
             Self::Metadata(_) => StatusCode::BAD_REQUEST,
+            Self::UserDoesNotExist(_) => StatusCode::NOT_FOUND,
         }
     }
 

--- a/server/src/rbac.rs
+++ b/server/src/rbac.rs
@@ -168,6 +168,10 @@ impl Users {
 
         Response::UnAuthorized
     }
+
+    pub fn get_username_from_session(&self, session: &SessionKey) -> Option<String> {
+        sessions().get_username(session).cloned()
+    }
 }
 
 fn roles_to_permission(roles: Vec<String>) -> Vec<Permission> {

--- a/server/src/rbac/map.rs
+++ b/server/src/rbac/map.rs
@@ -224,6 +224,10 @@ impl Sessions {
             })
         })
     }
+
+    pub fn get_username(&self, key: &SessionKey) -> Option<&String> {
+        self.active_sessions.get(key).map(|(username, _)| username)
+    }
 }
 
 // UserMap is a map of [username --> User]

--- a/server/src/users/dashboards.rs
+++ b/server/src/users/dashboards.rs
@@ -143,12 +143,15 @@ impl Dashboards {
         s.retain(|d| d.dashboard_id != Some(dashboard_id.to_string()));
     }
 
-    pub fn get_dashboard(&self, dashboard_id: &str) -> Option<Dashboard> {
+    pub fn get_dashboard(&self, dashboard_id: &str, user_id: &str) -> Option<Dashboard> {
         self.0
             .read()
             .expect(LOCK_EXPECT)
             .iter()
-            .find(|d| d.dashboard_id == Some(dashboard_id.to_string()))
+            .find(|d| {
+                d.dashboard_id == Some(dashboard_id.to_string())
+                    && d.user_id == Some(user_id.to_string())
+            })
             .cloned()
     }
 
@@ -157,7 +160,7 @@ impl Dashboards {
             .read()
             .expect(LOCK_EXPECT)
             .iter()
-            .filter(|d| d.user_id.as_ref().unwrap() == user_id)
+            .filter(|d| d.user_id == Some(user_id.to_string()))
             .cloned()
             .collect()
     }

--- a/server/src/users/dashboards.rs
+++ b/server/src/users/dashboards.rs
@@ -78,7 +78,7 @@ pub struct Dashboard {
     name: String,
     description: String,
     pub dashboard_id: Option<String>,
-    pub user_id: String,
+    pub user_id: Option<String>,
     pub time_filter: Option<TimeFilter>,
     refresh_interval: u64,
     pub tiles: Vec<Tiles>,
@@ -107,13 +107,13 @@ impl Dashboards {
 
     pub fn update(&self, dashboard: &Dashboard) {
         let mut s = self.0.write().expect(LOCK_EXPECT);
-        s.retain(|f| f.dashboard_id != dashboard.dashboard_id);
+        s.retain(|d| d.dashboard_id != dashboard.dashboard_id);
         s.push(dashboard.clone());
     }
 
     pub fn delete_dashboard(&self, dashboard_id: &str) {
         let mut s = self.0.write().expect(LOCK_EXPECT);
-        s.retain(|f| f.dashboard_id != Some(dashboard_id.to_string()));
+        s.retain(|d| d.dashboard_id != Some(dashboard_id.to_string()));
     }
 
     pub fn get_dashboard(&self, dashboard_id: &str) -> Option<Dashboard> {
@@ -121,7 +121,7 @@ impl Dashboards {
             .read()
             .expect(LOCK_EXPECT)
             .iter()
-            .find(|f| f.dashboard_id == Some(dashboard_id.to_string()))
+            .find(|d| d.dashboard_id == Some(dashboard_id.to_string()))
             .cloned()
     }
 
@@ -130,7 +130,7 @@ impl Dashboards {
             .read()
             .expect(LOCK_EXPECT)
             .iter()
-            .filter(|f| f.user_id == user_id)
+            .filter(|d| d.user_id.as_ref().unwrap() == user_id)
             .cloned()
             .collect()
     }

--- a/server/src/users/filters.rs
+++ b/server/src/users/filters.rs
@@ -28,7 +28,7 @@ pub const CURRENT_FILTER_VERSION: &str = "v1";
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct Filter {
     pub version: Option<String>,
-    pub user_id: String,
+    pub user_id: Option<String>,
     pub stream_name: String,
     pub filter_name: String,
     pub filter_id: Option<String>,
@@ -111,7 +111,7 @@ impl Filters {
             .read()
             .expect(LOCK_EXPECT)
             .iter()
-            .filter(|f| f.user_id == user_id)
+            .filter(|f| f.user_id.as_ref().unwrap() == user_id)
             .cloned()
             .collect()
     }

--- a/server/src/users/filters.rs
+++ b/server/src/users/filters.rs
@@ -18,13 +18,17 @@
 
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::sync::RwLock;
 
 use super::TimeFilter;
-use crate::{metadata::LOCK_EXPECT, option::CONFIG};
+use crate::{
+    metadata::LOCK_EXPECT, migration::to_bytes, option::CONFIG,
+    storage::object_storage::filter_path, utils::get_hash,
+};
 
 pub static FILTERS: Lazy<Filters> = Lazy::new(Filters::default);
-pub const CURRENT_FILTER_VERSION: &str = "v1";
+pub const CURRENT_FILTER_VERSION: &str = "v2";
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct Filter {
     pub version: Option<String>,
@@ -75,8 +79,37 @@ impl Filters {
         let filters = store.get_all_saved_filters().await.unwrap_or_default();
 
         for filter in filters {
-            if let Ok(filter) = serde_json::from_slice::<Filter>(&filter) {
-                this.push(filter);
+            if filter.is_empty() {
+                continue;
+            }
+
+            let mut filter_value = serde_json::from_slice::<serde_json::Value>(&filter)?;
+            if let Some(meta) = filter_value.clone().as_object() {
+                let version = meta.get("version").and_then(|version| version.as_str());
+                let user_id = meta.get("user_id").and_then(|user_id| user_id.as_str());
+                let filter_id = meta
+                    .get("filter_id")
+                    .and_then(|filter_id| filter_id.as_str());
+                let stream_name = meta
+                    .get("stream_name")
+                    .and_then(|stream_name| stream_name.as_str());
+
+                if version == Some("v1") {
+                    filter_value = migrate_v1_v2(filter_value);
+                    if let (Some(user_id), Some(stream_name), Some(filter_id)) =
+                        (user_id, stream_name, filter_id)
+                    {
+                        let path =
+                            filter_path(user_id, stream_name, &format!("{}.json", filter_id));
+                        let filter_bytes = to_bytes(&filter_value);
+                        store.put_object(&path, filter_bytes.clone()).await?;
+                        if let Ok(filter) = serde_json::from_slice::<Filter>(&filter_bytes) {
+                            this.push(filter);
+                        }
+                    }
+                } else if let Ok(filter) = serde_json::from_slice::<Filter>(&filter) {
+                    this.push(filter);
+                }
             }
         }
 
@@ -115,4 +148,18 @@ impl Filters {
             .cloned()
             .collect()
     }
+}
+
+fn migrate_v1_v2(mut filter_meta: Value) -> Value {
+    let filter_meta_map = filter_meta.as_object_mut().unwrap();
+    let user_id = filter_meta_map.get("user_id").unwrap().clone();
+    let str_user_id = user_id.as_str().unwrap();
+    let user_id_hash = get_hash(str_user_id);
+    filter_meta_map.insert("user_id".to_owned(), Value::String(user_id_hash));
+    filter_meta_map.insert(
+        "version".to_owned(),
+        Value::String(CURRENT_FILTER_VERSION.into()),
+    );
+
+    filter_meta
 }

--- a/server/src/users/filters.rs
+++ b/server/src/users/filters.rs
@@ -130,12 +130,14 @@ impl Filters {
         s.retain(|f| f.filter_id != Some(filter_id.to_string()));
     }
 
-    pub fn get_filter(&self, filter_id: &str) -> Option<Filter> {
+    pub fn get_filter(&self, filter_id: &str, user_id: &str) -> Option<Filter> {
         self.0
             .read()
             .expect(LOCK_EXPECT)
             .iter()
-            .find(|f| f.filter_id == Some(filter_id.to_string()))
+            .find(|f| {
+                f.filter_id == Some(filter_id.to_string()) && f.user_id == Some(user_id.to_string())
+            })
             .cloned()
     }
 
@@ -144,7 +146,7 @@ impl Filters {
             .read()
             .expect(LOCK_EXPECT)
             .iter()
-            .filter(|f| f.user_id.as_ref().unwrap() == user_id)
+            .filter(|f| f.user_id == Some(user_id.to_string()))
             .cloned()
             .collect()
     }


### PR DESCRIPTION
Fetch session key from HttpRequest
then fetch username from the session

updated all APIs, removed user_id from API requests while saving the json, generate hash for user_id

Dashboard API changes:

GET /dashboards/{user_id} -> GET /dashboards
this fetches all dashboards for user fetched from HttpRequest

GET /dashboards/dashboard/{dashboard_id} -> GET /dashboards/{dashboard_id} DELETE /dashboards/dashboard/{dashboard_id} -> DELETE /dashboards/{dashboard_id} PUT /dashboards/dashboard/{dashboard_id} -> PUT /dashboards/{dashboard_id}

Filter API changes:
GET /filters/{user_id} -> GET /filters
this fetches all filters for user fetched from HttpRequest

GET /filters/filter/{filter_id} -> GET /filters/{filter_id} DELETE /filters/filter/{filter_id} -> DELETE /filters/{filter_id} PUT /filters/filter/{filter_id} -> PUT /filters/{filter_id}

