### PR TITLE
feat: detect schema for a log event

### DIFF
--- a/server/src/handlers/http/logstream.rs
+++ b/server/src/handlers/http/logstream.rs
@@ -94,10 +94,11 @@ pub async fn list(_: HttpRequest) -> impl Responder {
 pub async fn detect_schema(body: Bytes) -> Result<impl Responder, StreamError> {
     let body_val: Value = serde_json::from_slice(&body)?;
     let value_arr: Vec<Value> = match body_val {
+        Value::Array(arr) => arr,
         value @ Value::Object(_) => vec![value],
         _ => {
             return Err(StreamError::Custom {
-                msg: "please send one json event as part of the request".to_string(),
+                msg: "please send json events as part of the request".to_string(),
                 status: StatusCode::BAD_REQUEST,
             })
         }

--- a/server/src/handlers/http/modal/query_server.rs
+++ b/server/src/handlers/http/modal/query_server.rs
@@ -259,6 +259,17 @@ impl QueryServer {
                     .route(web::get().to(logstream::list).authorize(Action::ListStream)),
             )
             .service(
+                web::scope("/schema/detect").service(
+                    web::resource("")
+                        // PUT "/logstream/{logstream}" ==> Create log stream
+                        .route(
+                            web::post()
+                                .to(logstream::detect_schema)
+                                .authorize(Action::DetectSchema),
+                        ),
+                ),
+            )
+            .service(
                 web::scope("/{logstream}")
                     .service(
                         web::resource("")

--- a/server/src/handlers/http/modal/server.rs
+++ b/server/src/handlers/http/modal/server.rs
@@ -293,6 +293,17 @@ impl Server {
                     .route(web::get().to(logstream::list).authorize(Action::ListStream)),
             )
             .service(
+                web::scope("/schema/detect").service(
+                    web::resource("")
+                        // PUT "/logstream/{logstream}" ==> Create log stream
+                        .route(
+                            web::post()
+                                .to(logstream::detect_schema)
+                                .authorize(Action::DetectSchema),
+                        ),
+                ),
+            )
+            .service(
                 web::scope("/{logstream}")
                     .service(
                         web::resource("")

--- a/server/src/rbac/role.rs
+++ b/server/src/rbac/role.rs
@@ -25,6 +25,7 @@ pub enum Action {
     CreateStream,
     ListStream,
     GetStreamInfo,
+    DetectSchema,
     GetSchema,
     GetStats,
     DeleteStream,
@@ -140,6 +141,7 @@ impl RoleBuilder {
                 | Action::GetAnalytics => Permission::Unit(action),
                 Action::Ingest
                 | Action::GetSchema
+                | Action::DetectSchema
                 | Action::GetStats
                 | Action::GetRetention
                 | Action::PutRetention
@@ -214,6 +216,7 @@ pub mod model {
                 Action::DeleteStream,
                 Action::ListStream,
                 Action::GetStreamInfo,
+                Action::DetectSchema,
                 Action::GetSchema,
                 Action::GetStats,
                 Action::GetRetention,


### PR DESCRIPTION
server can detect schema for a sample log event before creating stream helps user to create the static schema

new API endpoint `POST /logstream/schema/detect` with body as a json object returns schema
eg. for request json -
```
{
  "datetime": "2024-10-21T05:40:58.280Z",
  "b": 2.0,
  "c": 1,
  "host": "backend",
  "a": false,
  "id": "duzrixscdpavbdgc",
  "message": "Tom is interested in mathematics.",
  "method": "GET",
  "p_metadata": "state=fatal",
  "p_tags": "environment=development",
  "p_timestamp": "2024-10-15T14:00:00+05:30",
  "referrer": "http://www.facebook.com/",
  "status": 404,
  "user-identifier": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36 OPR/91.0.4516.20"
}
```

API returns
```
{
    "fields": [
        {
            "name": "datetime",
            "data_type": {
                "Timestamp": [
                    "Millisecond",
                    null
                ]
            },
            "nullable": true,
            "dict_id": 0,
            "dict_is_ordered": false,
            "metadata": {}
        },
        {
            "name": "b",
            "data_type": "Float64",
            "nullable": true,
            "dict_id": 0,
            "dict_is_ordered": false,
            "metadata": {}
        },
        {
            "name": "c",
            "data_type": "Int64",
            "nullable": true,
            "dict_id": 0,
            "dict_is_ordered": false,
            "metadata": {}
        },
        {
            "name": "host",
            "data_type": "Utf8",
            "nullable": true,
            "dict_id": 0,
            "dict_is_ordered": false,
            "metadata": {}
        },
        {
            "name": "a",
            "data_type": "Boolean",
            "nullable": true,
            "dict_id": 0,
            "dict_is_ordered": false,
            "metadata": {}
        },
        {
            "name": "id",
            "data_type": "Utf8",
            "nullable": true,
            "dict_id": 0,
            "dict_is_ordered": false,
            "metadata": {}
        },
        {
            "name": "message",
            "data_type": "Utf8",
            "nullable": true,
            "dict_id": 0,
            "dict_is_ordered": false,
            "metadata": {}
        },
        {
            "name": "method",
            "data_type": "Utf8",
            "nullable": true,
            "dict_id": 0,
            "dict_is_ordered": false,
            "metadata": {}
        },
        {
            "name": "p_metadata",
            "data_type": "Utf8",
            "nullable": true,
            "dict_id": 0,
            "dict_is_ordered": false,
            "metadata": {}
        },
        {
            "name": "p_tags",
            "data_type": "Utf8",
            "nullable": true,
            "dict_id": 0,
            "dict_is_ordered": false,
            "metadata": {}
        },
        {
            "name": "p_timestamp",
            "data_type": {
                "Timestamp": [
                    "Millisecond",
                    null
                ]
            },
            "nullable": true,
            "dict_id": 0,
            "dict_is_ordered": false,
            "metadata": {}
        },
        {
            "name": "referrer",
            "data_type": "Utf8",
            "nullable": true,
            "dict_id": 0,
            "dict_is_ordered": false,
            "metadata": {}
        },
        {
            "name": "status",
            "data_type": "Int64",
            "nullable": true,
            "dict_id": 0,
            "dict_is_ordered": false,
            "metadata": {}
        },
        {
            "name": "user-identifier",
            "data_type": "Utf8",
            "nullable": true,
            "dict_id": 0,
            "dict_is_ordered": false,
            "metadata": {}
        }
    ],
    "metadata": {}
}
```

console then asks user to confirm this schema or change as per his requirement
once confirmed, he can create stream with the static schema


