### PR TITLE
enhancement: implement generic flattening

### DIFF
--- a/src/handlers/http/ingest.rs
+++ b/src/handlers/http/ingest.rs
@@ -293,9 +293,7 @@ mod tests {
     use std::{collections::HashMap, sync::Arc};
 
     use actix_web::test::TestRequest;
-    use arrow_array::{
-        types::Int64Type, ArrayRef, Float64Array, Int64Array, ListArray, StringArray,
-    };
+    use arrow_array::{ArrayRef, Float64Array, Int64Array, StringArray};
     use arrow_schema::{DataType, Field};
     use serde_json::json;
 
@@ -689,25 +687,14 @@ mod tests {
             ])
         );
 
-        let c_a = vec![None, None, Some(vec![Some(1i64)]), Some(vec![Some(1)])];
-        let c_b = vec![None, None, None, Some(vec![Some(2i64)])];
-
         assert_eq!(
-            rb.column_by_name("c_a")
-                .unwrap()
-                .as_any()
-                .downcast_ref::<ListArray>()
-                .unwrap(),
-            &ListArray::from_iter_primitive::<Int64Type, _, _>(c_a)
+            rb.column_by_name("c_a").unwrap().as_int64_arr(),
+            &Int64Array::from(vec![None, None, Some(1), Some(1)])
         );
 
         assert_eq!(
-            rb.column_by_name("c_b")
-                .unwrap()
-                .as_any()
-                .downcast_ref::<ListArray>()
-                .unwrap(),
-            &ListArray::from_iter_primitive::<Int64Type, _, _>(c_b)
+            rb.column_by_name("c_b").unwrap().as_int64_arr(),
+            &Int64Array::from(vec![None, None, None, Some(2)])
         );
     }
 }

--- a/src/utils/json/flatten.rs
+++ b/src/utils/json/flatten.rs
@@ -350,16 +350,20 @@ pub fn flatten_json(value: &Value) -> Vec<Value> {
     }
 }
 
-pub fn convert_to_array(flatterned: Vec<Value>) -> Value {
+pub fn convert_to_array(flattened: Vec<Value>) -> Result<Value, anyhow::Error> {
     let mut result = Vec::new();
-    for item in flatterned {
+    for item in flattened {
         let mut map = Map::new();
-        for (key, value) in item.as_object().unwrap() {
-            map.insert(key.clone(), value.clone());
+        if let Some(item) = item.as_object() {
+            for (key, value) in item {
+                map.insert(key.clone(), value.clone());
+            }
+            result.push(Value::Object(map));
+        } else {
+            return Err(anyhow!("Expected object in array of objects"));
         }
-        result.push(Value::Object(map));
     }
-    Value::Array(result)
+    Ok(Value::Array(result))
 }
 #[cfg(test)]
 mod tests {

--- a/src/utils/json/mod.rs
+++ b/src/utils/json/mod.rs
@@ -28,8 +28,9 @@ pub fn flatten_json_body(
     custom_partition: Option<String>,
     validation_required: bool,
 ) -> Result<Value, anyhow::Error> {
+    let nested_value = flatten::convert_to_array(flatten::flatten_json(&body));
     flatten::flatten(
-        body,
+        nested_value,
         "_",
         time_partition,
         time_partition_limit,

--- a/src/utils/json/mod.rs
+++ b/src/utils/json/mod.rs
@@ -28,15 +28,17 @@ pub fn flatten_json_body(
     custom_partition: Option<String>,
     validation_required: bool,
 ) -> Result<Value, anyhow::Error> {
-    let nested_value = flatten::convert_to_array(flatten::flatten_json(&body));
-    flatten::flatten(
-        nested_value,
-        "_",
-        time_partition,
-        time_partition_limit,
-        custom_partition,
-        validation_required,
-    )
+    match flatten::convert_to_array(flatten::flatten_json(&body)) {
+        Ok(nested_value) => flatten::flatten(
+            nested_value,
+            "_",
+            time_partition,
+            time_partition_limit,
+            custom_partition,
+            validation_required,
+        ),
+        Err(err) => Err(err),
+    }
 }
 
 pub fn convert_array_to_object(


### PR DESCRIPTION
helps to flatten the nested json
such that all list type fields gets converted to primitive type hence spliting the repeating array to multiple rows

eg.
`[
        {
            "id": 1,
            "name": "John Doe",
            "addresses": [
                {
                    "street": "123 Main St",
                    "city": "Springfield",
                    "state": "IL",
                    "zip": "62701"
                },
                {
                    "street": "456 Elm St",
                    "city": "Springfield",
                    "state": "IL",
                    "zip": "62702"
                }
            ]
        }
    ]
`

gets coverted to below
`
[
		{
			"id": 1,
            "name": "John Doe",
			"addresses_street": "123 Main St",
			"addresses_city": "Springfield",
			"addresses_state": "IL",
			"addresses_zip": "62701",

		},
		{
			"id": 1,
            "name": "John Doe",
			"addresses_street": "456 Elm St",
			"addresses_city": "Springfield",
			"addresses_state": "IL",
			"addresses_zip": "62702",
		}
	]
`

