### PR TITLE
enhancement: azure blob store support with client credentials

### DIFF
--- a/server/src/storage/azure_blob.rs
+++ b/server/src/storage/azure_blob.rs
@@ -72,9 +72,9 @@ pub struct AzureBlobConfig {
         long,
         env = "P_AZR_ACCESS_KEY",
         value_name = "access-key",
-        required = true
+        required = false
     )]
-    pub access_key: String,
+    pub access_key: Option<String>,
 
     ///Client ID
     #[arg(
@@ -123,8 +123,11 @@ impl AzureBlobConfig {
         let mut builder = MicrosoftAzureBuilder::new()
             .with_endpoint(self.endpoint_url.clone())
             .with_account(&self.account)
-            .with_access_key(&self.access_key)
             .with_container_name(&self.container);
+
+        if let Some(access_key) = self.access_key.clone() {
+            builder = builder.with_access_key(access_key)
+        }
 
         if let (Some(client_id), Some(client_secret), Some(tenant_id)) = (
             self.client_id.clone(),


### PR DESCRIPTION
add env P_AZR_CLIENT_ID, P_AZR_CLIENT_SECRET and P_AZR_TENANT_ID 
access key P_AZR_ACCESS_KEY is made optional now
hence, there are two ways of authentication now along with mandatory parameters P_AZR_URL, P_AZR_ACCOUNT and P_AZR_CONTAINER-
1. use P_AZR_ACCESS_KEY 
2. use P_AZR_CLIENT_ID, P_AZR_CLIENT_SECRET and P_AZR_TENANT_ID
