### PR TITLE
Support SSE-C for S3 object storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2962,8 +2962,7 @@ dependencies = [
 [[package]]
 name = "object_store"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a0c4b3a0e31f8b66f71ad8064521efa773910196e2cde791436f13409f3b45"
+source = "git+https://github.com/parseablehq/arrow-rs.git?rev=23b6ff9f432e8e29c08d47a315ba0b7cb8758225#23b6ff9f432e8e29c08d47a315ba0b7cb8758225"
 dependencies = [
  "async-trait",
  "base64 0.22.0",
@@ -3447,8 +3446,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
 dependencies = [
  "bytes",
- "heck 0.5.0",
- "itertools 0.13.0",
+ "heck 0.4.1",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -3468,7 +3467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
@@ -4212,7 +4211,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.79",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2962,7 +2962,7 @@ dependencies = [
 [[package]]
 name = "object_store"
 version = "0.11.0"
-source = "git+https://github.com/parseablehq/arrow-rs.git?rev=23b6ff9f432e8e29c08d47a315ba0b7cb8758225#23b6ff9f432e8e29c08d47a315ba0b7cb8758225"
+source = "git+https://github.com/apache/arrow-rs.git?rev=23b6ff9f432e8e29c08d47a315ba0b7cb8758225#23b6ff9f432e8e29c08d47a315ba0b7cb8758225"
 dependencies = [
  "async-trait",
  "base64 0.22.0",
@@ -3446,7 +3446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -4211,7 +4211,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.79",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ resolver = "2"
 # - https://github.com/apache/arrow-rs/pull/6230
 # - https://github.com/apache/arrow-rs/pull/6260
 # But a new version hasn't been published to crates.io for this yet. So, we are using this patch temporarily.
-object_store = { git = "https://github.com/parseablehq/arrow-rs.git", rev = "23b6ff9f432e8e29c08d47a315ba0b7cb8758225" }
+object_store = { git = "https://github.com/apache/arrow-rs.git", rev = "23b6ff9f432e8e29c08d47a315ba0b7cb8758225" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
 [workspace]
 members = ["server"]
 resolver = "2"
+
+[patch.crates-io]
+object_store = { git = "https://github.com/MihirLuthra/arrow-rs.git", branch = "mihir/I-919-0.10.2-with-sse-c" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,8 @@ members = ["server"]
 resolver = "2"
 
 [patch.crates-io]
-object_store = { git = "https://github.com/MihirLuthra/arrow-rs.git", branch = "mihir/I-919-0.10.2-with-sse-c" }
+# object_store added support for SSE-C headers in:
+# - https://github.com/apache/arrow-rs/pull/6230
+# - https://github.com/apache/arrow-rs/pull/6260
+# But a new version hasn't been published to crates.io for this yet. So, we are using this patch temporarily.
+object_store = { git = "https://github.com/parseablehq/arrow-rs.git", rev = "23b6ff9f432e8e29c08d47a315ba0b7cb8758225" }

--- a/server/src/storage/s3.rs
+++ b/server/src/storage/s3.rs
@@ -89,8 +89,12 @@ pub struct S3Config {
     /// Server side encryption to use for operations with objects.
     /// Currently, this only supports SSE-C. Value should be
     /// like SSE-C:AES256:<base64_encoded_encryption_key>.
-    #[arg(long, env = "P_OBJECT_SSE", value_name = "object-sse")]
-    pub object_sse: Option<ObjectSse>,
+    #[arg(
+        long,
+        env = "P_S3_SSEC_ENCRYPTION_KEY",
+        value_name = "ssec-encryption-key"
+    )]
+    pub ssec_encryption_key: Option<SSECEncryptionKey>,
 
     /// Set client to send checksum header on every put request
     #[arg(
@@ -141,7 +145,7 @@ pub struct S3Config {
 /// This represents the server side encryption to be
 /// used when working with S3 objects.
 #[derive(Debug, Clone)]
-pub enum ObjectSse {
+pub enum SSECEncryptionKey {
     /// https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html
     SseC {
         // algorithm unused but being tracked separately to maintain
@@ -152,7 +156,7 @@ pub enum ObjectSse {
     },
 }
 
-impl FromStr for ObjectSse {
+impl FromStr for SSECEncryptionKey {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -169,7 +173,7 @@ impl FromStr for ObjectSse {
             let alg = ObjectEncryptionAlgorithm::from_str(algorithm)?;
 
             Ok(match alg {
-                ObjectEncryptionAlgorithm::Aes256 => ObjectSse::SseC {
+                ObjectEncryptionAlgorithm::Aes256 => SSECEncryptionKey::SseC {
                     _algorithm: alg,
                     base64_encryption_key: encryption_key.to_owned(),
                 },
@@ -234,9 +238,9 @@ impl S3Config {
                 .with_secret_access_key(secret_key);
         }
 
-        if let Some(object_sse) = &self.object_sse {
-            match object_sse {
-                ObjectSse::SseC {
+        if let Some(ssec_encryption_key) = &self.ssec_encryption_key {
+            match ssec_encryption_key {
+                SSECEncryptionKey::SseC {
                     _algorithm,
                     base64_encryption_key,
                 } => {

--- a/server/src/storage/s3.rs
+++ b/server/src/storage/s3.rs
@@ -88,7 +88,7 @@ pub struct S3Config {
 
     /// Server side encryption to use for operations with objects.
     /// Currently, this only supports SSE-C. Value should be
-    /// like AES256:<base64_encoded_encryption_key>.
+    /// like SSE-C:AES256:<base64_encoded_encryption_key>.
     #[arg(long, env = "P_OBJECT_SSE", value_name = "object-sse")]
     pub object_sse: Option<ObjectSse>,
 
@@ -157,9 +157,14 @@ impl FromStr for ObjectSse {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let parts = s.split(':').collect::<Vec<_>>();
-        if parts.len() == 2 {
-            let algorithm = parts[0];
-            let encryption_key = parts[1];
+        if parts.len() == 3 {
+            let sse_type = parts[0];
+            if sse_type != "SSE-C" {
+                return Err("Only SSE-C is supported for object encryption for now".into());
+            }
+
+            let algorithm = parts[1];
+            let encryption_key = parts[2];
 
             let alg = ObjectEncryptionAlgorithm::from_str(algorithm)?;
 
@@ -170,7 +175,7 @@ impl FromStr for ObjectSse {
                 },
             })
         } else {
-            Err("Expected <algorithm>:<base64_encryption_key>".into())
+            Err("Expected SSE-C:AES256:<base64_encryption_key>".into())
         }
     }
 }

--- a/server/src/storage/s3.rs
+++ b/server/src/storage/s3.rs
@@ -231,9 +231,12 @@ impl S3Config {
 
         if let Some(object_sse) = &self.object_sse {
             match object_sse {
-                ObjectSse::SseC { _algorithm, base64_encryption_key } => {
+                ObjectSse::SseC {
+                    _algorithm,
+                    base64_encryption_key,
+                } => {
                     builder = builder.with_ssec_encryption(base64_encryption_key);
-                },
+                }
             }
         }
 

--- a/server/src/storage/s3.rs
+++ b/server/src/storage/s3.rs
@@ -32,8 +32,10 @@ use object_store::{ClientOptions, ObjectStore, PutPayload};
 use relative_path::{RelativePath, RelativePathBuf};
 
 use std::collections::BTreeMap;
+use std::fmt::Display;
 use std::iter::Iterator;
 use std::path::Path as StdPath;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -84,6 +86,12 @@ pub struct S3Config {
     #[arg(long, env = "P_S3_BUCKET", value_name = "bucket-name", required = true)]
     pub bucket_name: String,
 
+    /// Server side encryption to use for operations with objects.
+    /// Currently, this only supports SSE-C. Value should be
+    /// like AES256:<base64_encoded_encryption_key>.
+    #[arg(long, env = "P_OBJECT_SSE", value_name = "object-sse")]
+    pub object_sse: Option<ObjectSse>,
+
     /// Set client to send checksum header on every put request
     #[arg(
         long,
@@ -130,6 +138,67 @@ pub struct S3Config {
     pub metadata_endpoint: Option<String>,
 }
 
+/// This represents the server side encryption to be
+/// used when working with S3 objects.
+#[derive(Debug, Clone)]
+pub enum ObjectSse {
+    /// https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html
+    SseC {
+        // algorithm unused but being tracked separately to maintain
+        // consistent interface via CLI if AWS adds any new algorithms
+        // in future.
+        _algorithm: ObjectEncryptionAlgorithm,
+        base64_encryption_key: String,
+    },
+}
+
+impl FromStr for ObjectSse {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts = s.split(':').collect::<Vec<_>>();
+        if parts.len() == 2 {
+            let algorithm = parts[0];
+            let encryption_key = parts[1];
+
+            let alg = ObjectEncryptionAlgorithm::from_str(algorithm)?;
+
+            Ok(match alg {
+                ObjectEncryptionAlgorithm::Aes256 => ObjectSse::SseC {
+                    _algorithm: alg,
+                    base64_encryption_key: encryption_key.to_owned(),
+                },
+            })
+        } else {
+            Err("Expected <algorithm>:<base64_encryption_key>".into())
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ObjectEncryptionAlgorithm {
+    Aes256,
+}
+
+impl FromStr for ObjectEncryptionAlgorithm {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AES256" => Ok(ObjectEncryptionAlgorithm::Aes256),
+            _ => Err("Invalid SSE algorithm. Following are supported: AES256".into()),
+        }
+    }
+}
+
+impl Display for ObjectEncryptionAlgorithm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ObjectEncryptionAlgorithm::Aes256 => write!(f, "AES256"),
+        }
+    }
+}
+
 impl S3Config {
     fn get_default_builder(&self) -> AmazonS3Builder {
         let mut client_options = ClientOptions::default()
@@ -158,6 +227,14 @@ impl S3Config {
             builder = builder
                 .with_access_key_id(access_key)
                 .with_secret_access_key(secret_key);
+        }
+
+        if let Some(object_sse) = &self.object_sse {
+            match object_sse {
+                ObjectSse::SseC { _algorithm, base64_encryption_key } => {
+                    builder = builder.with_ssec_encryption(base64_encryption_key);
+                },
+            }
         }
 
         if let Ok(relative_uri) = std::env::var(AWS_CONTAINER_CREDENTIALS_RELATIVE_URI) {


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #919.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- Describe the goal of this PR -->

This PR introduces new args/envs allowing users to use [SSE-C](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html) for encrypting the objects in `S3`.

To achieve that, an arg `--object-sse` and env `P_OBJECT_SSE` have been exposed. Example usage:
```
parseable s3-store --object-sse SSE-C:AES256:$BASE64_ENCRYPTION_KEY
```
Fortunately, `object_store` crate had already added a way to define `SSE-C` key from `AmazonS3Builder`: apache/arrow-rs#6230. But they have not published a new version to crates.io containing this change.

Although, even if they did, it won't be usable yet. Apparently, the version of datafusion being used in `parseable` is not compatible with anything above `0.10.2` yet. So, for now, I have created a fork of `arrow-rs` with a branch checked out of `object_store_0.10.2` tag. On top of that, I have cherry picked commits from:
- https://github.com/apache/arrow-rs/pull/6230
- https://github.com/apache/arrow-rs/pull/6260
Can be seen here: https://github.com/MihirLuthra/arrow-rs/tree/mihir/I-919-0.10.2-with-sse-c. This version of arrow-rs has been used in `parseable` by `[patch.crates-io]`.


In the changes here, I have used my own fork but if this way is acceptable, a fork would be needed in `parseablehq` organization instead.

Other ways could be:

- Fix datafusion to work with `0.11.0` and ask `arrow-rs` maintainers to publish new version on crates.io. I think this would be a new issue in itself.
- Ask arrow-rs maintainers if they are okay with backporting `SSE-C` change to 0.10 and introduce a new 0.10.3.


I have tested this with my AWS Account. If parseable is started with `SSE-C` configured, then an attempt to download object without the key looks like this:
```
❯ aws s3api get-object  --bucket parseable-bucket-2 --key demo/date=2024-09-24/hour=23/minute=46/mihir.data.czlkrB4wsZ6vf2X.parquet /dev/stdout | more

An error occurred (InvalidRequest) when calling the GetObject operation: The object was stored using a form of Server Side Encryption. The correct parameters must be provided to retrieve the object.
```
But following works if correct key and md5 hash given:

```
❯ aws s3api get-object  --bucket parseable-bucket-2 --key demo/date=2024-09-24/hour=23/minute=46/mihir.data.czlkrB4wsZ6vf2X.parquet /dev/stdout --sse-customer-algorithm AES256 --sse-customer-key $ENCRYPTION_KEY --sse-customer-key-md5 $ENCRYPTION_KEY_MD5 | more
```

For my testing, keys were generated as:

```bash
#!/bin/bash

# Generate a 256-bit (32-byte) AES key and base64 encode it
ENCRYPTION_KEY=$(openssl rand -base64 32)

# Compute the MD5 hash of the encryption key and base64 encode it
ENCRYPTION_KEY_MD5=$(echo -n $ENCRYPTION_KEY | base64 -d | openssl md5 -binary | base64)

echo "Encryption Key: $ENCRYPTION_KEY"
echo "Key MD5: $ENCRYPTION_KEY_MD5"
```

<hr>

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
