### PR TITLE
enhancement: add schema type to stream info

### DIFF
--- a/src/handlers/http/logstream.rs
+++ b/src/handlers/http/logstream.rs
@@ -505,6 +505,7 @@ fn remove_id_from_alerts(value: &mut Value) {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn create_stream(
     stream_name: String,
     time_partition: &str,
@@ -513,6 +514,7 @@ pub async fn create_stream(
     static_schema_flag: &str,
     schema: Arc<Schema>,
     stream_type: &str,
+    schema_type: &str,
 ) -> Result<(), CreateStreamError> {
     // fail to proceed if invalid stream name
     if stream_type != StreamType::Internal.to_string() {
@@ -530,6 +532,7 @@ pub async fn create_stream(
             static_schema_flag,
             schema.clone(),
             stream_type,
+            schema_type,
         )
         .await
     {
@@ -553,6 +556,7 @@ pub async fn create_stream(
                 static_schema_flag.to_string(),
                 static_schema,
                 stream_type,
+                schema_type,
             );
         }
         Err(err) => {
@@ -602,6 +606,7 @@ pub async fn get_stream_info(req: HttpRequest) -> Result<impl Responder, StreamE
         custom_partition: stream_meta.custom_partition.clone(),
         cache_enabled: stream_meta.cache_enabled,
         static_schema_flag: stream_meta.static_schema_flag.clone(),
+        schema_type: stream_meta.schema_type.clone(),
     };
 
     // get the other info from
@@ -744,8 +749,12 @@ pub async fn delete_stream_hot_tier(req: HttpRequest) -> Result<impl Responder, 
 }
 
 pub async fn create_internal_stream_if_not_exists() -> Result<(), StreamError> {
-    if let Ok(stream_exists) =
-        create_stream_if_not_exists(INTERNAL_STREAM_NAME, &StreamType::Internal.to_string()).await
+    if let Ok(stream_exists) = create_stream_if_not_exists(
+        INTERNAL_STREAM_NAME,
+        &StreamType::Internal.to_string(),
+        INTERNAL_STREAM_NAME,
+    )
+    .await
     {
         if stream_exists {
             return Ok(());

--- a/src/handlers/http/modal/utils/logstream_utils.rs
+++ b/src/handlers/http/modal/utils/logstream_utils.rs
@@ -26,8 +26,8 @@ use http::StatusCode;
 use crate::{
     handlers::{
         http::logstream::error::{CreateStreamError, StreamError},
-        CUSTOM_PARTITION_KEY, STATIC_SCHEMA_FLAG, STREAM_TYPE_KEY, TIME_PARTITION_KEY,
-        TIME_PARTITION_LIMIT_KEY, UPDATE_STREAM_KEY,
+        CUSTOM_PARTITION_KEY, SCHEMA_TYPE_KEY, STATIC_SCHEMA_FLAG, STREAM_TYPE_KEY,
+        TIME_PARTITION_KEY, TIME_PARTITION_LIMIT_KEY, UPDATE_STREAM_KEY,
     },
     metadata::{self, STREAM_INFO},
     option::{Mode, CONFIG},
@@ -48,6 +48,7 @@ pub async fn create_update_stream(
         static_schema_flag,
         update_stream_flag,
         stream_type,
+        schema_type,
     ) = fetch_headers_from_put_stream_request(req);
 
     if metadata::STREAM_INFO.stream_exists(stream_name) && update_stream_flag != "true" {
@@ -113,6 +114,7 @@ pub async fn create_update_stream(
         &static_schema_flag,
         schema,
         &stream_type,
+        &schema_type,
     )
     .await?;
 
@@ -167,13 +169,14 @@ async fn validate_and_update_custom_partition(
 
 pub fn fetch_headers_from_put_stream_request(
     req: &HttpRequest,
-) -> (String, String, String, String, String, String) {
+) -> (String, String, String, String, String, String, String) {
     let mut time_partition = String::default();
     let mut time_partition_limit = String::default();
     let mut custom_partition = String::default();
     let mut static_schema_flag = String::default();
     let mut update_stream = String::default();
     let mut stream_type = StreamType::UserDefined.to_string();
+    let mut schema_type = String::default();
     req.headers().iter().for_each(|(key, value)| {
         if key == TIME_PARTITION_KEY {
             time_partition = value.to_str().unwrap().to_string();
@@ -193,6 +196,9 @@ pub fn fetch_headers_from_put_stream_request(
         if key == STREAM_TYPE_KEY {
             stream_type = value.to_str().unwrap().to_string();
         }
+        if key == SCHEMA_TYPE_KEY {
+            schema_type = value.to_str().unwrap().to_string();
+        }
     });
 
     (
@@ -202,6 +208,7 @@ pub fn fetch_headers_from_put_stream_request(
         static_schema_flag,
         update_stream,
         stream_type,
+        schema_type,
     )
 }
 
@@ -378,6 +385,7 @@ pub async fn update_custom_partition_in_stream(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn create_stream(
     stream_name: String,
     time_partition: &str,
@@ -386,6 +394,7 @@ pub async fn create_stream(
     static_schema_flag: &str,
     schema: Arc<Schema>,
     stream_type: &str,
+    schema_type: &str,
 ) -> Result<(), CreateStreamError> {
     // fail to proceed if invalid stream name
     if stream_type != StreamType::Internal.to_string() {
@@ -403,6 +412,7 @@ pub async fn create_stream(
             static_schema_flag,
             schema.clone(),
             stream_type,
+            schema_type,
         )
         .await
     {
@@ -426,6 +436,7 @@ pub async fn create_stream(
                 static_schema_flag.to_string(),
                 static_schema,
                 stream_type,
+                schema_type,
             );
         }
         Err(err) => {
@@ -475,7 +486,7 @@ pub async fn create_stream_and_schema_from_storage(stream_name: &str) -> Result<
         let custom_partition = stream_metadata.custom_partition.as_deref().unwrap_or("");
         let static_schema_flag = stream_metadata.static_schema_flag.as_deref().unwrap_or("");
         let stream_type = stream_metadata.stream_type.as_deref().unwrap_or("");
-
+        let schema_type = stream_metadata.schema_type.as_deref().unwrap_or("");
         metadata::STREAM_INFO.add_stream(
             stream_name.to_string(),
             stream_metadata.created_at,
@@ -485,6 +496,7 @@ pub async fn create_stream_and_schema_from_storage(stream_name: &str) -> Result<
             static_schema_flag.to_string(),
             static_schema,
             stream_type,
+            schema_type,
         );
     } else {
         return Ok(false);

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -35,6 +35,7 @@ const AUTHORIZATION_KEY: &str = "authorization";
 const SEPARATOR: char = '^';
 const UPDATE_STREAM_KEY: &str = "x-p-update-stream";
 const STREAM_TYPE_KEY: &str = "x-p-stream-type";
+const SCHEMA_TYPE_KEY: &str = "x-p-schema-type";
 const OIDC_SCOPE: &str = "openid profile email";
 const COOKIE_AGE_DAYS: usize = 7;
 const SESSION_COOKIE_NAME: &str = "session";
@@ -47,6 +48,6 @@ const TRINO_USER: &str = "x-trino-user";
 
 // constants for log Source values for known sources and formats
 const LOG_SOURCE_KINESIS: &str = "kinesis";
-
+const LOG_SOURCE_OTEL: &str = "otel";
 // AWS Kinesis constants
 const KINESIS_COMMON_ATTRIBUTES_KEY: &str = "x-amz-firehose-common-attributes";

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -208,7 +208,6 @@ impl StreamInfo {
             })
     }
 
-    #[allow(dead_code)]
     pub fn set_schema_type(
         &self,
         stream_name: &str,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -104,7 +104,10 @@ pub struct ObjectStoreFormat {
     pub static_schema_flag: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hot_tier_enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stream_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema_type: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -124,7 +127,10 @@ pub struct StreamInfo {
     pub custom_partition: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub static_schema_flag: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stream_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema_type: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
@@ -191,6 +197,7 @@ impl Default for ObjectStoreFormat {
             custom_partition: None,
             static_schema_flag: None,
             hot_tier_enabled: None,
+            schema_type: None,
         }
     }
 }

--- a/src/storage/object_storage.rs
+++ b/src/storage/object_storage.rs
@@ -145,6 +145,7 @@ pub trait ObjectStorage: Send + Sync + 'static {
         static_schema_flag: &str,
         schema: Arc<Schema>,
         stream_type: &str,
+        schema_type: &str,
     ) -> Result<String, ObjectStorageError> {
         let mut format = ObjectStoreFormat::default();
         format.set_id(CONFIG.parseable.username.clone());
@@ -171,6 +172,11 @@ pub trait ObjectStorage: Send + Sync + 'static {
             format.static_schema_flag = None;
         } else {
             format.static_schema_flag = Some(static_schema_flag.to_string());
+        }
+        if schema_type.is_empty() {
+            format.schema_type = None;
+        } else {
+            format.schema_type = Some(schema_type.to_string());
         }
         let format_json = to_bytes(&format);
         self.put_object(&schema_path(stream_name), to_bytes(&schema))


### PR DESCRIPTION
add optional field `schema_type` when creating stream add this field to storage and STREAM_INFO

use this field for known log sources like otel, k8s-events etc

for API `/v1/logs` to ingest otel-logs, add `schema_type`=`otel` 
for API `/api/v1/ingest` with header `X-P-Log-Source`=`otel` add `schema_type`=`otel`

this field will be used for schema detection
