### PR TITLE
feat: allow stream creation from ingestor in distributed deployments

### DIFF
--- a/server/src/handlers/http/cluster/mod.rs
+++ b/server/src/handlers/http/cluster/mod.rs
@@ -849,8 +849,8 @@ pub async fn forward_create_stream_request(stream_name: &str) -> Result<(), Stre
     let staging_metadata = get_staging_metadata().unwrap().ok_or_else(|| {
         StreamError::Anyhow(anyhow::anyhow!("Failed to retrieve staging metadata"))
     })?;
-    let querier_endpoint = to_url_string(staging_metadata.querier_endpoint.unwrap());
-    let token = staging_metadata.querier_auth_token.unwrap();
+    let querier_endpoint = to_url_string(staging_metadata.querier_endpoint);
+    let token = staging_metadata.querier_auth_token;
 
     if !check_liveness(&querier_endpoint).await {
         log::warn!("Querier {} is not live", querier_endpoint);

--- a/server/src/handlers/http/cluster/mod.rs
+++ b/server/src/handlers/http/cluster/mod.rs
@@ -30,6 +30,7 @@ use crate::metrics::prom_utils::Metrics;
 use crate::rbac::role::model::DefaultPrivilege;
 use crate::rbac::user::User;
 use crate::stats::Stats;
+use crate::storage::get_staging_metadata;
 use crate::storage::object_storage::ingestor_metadata_path;
 use crate::storage::{ObjectStorageError, STREAM_ROOT_DIRECTORY};
 use crate::storage::{ObjectStoreFormat, PARSEABLE_ROOT_DIRECTORY};
@@ -838,6 +839,64 @@ pub fn init_cluster_metrics_schedular() -> Result<(), PostError> {
             tokio::time::sleep(Duration::from_secs(10)).await;
         }
     });
+
+    Ok(())
+}
+
+pub async fn forward_create_stream_request(stream_name: &str) -> Result<(), StreamError> {
+    let client = reqwest::Client::new();
+
+    let staging_metadata = get_staging_metadata().unwrap().ok_or_else(|| {
+        StreamError::Anyhow(anyhow::anyhow!("Failed to retrieve staging metadata"))
+    })?;
+    let querier_endpoint = to_url_string(staging_metadata.querier_endpoint.unwrap());
+    let token = staging_metadata.querier_auth_token.unwrap();
+
+    if !check_liveness(&querier_endpoint).await {
+        log::warn!("Querier {} is not live", querier_endpoint);
+        return Err(StreamError::Anyhow(anyhow::anyhow!("Querier is not live")));
+    }
+
+    let url = format!(
+        "{}{}/logstream/{}",
+        querier_endpoint,
+        base_path_without_preceding_slash(),
+        stream_name
+    );
+
+    let response = client
+        .put(&url)
+        .header(header::AUTHORIZATION, &token)
+        .send()
+        .await
+        .map_err(|err| {
+            log::error!(
+                "Fatal: failed to forward create stream request to querier: {}\n Error: {:?}",
+                &url,
+                err
+            );
+            StreamError::Network(err)
+        })?;
+
+    let status = response.status();
+
+    if !status.is_success() {
+        let response_text = response.text().await.map_err(|err| {
+            log::error!("Failed to read response text from querier: {}", &url);
+            StreamError::Network(err)
+        })?;
+
+        log::error!(
+            "Failed to forward create stream request to querier: {}\nResponse Returned: {:?}",
+            &url,
+            response_text
+        );
+
+        return Err(StreamError::Anyhow(anyhow::anyhow!(
+            "Request failed with status: {}",
+            status,
+        )));
+    }
 
     Ok(())
 }

--- a/server/src/handlers/http/cluster/mod.rs
+++ b/server/src/handlers/http/cluster/mod.rs
@@ -849,8 +849,8 @@ pub async fn forward_create_stream_request(stream_name: &str) -> Result<(), Stre
     let staging_metadata = get_staging_metadata().unwrap().ok_or_else(|| {
         StreamError::Anyhow(anyhow::anyhow!("Failed to retrieve staging metadata"))
     })?;
-    let querier_endpoint = to_url_string(staging_metadata.querier_endpoint);
-    let token = staging_metadata.querier_auth_token;
+    let querier_endpoint = to_url_string(staging_metadata.querier_endpoint.unwrap());
+    let token = staging_metadata.querier_auth_token.unwrap();
 
     if !check_liveness(&querier_endpoint).await {
         log::warn!("Querier {} is not live", querier_endpoint);

--- a/server/src/handlers/http/logstream.rs
+++ b/server/src/handlers/http/logstream.rs
@@ -654,7 +654,7 @@ pub async fn create_internal_stream_if_not_exists() -> Result<(), StreamError> {
             header::CONTENT_TYPE,
             HeaderValue::from_static("application/json"),
         );
-        sync_streams_with_ingestors(header_map, Bytes::new(), INTERNAL_STREAM_NAME).await?;
+        sync_streams_with_ingestors(header_map, Bytes::new(), INTERNAL_STREAM_NAME, None).await?;
     }
     Ok(())
 }

--- a/server/src/handlers/http/modal/query/querier_logstream.rs
+++ b/server/src/handlers/http/modal/query/querier_logstream.rs
@@ -1,9 +1,11 @@
+use core::str;
 use std::fs;
 
 use actix_web::{web, HttpRequest, Responder};
 use bytes::Bytes;
 use chrono::Utc;
 use http::StatusCode;
+use serde::Deserialize;
 use tokio::sync::Mutex;
 
 static CREATE_STREAM_LOCK: Mutex<()> = Mutex::const_new(());
@@ -77,12 +79,22 @@ pub async fn delete(req: HttpRequest) -> Result<impl Responder, StreamError> {
     Ok((format!("log stream {stream_name} deleted"), StatusCode::OK))
 }
 
-pub async fn put_stream(req: HttpRequest, body: Bytes) -> Result<impl Responder, StreamError> {
+#[derive(Deserialize)]
+pub struct PutStreamQuery {
+    skip_ingestors: Option<String>,
+}
+
+pub async fn put_stream(
+    req: HttpRequest,
+    body: Bytes,
+    info: web::Query<PutStreamQuery>,
+) -> Result<impl Responder, StreamError> {
     let stream_name: String = req.match_info().get("logstream").unwrap().parse().unwrap();
 
     let _ = CREATE_STREAM_LOCK.lock().await;
     let headers = create_update_stream(&req, &body, &stream_name).await?;
-    sync_streams_with_ingestors(headers, body, &stream_name).await?;
+
+    sync_streams_with_ingestors(headers, body, &stream_name, info.skip_ingestors.clone()).await?;
 
     Ok(("Log stream created", StatusCode::OK))
 }

--- a/server/src/migration.rs
+++ b/server/src/migration.rs
@@ -78,6 +78,10 @@ pub async fn run_metadata_migration(
                 let metadata = metadata_migration::v3_v4(storage_metadata);
                 put_remote_metadata(&*object_store, &metadata).await?;
             }
+            Some("v4") => {
+                let metadata = metadata_migration::v4_v5(storage_metadata);
+                put_remote_metadata(&*object_store, &metadata).await?;
+            }
             _ => (),
         }
     }

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -40,7 +40,8 @@ pub use localfs::FSConfig;
 pub use object_storage::{ObjectStorage, ObjectStorageProvider};
 pub use s3::S3Config;
 pub use store_metadata::{
-    put_remote_metadata, put_staging_metadata, resolve_parseable_metadata, StorageMetadata,
+    get_staging_metadata, put_remote_metadata, put_staging_metadata, resolve_parseable_metadata,
+    StorageMetadata,
 };
 
 // metadata file names in a Stream prefix

--- a/server/src/storage/store_metadata.rs
+++ b/server/src/storage/store_metadata.rs
@@ -80,7 +80,7 @@ impl StorageMetadata {
 
         let (querier_endpoint, querier_auth_token) = match CONFIG.parseable.mode {
             Mode::All | Mode::Query => (CONFIG.parseable.address.clone(), querier_auth_token),
-            Mode::Ingest => (String::new(), String::new()),
+            Mode::Ingest => (String::default(), String::default()),
         };
 
         Self {

--- a/server/src/storage/store_metadata.rs
+++ b/server/src/storage/store_metadata.rs
@@ -64,23 +64,27 @@ pub struct StorageMetadata {
     pub roles: HashMap<String, Vec<DefaultPrivilege>>,
     #[serde(default)]
     pub default_role: Option<String>,
-    pub querier_endpoint: String,
-    pub querier_auth_token: String,
+    pub querier_endpoint: Option<String>,
+    pub querier_auth_token: Option<String>,
 }
 
 impl StorageMetadata {
     pub fn new() -> Self {
-        let querier_auth_token = format!(
-            "Basic {}",
-            base64::prelude::BASE64_STANDARD.encode(format!(
-                "{}:{}",
-                CONFIG.parseable.username, CONFIG.parseable.password
-            ))
-        );
-
         let (querier_endpoint, querier_auth_token) = match CONFIG.parseable.mode {
-            Mode::All | Mode::Query => (CONFIG.parseable.address.clone(), querier_auth_token),
-            Mode::Ingest => (String::default(), String::default()),
+            Mode::All | Mode::Query => {
+                let querier_auth_token = format!(
+                    "Basic {}",
+                    base64::prelude::BASE64_STANDARD.encode(format!(
+                        "{}:{}",
+                        CONFIG.parseable.username, CONFIG.parseable.password
+                    ))
+                );
+                (
+                    Some(CONFIG.parseable.address.clone()),
+                    Some(querier_auth_token),
+                )
+            }
+            Mode::Ingest => (None, None),
         };
 
         Self {

--- a/server/src/storage/store_metadata.rs
+++ b/server/src/storage/store_metadata.rs
@@ -63,6 +63,8 @@ pub struct StorageMetadata {
     pub roles: HashMap<String, Vec<DefaultPrivilege>>,
     #[serde(default)]
     pub default_role: Option<String>,
+    pub querier_endpoint: Option<String>,
+    pub querier_auth_token: Option<String>,
 }
 
 impl StorageMetadata {
@@ -78,6 +80,8 @@ impl StorageMetadata {
             streams: Vec::new(),
             roles: HashMap::default(),
             default_role: None,
+            querier_endpoint: None,
+            querier_auth_token: None,
         }
     }
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #825.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

As per @nikhilsinhaparseable comment in https://github.com/parseablehq/parseable/issues/825#issuecomment-2183739545: 
- [x] add auth token (named `querier_auth_token`) and domain/port (`querier_endpoint`) in parseable.json that tells you where and how to connect to query server
- [x] create a lock when querier is creating stream based on ingestor's signal - this is required for scenario when multiple ingestors send the stream creation request to querier at the same time and querier has to ensure it creates only once (**`TODO`**: need some help in testing this though)
- [x] migrate the existing parseable.json to add the new fields (from point 1) so that older deployments when migrated to this new change, can add this new field at the time of upgrade (migration code also in place, we need to update and create new version). (`v5`)


This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
