### PR TITLE
fix: saved filters load issue on server restart

### DIFF
--- a/server/src/storage/object_storage.rs
+++ b/server/src/storage/object_storage.rs
@@ -85,8 +85,12 @@ pub trait ObjectStorage: Sync + 'static {
     async fn list_streams(&self) -> Result<Vec<LogStream>, ObjectStorageError>;
     async fn list_old_streams(&self) -> Result<Vec<LogStream>, ObjectStorageError>;
     async fn list_dirs(&self) -> Result<Vec<String>, ObjectStorageError>;
-    async fn get_all_saved_filters(&self) -> Result<Vec<Bytes>, ObjectStorageError>;
-    async fn get_all_dashboards(&self) -> Result<Vec<Bytes>, ObjectStorageError>;
+    async fn get_all_saved_filters(
+        &self,
+    ) -> Result<HashMap<RelativePathBuf, Vec<Bytes>>, ObjectStorageError>;
+    async fn get_all_dashboards(
+        &self,
+    ) -> Result<HashMap<RelativePathBuf, Vec<Bytes>>, ObjectStorageError>;
     async fn list_dates(&self, stream_name: &str) -> Result<Vec<String>, ObjectStorageError>;
     async fn list_manifest_files(
         &self,

--- a/server/src/users/filters.rs
+++ b/server/src/users/filters.rs
@@ -111,20 +111,9 @@ impl Filters {
                             this.push(filter);
                         }
                     }
-                } else if let (Some(user_id), Some(stream_name), Some(filter_id)) =
-                    (user_id, stream_name, filter_id)
-                {
-                    let path = filter_path(
-                        &get_hash(user_id),
-                        stream_name,
-                        &format!("{}.json", filter_id),
-                    );
-                    let filter_bytes = to_bytes(&filter_value);
-                    store.put_object(&path, filter_bytes.clone()).await?;
-                    if let Ok(filter) = serde_json::from_slice::<Filter>(&filter) {
-                        this.retain(|f: &Filter| f.filter_id != filter.filter_id);
-                        this.push(filter);
-                    }
+                } else if let Ok(filter) = serde_json::from_slice::<Filter>(&filter) {
+                    this.retain(|f: &Filter| f.filter_id != filter.filter_id);
+                    this.push(filter);
                 }
             }
         }

--- a/server/src/users/filters.rs
+++ b/server/src/users/filters.rs
@@ -77,7 +77,6 @@ impl Filters {
         let mut this = vec![];
         let store = CONFIG.storage().get_object_store();
         let all_filters = store.get_all_saved_filters().await.unwrap_or_default();
-
         for (filter_relative_path, filters) in all_filters {
             for filter in filters {
                 if filter.is_empty() {
@@ -92,11 +91,19 @@ impl Filters {
                         store.delete_object(&filter_relative_path).await?;
 
                         filter_value = migrate_v1_v2(filter_value);
-                        let user_id = meta.get("user_id").and_then(|user_id| user_id.as_str());
-                        let filter_id = meta
+                        let user_id = filter_value
+                            .as_object()
+                            .unwrap()
+                            .get("user_id")
+                            .and_then(|user_id| user_id.as_str());
+                        let filter_id = filter_value
+                            .as_object()
+                            .unwrap()
                             .get("filter_id")
                             .and_then(|filter_id| filter_id.as_str());
-                        let stream_name = meta
+                        let stream_name = filter_value
+                            .as_object()
+                            .unwrap()
                             .get("stream_name")
                             .and_then(|stream_name| stream_name.as_str());
                         if let (Some(user_id), Some(stream_name), Some(filter_id)) =


### PR DESCRIPTION
issue: server checks the version of all filters
and migrates if version is v1
if v2 (current version), it again calculates hash of the user_id from json and puts the json back in storage and load to memory

fix: if v2, load to memory

