### PR TITLE
perf: do FAT LTO and singular `codegen-unit` on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,11 @@ jobs:
         with:
           use-cross: true
           command: build
-          args: --release --target ${{matrix.target}}
+          args: --profile release-lto --target ${{matrix.target}}
 
       - name: Rename binary
         run: |
-          mv target/${{ matrix.target }}/release/parseable Parseable_OSS_${{ matrix.target }}
+          mv target/${{ matrix.target }}/release-lto/parseable Parseable_OSS_${{ matrix.target }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
@@ -82,11 +82,11 @@ jobs:
           override: true
 
       - name: Build
-        run: cargo build --all --release --target x86_64-pc-windows-msvc
+        run: cargo build --all --profile release-lto --target x86_64-pc-windows-msvc
 
       - name: Rename binary
         run: |
-          mv target/x86_64-pc-windows-msvc/release/PARSEABLE.exe Parseable_OSS_x86_64-pc-windows-msvc.exe
+          mv target/x86_64-pc-windows-msvc/release-lto/PARSEABLE.exe Parseable_OSS_x86_64-pc-windows-msvc.exe
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
@@ -135,12 +135,12 @@ jobs:
 
       - name: Build
         run: |
-          cargo build --release --target ${{ matrix.target }}
-          strip target/${{ matrix.target }}/release/Parseable
+          cargo build --profile release-lto --target ${{ matrix.target }}
+          strip target/${{ matrix.target }}/release-lto/Parseable
 
       - name: Rename binary
         run: |
-          mv target/${{ matrix.target }}/release/Parseable Parseable_OSS_${{ matrix.target }}
+          mv target/${{ matrix.target }}/release-lto/Parseable Parseable_OSS_${{ matrix.target }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,3 +127,8 @@ assets-sha1 = "9d5a45f204d709a2dd96f6a5e0b21b3834ee0e36"
 
 [features]
 debug = []
+
+[profile.release-lto]
+inherits = "release"
+lto = "fat"
+codegen-units = 1


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #224 .

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->
Optimize release builds by building them in a special profile `release-lto` that:
1. Enables `FAT LTO`
2. Uses `codegen-unit = 1`
This is intended to improve the quality of parseable binary compiled at release, in terms of performance and size.
<!-- Describe the possible solutions and chosen one with the rationale. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
