### PR TITLE
fix: allow updating custom partition and time limit together

### DIFF
--- a/src/handlers/http/modal/utils/logstream_utils.rs
+++ b/src/handlers/http/modal/utils/logstream_utils.rs
@@ -145,7 +145,6 @@ async fn update_stream(
     if !time_partition_limit.is_empty() {
         let time_partition_days = validate_time_partition_limit(time_partition_limit)?;
         update_time_partition_limit_in_stream(stream_name.to_string(), time_partition_days).await?;
-        return Ok(req.headers().clone());
     }
     validate_and_update_custom_partition(stream_name, custom_partition).await?;
 


### PR DESCRIPTION


<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->
Currently custom partition name and time-limit can't be set together in one API call, this PR changes that.
<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
