### PR TITLE
feat: enable otel metrics and traces

### DIFF
--- a/src/handlers/http/ingest.rs
+++ b/src/handlers/http/ingest.rs
@@ -106,7 +106,10 @@ pub async fn ingest_internal_stream(stream_name: String, body: Bytes) -> Result<
 // Handler for POST /v1/logs to ingest OTEL logs
 // ingests events by extracting stream name from header
 // creates if stream does not exist
-pub async fn ingest_otel_logs(req: HttpRequest, body: Bytes) -> Result<HttpResponse, PostError> {
+pub async fn handle_otel_ingestion(
+    req: HttpRequest,
+    body: Bytes,
+) -> Result<HttpResponse, PostError> {
     if let Some((_, stream_name)) = req
         .headers()
         .iter()

--- a/src/handlers/http/modal/server.rs
+++ b/src/handlers/http/modal/server.rs
@@ -406,14 +406,35 @@ impl Server {
     }
 
     // /v1/logs endpoint to be used for OTEL log ingestion only
-    pub fn get_ingest_otel_factory() -> Resource {
-        web::resource("/v1/logs")
-            .route(
-                web::post()
-                    .to(ingest::ingest_otel_logs)
-                    .authorize_for_stream(Action::Ingest),
+    pub fn get_ingest_otel_factory() -> Scope {
+        web::scope("/v1")
+            .service(
+                web::resource("/logs")
+                    .route(
+                        web::post()
+                            .to(ingest::handle_otel_ingestion)
+                            .authorize_for_stream(Action::Ingest),
+                    )
+                    .app_data(web::PayloadConfig::default().limit(MAX_EVENT_PAYLOAD_SIZE)),
             )
-            .app_data(web::PayloadConfig::default().limit(MAX_EVENT_PAYLOAD_SIZE))
+            .service(
+                web::resource("/metrics")
+                    .route(
+                        web::post()
+                            .to(ingest::handle_otel_ingestion)
+                            .authorize_for_stream(Action::Ingest),
+                    )
+                    .app_data(web::PayloadConfig::default().limit(MAX_EVENT_PAYLOAD_SIZE)),
+            )
+            .service(
+                web::resource("/traces")
+                    .route(
+                        web::post()
+                            .to(ingest::handle_otel_ingestion)
+                            .authorize_for_stream(Action::Ingest),
+                    )
+                    .app_data(web::PayloadConfig::default().limit(MAX_EVENT_PAYLOAD_SIZE)),
+            )
     }
 
     // get the oauth webscope


### PR DESCRIPTION
OTEL metrics endpoint `/v1/metrics`
OTEL traces endpoint `/v1/traces`

above two endpoints are added to support OTEL metrics and traces ingestion similar to OTEL logs endpoint `/v1/logs`
