### PR TITLE
Solves issue #976 (added working link in place of page not found link) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ curl --location --request POST 'http://localhost:8000/api/v1/ingest' \
 - [Alerts ↗︎](https://www.parseable.io/docs/alerts)
 - [Role based access control ↗︎](https://www.parseable.io/docs/rbac)
 - [OAuth2 support ↗︎](https://www.parseable.io/docs/oidc)
-- [LLM integration ↗︎](https://www.parseable.io/docs/llm)
+- [LLM integration ↗︎](https://www.parseable.com/docs/integrations/llm-based-sql-generation)
 - [OpenTelemetry support ↗︎](https://www.parseable.com/docs/opentelemetry)
 
 ## How do people use Parseable :bulb:


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #976

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

This PR adds working link as mentioned in issue #976, below page opens up when clicked on this link https://www.parseable.io/docs/llm in README.md

![image](https://github.com/user-attachments/assets/b0c84417-c662-4047-b9da-10bb5ce0188e)

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.
