### PR TITLE
fix: multiple issues around analytics

### DIFF
--- a/server/src/analytics.rs
+++ b/server/src/analytics.rs
@@ -20,6 +20,7 @@
 use crate::about::{current, platform};
 use crate::handlers::http::cluster::utils::check_liveness;
 use crate::handlers::http::{base_path_without_preceding_slash, cluster};
+use crate::handlers::STREAM_NAME_HEADER_KEY;
 use crate::option::{Mode, CONFIG};
 use crate::storage;
 use crate::{metadata, stats};
@@ -134,7 +135,7 @@ impl Report {
 
         let _ = client
             .post(ANALYTICS_SERVER_URL)
-            .header("X-P-Stream", "serverusageevent")
+            .header(STREAM_NAME_HEADER_KEY, "serverusageevent")
             .json(&self)
             .send()
             .await;

--- a/server/src/analytics.rs
+++ b/server/src/analytics.rs
@@ -131,7 +131,13 @@ impl Report {
 
     pub async fn send(&self) {
         let client = reqwest::Client::new();
-        let _ = client.post(ANALYTICS_SERVER_URL).json(&self).send().await;
+
+        let _ = client
+            .post(ANALYTICS_SERVER_URL)
+            .header("X-P-Stream", "serverusageevent")
+            .json(&self)
+            .send()
+            .await;
     }
 }
 

--- a/server/src/handlers.rs
+++ b/server/src/handlers.rs
@@ -22,7 +22,7 @@ pub mod livetail;
 
 const PREFIX_TAGS: &str = "x-p-tag-";
 const PREFIX_META: &str = "x-p-meta-";
-const STREAM_NAME_HEADER_KEY: &str = "x-p-stream";
+pub const STREAM_NAME_HEADER_KEY: &str = "x-p-stream";
 const CACHE_RESULTS_HEADER_KEY: &str = "x-p-cache-results";
 const CACHE_VIEW_HEADER_KEY: &str = "x-p-show-cached";
 const USER_ID_HEADER_KEY: &str = "x-p-user-id";

--- a/server/src/handlers/http/about.rs
+++ b/server/src/handlers/http/about.rs
@@ -20,10 +20,9 @@ use actix_web::web::Json;
 use serde_json::json;
 
 use crate::{
-    about,
+    about::{self, get_latest_release},
     option::{Mode, CONFIG},
     storage::StorageMetadata,
-    utils::update,
 };
 use std::path::PathBuf;
 
@@ -51,14 +50,13 @@ pub async fn about() -> Json<serde_json::Value> {
     let meta = StorageMetadata::global();
 
     let current_release = about::current();
-    let latest_release = update::get_latest(&meta.deployment_id).await;
-
+    let latest_release = get_latest_release();
     let (update_available, latest_release) = match latest_release {
-        Ok(latest_release) => (
+        Some(latest_release) => (
             latest_release.version > current_release.released_version,
             Some(format!("v{}", latest_release.version)),
         ),
-        Err(_) => (false, None),
+        None => (false, None),
     };
 
     let current_version = format!("v{}", current_release.released_version);

--- a/server/src/utils/update.rs
+++ b/server/src/utils/update.rs
@@ -25,7 +25,7 @@ use crate::about;
 
 use super::uid;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LatestRelease {
     pub version: semver::Version,
     pub date: DateTime<Utc>,
@@ -37,20 +37,17 @@ pub async fn get_latest(deployment_id: &uid::Uid) -> Result<LatestRelease, anyho
         .timeout(Duration::from_secs(8))
         .build()
         .expect("client can be built on this system");
-
     let json: serde_json::Value = agent
         .get("https://download.parseable.io/latest-version")
         .send()
         .await?
         .json()
         .await?;
-
     let version = json["tag_name"]
         .as_str()
         .and_then(|ver| ver.strip_prefix('v'))
         .and_then(|ver| semver::Version::parse(ver).ok())
         .ok_or_else(|| anyhow!("Failed parsing version"))?;
-
     let date = json["published_at"]
         .as_str()
         .ok_or_else(|| anyhow!("Failed parsing published date"))?;


### PR DESCRIPTION
1. fix for multiple calls happening to analytics server 
global variable to hold latest version
sets when server starts
get from global variable in about api call

2. send `X-P-Stream` header in POST call to analytics server 
resolves the issue of hardcoded stream in analytics server code

