### PR TITLE
fix: port 80 ignored in ingestor endpoint

### DIFF
--- a/server/src/storage/staging.rs
+++ b/server/src/storage/staging.rs
@@ -363,7 +363,7 @@ pub fn get_ingestor_info() -> anyhow::Result<IngestorMetadata> {
     // all the files should be in the staging directory root
     let entries = std::fs::read_dir(path)?;
     let url = get_url();
-    let port = url.port().expect("here port should be defined").to_string();
+    let port = url.port().unwrap_or(80).to_string();
     let url = url.to_string();
 
     for entry in entries {


### PR DESCRIPTION
current state -
if ingest node starts at port 80 i.e.
if env vars P_ADDR or P_INGESTOR_ENDPOINT are set with port 80
server ignores the port and panics at start with error

fix -
if port is ignored, use default port to 80

