### PR TITLE
FIX: Windows failing build and querying

### DIFF
--- a/server/src/handlers/http/health_check.rs
+++ b/server/src/handlers/http/health_check.rs
@@ -21,9 +21,9 @@ use actix_web::http::StatusCode;
 use actix_web::HttpResponse;
 use lazy_static::lazy_static;
 use std::sync::Arc;
-use tokio::signal::unix::{signal, SignalKind};
-use tokio::sync::{oneshot, Mutex};
-use tokio::time::{sleep, Duration};
+#[allow(unused_imports)]
+use tokio::sync::oneshot;
+use tokio::sync::Mutex;
 
 // Create a global variable to store signal status
 lazy_static! {
@@ -34,7 +34,13 @@ pub async fn liveness() -> HttpResponse {
     HttpResponse::new(StatusCode::OK)
 }
 
+// This configuration option specifies that handle_signal() will only be compiled in case of the OS kind being unix
+// We are doing this because tokio::signal::Windows lacks a handler for SIGTERM (which is what kubelet sends while scaling down)
+#[cfg(unix)]
 pub async fn handle_signals(shutdown_signal: Arc<Mutex<Option<oneshot::Sender<()>>>>) {
+    use tokio::signal::unix::{signal, SignalKind};
+    use tokio::time::{sleep, Duration};
+
     let signal_received = SIGNAL_RECEIVED.clone();
 
     let mut sigterm =

--- a/server/src/query/stream_schema_provider.rs
+++ b/server/src/query/stream_schema_provider.rs
@@ -233,7 +233,18 @@ fn partitioned_files(
             columns,
             ..
         } = file;
-        partitioned_files[index].push(PartitionedFile::new(file_path, file.file_size));
+
+        // object_store::path::Path doesn't automatically deal with Windows path separators
+        // to do that, we are using from_absolute_path() which takes into consideration the underlying filesystem
+        // before sending the file path to PartitionedFile
+        let pf = if CONFIG.storage_name.eq("drive") {
+            let file_path = object_store::path::Path::from_absolute_path(file_path).unwrap();
+            PartitionedFile::new(file_path, file.file_size)
+        } else {
+            PartitionedFile::new(file_path, file.file_size)
+        };
+
+        partitioned_files[index].push(pf);
         columns.into_iter().for_each(|col| {
             column_statistics
                 .entry(col.name)


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #824 and Failing builds on windows

For #824, the file path being passed to `PartitionedFile` struct is being modified if the `storage_mode` is `drive` (for `s3-store`, and `blob-store` the current code works just fine)

For failing windows builds, a `cfg!()` is added to ensure that `handle_signals()` is compiled and available only for unix based OS

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.
