### PR TITLE
fix: allow int and uint values in float type fields

### DIFF
--- a/src/event/format/json.rs
+++ b/src/event/format/json.rs
@@ -183,7 +183,9 @@ fn valid_type(data_type: &DataType, value: &Value) -> bool {
         DataType::Boolean => value.is_boolean(),
         DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 => value.is_i64(),
         DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64 => value.is_u64(),
-        DataType::Float16 | DataType::Float32 | DataType::Float64 => value.is_f64(),
+        DataType::Float16 | DataType::Float32 | DataType::Float64 => {
+            value.is_f64() || value.is_i64() || value.is_u64()
+        }
         DataType::Utf8 => value.is_string(),
         DataType::List(field) => {
             let data_type = field.data_type();


### PR DESCRIPTION
Fixes #989.

### Description

allows int and uint values even when a field type is float


Using the same example mentioned in https://github.com/parseablehq/parseable/issues/989#issuecomment-2475351162

![image](https://github.com/user-attachments/assets/a0cb1935-bf77-4cf6-9c15-ba0cb4a4e735)
![image](https://github.com/user-attachments/assets/cf52c56e-43ef-4069-9166-149a2a544246)


This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
