### PR TITLE
WIP: adding azure blob as object store

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -16,7 +16,7 @@ arrow-json = "52.1.0"
 arrow-ipc = { version = "52.1.0", features = ["zstd"] }
 arrow-select = "52.1.0"
 datafusion = { git = "https://github.com/apache/datafusion.git", rev = "a64df83502821f18067fb4ff65dd217815b305c9" }
-object_store = { version = "0.10.2", features = ["cloud", "aws"] }  # cannot update object_store as datafusion has not caught up
+object_store = { version = "0.10.2", features = ["cloud", "aws", "azure"] }  # cannot update object_store as datafusion has not caught up
 parquet = "52.1.0"
 arrow-flight = { version = "52.1.0", features = [ "tls" ] }
 tonic = {version = "0.11.0", features = ["tls", "transport", "gzip", "zstd"] }

--- a/server/src/option.rs
+++ b/server/src/option.rs
@@ -18,7 +18,7 @@
 
 use crate::cli::Cli;
 use crate::storage::object_storage::parseable_json_path;
-use crate::storage::{FSConfig, ObjectStorageError, ObjectStorageProvider, S3Config};
+use crate::storage::{AzureBlobConfig, FSConfig, ObjectStorageError, ObjectStorageProvider, S3Config};
 use bytes::Bytes;
 use clap::error::ErrorKind;
 use clap::{command, Args, Command, FromArgMatches};
@@ -105,6 +105,22 @@ Cloud Native, log analytics platform for modern applications."#,
                     storage_name: "s3",
                 }
             }
+            Some(("azure-blob", m)) => {
+                let cli = match Cli::from_arg_matches(m) {
+                    Ok(cli) => cli,
+                    Err(err) => err.exit(),
+                };
+                let storage = match AzureBlobConfig::from_arg_matches(m) {
+                    Ok(storage) => storage,
+                    Err(err) => err.exit(),
+                };
+
+                Config {
+                    parseable: cli,
+                    storage: Arc::new(storage),
+                    storage_name: "azure_blob",
+                }
+            }
             _ => unreachable!(),
         }
     }
@@ -163,11 +179,14 @@ Cloud Native, log analytics platform for modern applications."#,
     // returns the string representation of the storage mode
     // drive --> Local drive
     // s3 --> S3 bucket
+    // azure_blob --> Azure Blob Storage
     pub fn get_storage_mode_string(&self) -> &str {
         if self.storage_name == "drive" {
             return "Local drive";
+        } else if self.storage_name == "s3" {
+            return "S3 bucket"
         }
-        "S3 bucket"
+        return "Azure Blob Storage"
     }
 
     pub fn get_server_mode_string(&self) -> &str {
@@ -193,6 +212,9 @@ fn create_parseable_cli_command() -> Command {
     let s3 = Cli::create_cli_command_with_clap("s3-store");
     let s3 = <S3Config as Args>::augment_args_for_update(s3);
 
+    let azureblob = Cli::create_cli_command_with_clap("azure-blob");
+    let azureblob = <AzureBlobConfig as Args>::augment_args_for_update(azureblob);
+
     command!()
         .name("Parseable")
         .bin_name("parseable")
@@ -207,7 +229,7 @@ Join the community at https://logg.ing/community.
         "#,
         )
         .subcommand_required(true)
-        .subcommands([local, s3])
+        .subcommands([local, s3, azureblob])
 }
 
 #[derive(Debug, Default, Eq, PartialEq)]

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -29,6 +29,7 @@ mod metrics_layer;
 pub(crate) mod object_storage;
 pub mod retention;
 mod s3;
+mod azure_blob;
 pub mod staging;
 mod store_metadata;
 
@@ -37,6 +38,7 @@ pub use self::staging::StorageDir;
 pub use localfs::FSConfig;
 pub use object_storage::{ObjectStorage, ObjectStorageProvider};
 pub use s3::S3Config;
+pub use azure_blob::AzureBlobConfig;
 pub use store_metadata::{
     put_remote_metadata, put_staging_metadata, resolve_parseable_metadata, StorageMetadata,
 };

--- a/server/src/storage/azure_blob.rs
+++ b/server/src/storage/azure_blob.rs
@@ -1,0 +1,95 @@
+/*
+ * Parseable Server (C) 2022 - 2024 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+use object_store::azure::{MicrosoftAzureBuilder, MicrosoftAzure};
+use super::s3::ObjStoreClient;
+use super::ObjectStorageProvider;
+use datafusion::execution::runtime_env::RuntimeConfig;
+use datafusion::datasource::object_store::{
+    DefaultObjectStoreRegistry, ObjectStoreRegistry, ObjectStoreUrl,
+};
+use crate::metrics::storage::StorageMetrics;
+use std::sync::Arc;
+use object_store::limit::LimitStore;
+use super::metrics_layer::MetricLayer;
+use object_store::path::Path as StorePath;
+
+#[derive(Debug, Clone, clap::Args)]
+#[command(
+    name = "Azure config",
+    about = "Start Parseable with Azure Blob storage",
+    help_template = "\
+{about-section}
+{all-args}
+"
+)]
+pub struct AzureBlobConfig {
+    // The Azure Storage Account ID
+    #[arg(long, env = "P_AZR_ACCOUNT", value_name = "account", required = true)]
+    pub account: String,
+
+    /// The Azure Storage Access key
+    #[arg(long, env = "P_AZR_ACCESS_KEY", value_name = "access-key", required = true)]
+    pub access_key: String,
+
+    /// The container name to be used for storage
+    #[arg(long, env = "P_AZR_CONTAINER", value_name = "container", required = true)]
+    pub container: String,
+}
+
+impl AzureBlobConfig {
+    fn get_default_interface(&self) -> MicrosoftAzure {
+        let result = MicrosoftAzureBuilder::new()
+        .with_account(self.account.clone())
+        .with_access_key(self.access_key.clone())
+        .with_container_name(self.container.clone())
+        .build().expect("Failed to build Microsoft Azure interface");
+
+        return result
+    }
+}
+
+impl ObjectStorageProvider for AzureBlobConfig {
+    fn get_datafusion_runtime(&self) -> RuntimeConfig {
+        let azure = self.get_default_interface();
+        // limit objectstore to a concurrent request limit
+        let azure = LimitStore::new(azure, super::MAX_OBJECT_STORE_REQUESTS);
+        let azure = MetricLayer::new(azure);
+
+        let object_store_registry: DefaultObjectStoreRegistry = DefaultObjectStoreRegistry::new();
+        let url = ObjectStoreUrl::parse(format!("az://{}", &self.container)).unwrap();
+        object_store_registry.register_store(url.as_ref(), Arc::new(azure));
+
+        RuntimeConfig::new().with_object_store_registry(Arc::new(object_store_registry))
+    }
+
+    fn get_object_store(&self) -> Arc<dyn super::ObjectStorage + Send> {
+        let azure = self.get_default_interface();
+
+        // limit objectstore to a concurrent request limit
+        let azure = LimitStore::new(azure, super::MAX_OBJECT_STORE_REQUESTS);
+        Arc::new(ObjStoreClient::new(azure, self.container.clone(), StorePath::from("")))
+    }
+
+    fn get_endpoint(&self) -> String {
+        return String::from("to be implmented")
+    }
+
+    fn register_store_metrics(&self, handler: &actix_web_prometheus::PrometheusMetrics) {
+        self.register_metrics(handler)
+    }
+}

--- a/server/src/storage/s3.rs
+++ b/server/src/storage/s3.rs
@@ -50,8 +50,8 @@ use super::{
 #[allow(dead_code)]
 // in bytes
 const MULTIPART_UPLOAD_SIZE: usize = 1024 * 1024 * 100;
-const CONNECT_TIMEOUT_SECS: u64 = 5;
-const REQUEST_TIMEOUT_SECS: u64 = 300;
+pub const CONNECT_TIMEOUT_SECS: u64 = 5;
+pub const REQUEST_TIMEOUT_SECS: u64 = 300;
 const AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: &str = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
 
 #[derive(Debug, Clone, clap::Args)]


### PR DESCRIPTION
Fixes #687 .

### Description

This PR aims to add support for Azure Blob Storage as Object Store in parseable.

The Solution/Changes implemented in this PR are as follows:
- Add a separate CLI subcommand similar to `s3-store`
- Add Config/Vars required to connect to Azure Blob Storage
- Alter + Rename previously written S3 struct into a generic struct to use LimitStore better and to enable re-usability of code for Azure Blob as well.

> [!NOTE]  
> I've only started learning Rust less than a week ago, so I am unfamiliar with Rust ecosystem. Any guidance or feedback would be greatly appreciated as I work on this task.

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
