### PR TITLE
Schema merge

### DIFF
--- a/src/handlers/http/mod.rs
+++ b/src/handlers/http/mod.rs
@@ -21,7 +21,7 @@ use arrow_schema::Schema;
 use itertools::Itertools;
 use serde_json::Value;
 
-use crate::option::CONFIG;
+use crate::{option::CONFIG, storage::STREAM_ROOT_DIRECTORY};
 
 use self::{cluster::get_ingestor_info, query::Query};
 
@@ -77,7 +77,7 @@ pub fn base_path_without_preceding_slash() -> String {
 /// An `anyhow::Result` containing the `arrow_schema::Schema` for the specified stream.
 pub async fn fetch_schema(stream_name: &str) -> anyhow::Result<arrow_schema::Schema> {
     let path_prefix =
-        relative_path::RelativePathBuf::from(format!("{}/{}", stream_name, ".stream"));
+        relative_path::RelativePathBuf::from(format!("{}/{}", stream_name, STREAM_ROOT_DIRECTORY));
     let store = CONFIG.storage().get_object_store();
     let res: Vec<Schema> = store
         .get_objects(


### PR DESCRIPTION
fix: get schema for distributed

current: querier checks if schema is available in STREAM_INFO
if not, create schema from storage, load in STREAM_INFO and return

still, because of long running ingestions, querier's STREAM_INFO cannot guarantee the latest state of the schema for distributed

fix: merge schema from all ingestors and queriers and then load in STREAM_INFO and return