### PR TITLE
enhancement: stream name validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.80"
+version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -34,7 +34,7 @@ mime = "0.3.17"
 ### other dependencies
 anyhow = { version = "1.0", features = ["backtrace"] }
 argon2 = "0.5.0"
-async-trait = "0.1"
+async-trait = "0.1.82"
 base64 = "0.22.0"
 lazy_static = "1.4"
 bytes = "1.4"
@@ -71,7 +71,7 @@ prometheus = { version = "0.13", features = ["process"] }
 rand = "0.8"
 regex = "1.7.3"
 relative-path = { version = "1.7", features = ["serde"] }
-reqwest = { version = "0.11.27", default_features = false, features = [
+reqwest = { version = "0.11.27", default-features = false, features = [
   "rustls-tls",
   "json",
 ] }         # cannot update cause rustls is not latest `see rustls`
@@ -113,7 +113,7 @@ sha1_smol = { version = "1.0", features = ["std"] }
 static-files = "0.2"
 ureq = "2.6"
 vergen = { version = "8.1", features = ["build", "git", "cargo", "gitcl"] }
-zip = { version = "1.1.1", default_features = false, features = ["deflate"] }
+zip = { version = "1.1.1", default-features = false, features = ["deflate"] }
 url = "2.4.0"
 prost-build = "0.12.3"
 

--- a/server/src/storage/s3.rs
+++ b/server/src/storage/s3.rs
@@ -322,7 +322,7 @@ impl S3 {
             stream_json_check.push(task);
         }
 
-        stream_json_check.try_collect().await?;
+        stream_json_check.try_collect::<()>().await?;
 
         Ok(dirs.into_iter().map(|name| LogStream { name }).collect())
     }
@@ -633,7 +633,7 @@ impl ObjectStorage for S3 {
             stream_json_check.push(task);
         }
 
-        stream_json_check.try_collect().await?;
+        stream_json_check.try_collect::<()>().await?;
 
         Ok(dirs.into_iter().map(|name| LogStream { name }).collect())
     }

--- a/server/src/utils/arrow.rs
+++ b/server/src/utils/arrow.rs
@@ -98,10 +98,8 @@ pub fn record_batches_to_json(records: &[&RecordBatch]) -> Result<Vec<Map<String
 
     let buf = writer.into_inner();
 
-    let json_rows: Vec<Map<String, Value>> = match serde_json::from_reader(buf.as_slice()) {
-        Ok(json) => json,
-        Err(_) => vec![],
-    };
+    let json_rows: Vec<Map<String, Value>> =
+        serde_json::from_reader(buf.as_slice()).unwrap_or_default();
 
     Ok(json_rows)
 }


### PR DESCRIPTION
removed existing stream name validation
added validation to allow below special characters - Hyphen (-)
Underscore (_)

Fixes #917 .

This requires change in console to sanitise the query before making a call -
`"query": "select * from \"a_b\""`