### PR TITLE
fix: dynamic schema inference casts strings as timestamp

### DIFF
--- a/src/event/format/json.rs
+++ b/src/event/format/json.rs
@@ -70,8 +70,9 @@ impl EventFormat for Event {
             Ok(schema) => schema,
             Err(_) => match infer_json_schema_from_iterator(value_arr.iter().map(Ok)) {
                 Ok(mut infer_schema) => {
-                    let new_infer_schema = super::super::format::update_field_type_in_schema(
-                        Arc::new(infer_schema),
+                    let mut new_infer_schema = Arc::new(infer_schema);
+                    super::super::format::update_field_type_in_schema(
+                        &mut new_infer_schema,
                         Some(&stream_schema),
                         time_partition,
                         Some(&value_arr),

--- a/src/event/format/mod.rs
+++ b/src/event/format/mod.rs
@@ -241,18 +241,16 @@ fn update_schema_from_logs(
             if !existing_field_names.contains(&field.name())
                 && field.data_type() == &DataType::Utf8
                 && TIME_FIELD_PREFIXS.iter().any(|p| field.name().contains(p))
-            {
-                if log_records
+                && log_records
                     .iter()
                     .any(|record| matches_date_time_field(field.name(), record))
-                {
-                    // Update the field's data type to Timestamp
-                    return Field::new(
-                        field.name().clone(),
-                        DataType::Timestamp(TimeUnit::Millisecond, None),
-                        true,
-                    );
-                }
+            {
+                // Update the field's data type to Timestamp
+                return Field::new(
+                    field.name().clone(),
+                    DataType::Timestamp(TimeUnit::Millisecond, None),
+                    true,
+                );
             }
             Field::new(field.name().clone(), field.data_type().clone(), true)
         })

--- a/src/event/format/mod.rs
+++ b/src/event/format/mod.rs
@@ -169,7 +169,7 @@ pub fn update_field_type_in_schema(
     }
 
     if let Some(records) = log_records {
-        update_schema_from_logs(schema, existing_schema, records);
+        detect_and_override_timestamp_fields(schema, existing_schema, records);
     }
 
     if let Some(partition_field) = time_partition {
@@ -217,7 +217,7 @@ pub fn override_timestamp_fields_from_existing_schema(
 /// Updates the schema based on log records by identifying fields containing datetime patterns.
 /// Fields within the log records that match an expected substring in their names and have values
 /// resembling a datetime type will be added to or updated in the given schema.
-fn update_schema_from_logs(
+fn detect_and_override_timestamp_fields(
     schema: &mut Arc<Schema>,
     existing_schema: Option<&HashMap<String, Arc<Field>>>,
     log_records: &[Value],

--- a/src/event/format/mod.rs
+++ b/src/event/format/mod.rs
@@ -17,7 +17,10 @@
  *
  */
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use anyhow::{anyhow, Error as AnyError};
 use arrow_array::{RecordBatch, StringArray};
@@ -162,26 +165,18 @@ pub fn get_existing_fields(
     existing_fields
 }
 
-pub fn get_existing_timestamp_fields(
-    existing_schema: &HashMap<String, Arc<Field>>,
-) -> Vec<Arc<Field>> {
-    let mut timestamp_fields = Vec::new();
-
-    for field in existing_schema.values() {
-        if let DataType::Timestamp(TimeUnit::Millisecond, None) = field.data_type() {
-            timestamp_fields.push(field.clone());
-        }
-    }
-
-    timestamp_fields
-}
-
-pub fn override_timestamp_fields(
+pub fn override_timestamp_fields_from_existing_schema(
     inferred_schema: Arc<Schema>,
-    existing_timestamp_fields: &[Arc<Field>],
+    existing_schema: &HashMap<String, Arc<Field>>,
 ) -> Arc<Schema> {
-    let timestamp_field_names: Vec<&str> = existing_timestamp_fields
-        .iter()
+    let timestamp_field_names: HashSet<&str> = existing_schema
+        .values()
+        .filter(|field| {
+            matches!(
+                field.data_type(),
+                DataType::Timestamp(TimeUnit::Millisecond, None)
+            )
+        })
         .map(|field| field.name().as_str())
         .collect();
 
@@ -214,9 +209,9 @@ pub fn update_field_type_in_schema(
 
     if let Some(existing_schema) = existing_schema {
         let existing_fields = get_existing_fields(inferred_schema.clone(), Some(existing_schema));
-        let existing_timestamp_fields = get_existing_timestamp_fields(existing_schema);
         // overriding known timestamp fields which were inferred as string fields
-        updated_schema = override_timestamp_fields(updated_schema, &existing_timestamp_fields);
+        updated_schema =
+            override_timestamp_fields_from_existing_schema(updated_schema, existing_schema);
         let existing_field_names: Vec<String> = existing_fields
             .iter()
             .map(|field| field.name().clone())

--- a/src/event/format/mod.rs
+++ b/src/event/format/mod.rs
@@ -184,7 +184,7 @@ pub fn override_timestamp_fields_from_existing_schema(
     schema: &mut Arc<Schema>,
     existing_schema: &HashMap<String, Arc<Field>>,
 ) {
-    let timestamp_field_names: HashSet<&str> = existing_schema
+    let timestamp_field_names: HashSet<&String> = existing_schema
         .values()
         .filter(|field| {
             matches!(
@@ -192,14 +192,14 @@ pub fn override_timestamp_fields_from_existing_schema(
                 DataType::Timestamp(TimeUnit::Millisecond, None)
             )
         })
-        .map(|field| field.name().as_str())
+        .map(|field| field.name())
         .collect();
 
     let updated_fields: Vec<Arc<Field>> = schema
         .fields()
         .iter()
         .map(|field| {
-            if timestamp_field_names.contains(field.name().as_str()) {
+            if timestamp_field_names.contains(field.name()) {
                 Arc::new(Field::new(
                     field.name(),
                     DataType::Timestamp(TimeUnit::Millisecond, None),
@@ -222,16 +222,11 @@ fn update_schema_from_logs(
     existing_schema: Option<&HashMap<String, Arc<Field>>>,
     log_records: &[Value],
 ) {
-    let existing_field_names: Vec<&String> = schema
+    let existing_field_names: HashSet<&String> = schema
         .fields()
         .iter()
-        .filter_map(|field| {
-            if existing_schema.map_or(false, |s| s.contains_key(field.name())) {
-                Some(field.name())
-            } else {
-                None
-            }
-        })
+        .filter(|field| existing_schema.map_or(false, |s| s.contains_key(field.name())))
+        .map(|field| field.name())
         .collect();
 
     let updated_schema = schema

--- a/src/event/format/mod.rs
+++ b/src/event/format/mod.rs
@@ -36,7 +36,7 @@ use super::{DEFAULT_METADATA_KEY, DEFAULT_TAGS_KEY, DEFAULT_TIMESTAMP_KEY};
 pub mod json;
 
 // Prefixes that are most common in datetime field names
-const TIME_FIELD_PREFIXS: [&str; 2] = ["date", "time"];
+const TIME_FIELD_PREFIXES: [&str; 2] = ["date", "time"];
 
 type Tags = String;
 type Metadata = String;
@@ -235,7 +235,9 @@ fn detect_and_override_timestamp_fields(
         .map(|field| {
             if !existing_field_names.contains(&field.name())
                 && field.data_type() == &DataType::Utf8
-                && TIME_FIELD_PREFIXS.iter().any(|p| field.name().contains(p))
+                && TIME_FIELD_PREFIXES
+                    .iter()
+                    .any(|p| field.name().to_lowercase().contains(p))
                 && log_records
                     .iter()
                     .any(|record| matches_date_time_field(field.name(), record))

--- a/src/handlers/http/logstream.rs
+++ b/src/handlers/http/logstream.rs
@@ -26,7 +26,7 @@ use super::modal::utils::logstream_utils::{
 use super::query::update_schema_when_distributed;
 use crate::alerts::Alerts;
 use crate::catalog::get_first_event;
-use crate::event::format::update_data_type_to_datetime;
+use crate::event::format::update_field_type_in_schema;
 use crate::handlers::STREAM_TYPE_KEY;
 use crate::hottier::{HotTierManager, StreamHotTier, CURRENT_HOT_TIER_VERSION};
 use crate::metadata::STREAM_INFO;
@@ -110,10 +110,8 @@ pub async fn detect_schema(body: Bytes) -> Result<impl Responder, StreamError> {
         }
     };
 
-    let mut schema = infer_json_schema_from_iterator(log_records.iter().map(Ok)).unwrap();
-    for log_record in log_records {
-        schema = update_data_type_to_datetime(schema, log_record, Vec::new());
-    }
+    let mut schema = Arc::new(infer_json_schema_from_iterator(log_records.iter().map(Ok)).unwrap());
+    update_field_type_in_schema(&mut schema, None, None, Some(&log_records));
     Ok((web::Json(schema), StatusCode::OK))
 }
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

- Fixes timestamp field detection in dynamic schema inference.
- Operates with the same schema inference step in detect schema API.
- Improves performance of schema inference step during ingestion by streamlining steps.

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
