### PR TITLE
fix: OAuth error

### DIFF
--- a/server/src/handlers/http/oidc.rs
+++ b/server/src/handlers/http/oidc.rs
@@ -63,7 +63,7 @@ pub async fn login(
     req: HttpRequest,
     query: web::Query<RedirectAfterLogin>,
 ) -> Result<HttpResponse, OIDCError> {
-    let conn = req.connection_info();
+    let conn = req.connection_info().clone();
     let base_url = format!("{}://{}/", conn.scheme(), conn.host());
     if !base_url.eq(query.redirect.as_str()) {
         return Err(OIDCError::BadRequest);


### PR DESCRIPTION
issue: already borrowed: BorrowMutError when try login with oauth because of req.connection_info() 
which makes an immutable borrow of req method extract_session_key_from_req() also borrows req 
because of which the server panics with the error 

fix is to use connection_info().clone() to avoid multiple borrows

