### PR TITLE
feat: conditionalize generic flattening and type casting for streams v1+

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-  check_run:
 
 name: Lint, Test and Coverage Report
 jobs:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+  check_run:
 
 name: Lint, Test and Coverage Report
 jobs:

--- a/src/event/format/json.rs
+++ b/src/event/format/json.rs
@@ -74,11 +74,12 @@ impl EventFormat for Event {
             Ok(schema) => schema,
             Err(_) => match infer_json_schema_from_iterator(value_arr.iter().map(Ok)) {
                 Ok(mut infer_schema) => {
-                    let new_infer_schema = super::super::format::update_field_type_in_schema(
+                    let new_infer_schema = super::update_field_type_in_schema(
                         Arc::new(infer_schema),
                         Some(stream_schema),
                         time_partition,
                         Some(&value_arr),
+                        schema_version,
                     );
                     infer_schema = Schema::new(new_infer_schema.fields().clone());
                     if let Err(err) = Schema::try_merge(vec![

--- a/src/event/format/json.rs
+++ b/src/event/format/json.rs
@@ -30,7 +30,10 @@ use std::{collections::HashMap, sync::Arc};
 use tracing::error;
 
 use super::{EventFormat, Metadata, Tags};
-use crate::utils::{arrow::get_field, json::flatten_json_body};
+use crate::{
+    metadata::SchemaVersion,
+    utils::{arrow::get_field, json::flatten_json_body},
+};
 
 pub struct Event {
     pub data: Value,
@@ -48,8 +51,9 @@ impl EventFormat for Event {
         schema: &HashMap<String, Arc<Field>>,
         static_schema_flag: Option<&String>,
         time_partition: Option<&String>,
+        schema_version: SchemaVersion,
     ) -> Result<(Self::Data, Vec<Arc<Field>>, bool, Tags, Metadata), anyhow::Error> {
-        let data = flatten_json_body(&self.data, None, None, None, false)?;
+        let data = flatten_json_body(self.data, None, None, None, schema_version, false)?;
         let stream_schema = schema;
 
         // incoming event may be a single json or a json array

--- a/src/event/format/json.rs
+++ b/src/event/format/json.rs
@@ -190,7 +190,9 @@ fn valid_type(data_type: &DataType, value: &Value) -> bool {
         DataType::Boolean => value.is_boolean(),
         DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 => value.is_i64(),
         DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64 => value.is_u64(),
-        DataType::Float16 | DataType::Float32 | DataType::Float64 => value.is_f64(),
+        DataType::Float16 | DataType::Float32 => value.is_f64(),
+        // All numbers can be cast as Float64 from schema version v1
+        DataType::Float64 => value.is_number(),
         DataType::Utf8 => value.is_string(),
         DataType::List(field) => {
             let data_type = field.data_type();

--- a/src/event/format/mod.rs
+++ b/src/event/format/mod.rs
@@ -139,20 +139,14 @@ pub trait EventFormat: Sized {
         if static_schema_flag.is_none() {
             return true;
         }
-        for (field_name, field) in new_schema
-            .fields()
-            .iter()
-            .map(|field| (field.name().to_owned(), field.clone()))
-            .collect::<HashMap<String, Arc<Field>>>()
-        {
-            if let Some(storage_field) = storage_schema.get(&field_name) {
-                if field_name != *storage_field.name() {
-                    return false;
-                }
-                if field.data_type() != storage_field.data_type() {
-                    return false;
-                }
-            } else {
+        for field in new_schema.fields() {
+            let Some(storage_field) = storage_schema.get(field.name()) else {
+                return false;
+            };
+            if field.name() != storage_field.name() {
+                return false;
+            }
+            if field.data_type() != storage_field.data_type() {
                 return false;
             }
         }

--- a/src/event/format/mod.rs
+++ b/src/event/format/mod.rs
@@ -272,7 +272,8 @@ pub fn update_data_type_to_datetime(
                 // for new fields in json with inferred type string, parse to check if timestamp value
                 if field.data_type() == &DataType::Utf8
                     && !ignore_field_names.contains(field.name().as_str())
-                    && DateTime::parse_from_rfc3339(s).is_ok()
+                    && (DateTime::parse_from_rfc3339(s).is_ok()
+                        || DateTime::parse_from_rfc2822(s).is_ok())
                 {
                     // Update the field's data type to Timestamp
                     return Field::new(

--- a/src/handlers/http/ingest.rs
+++ b/src/handlers/http/ingest.rs
@@ -786,8 +786,8 @@ mod tests {
         assert_eq!(rb.num_rows(), 4);
         assert_eq!(rb.num_columns(), 7);
         assert_eq!(
-            rb.column_by_name("a").unwrap().as_int64_arr().unwrap(),
-            &Int64Array::from(vec![Some(1), Some(1), Some(1), Some(1)])
+            rb.column_by_name("a").unwrap().as_float64_arr().unwrap(),
+            &Float64Array::from(vec![Some(1.0), Some(1.0), Some(1.0), Some(1.0)])
         );
         assert_eq!(
             rb.column_by_name("b").unwrap().as_utf8_arr().unwrap(),
@@ -800,13 +800,13 @@ mod tests {
         );
 
         assert_eq!(
-            rb.column_by_name("c_a").unwrap().as_int64_arr().unwrap(),
-            &Int64Array::from(vec![None, None, Some(1), Some(1)])
+            rb.column_by_name("c_a").unwrap().as_float64_arr().unwrap(),
+            &Float64Array::from(vec![None, None, Some(1.0), Some(1.0)])
         );
 
         assert_eq!(
-            rb.column_by_name("c_b").unwrap().as_int64_arr().unwrap(),
-            &Int64Array::from(vec![None, None, None, Some(2)])
+            rb.column_by_name("c_b").unwrap().as_float64_arr().unwrap(),
+            &Float64Array::from(vec![None, None, None, Some(2.0)])
         );
     }
 }

--- a/src/handlers/http/ingest.rs
+++ b/src/handlers/http/ingest.rs
@@ -84,6 +84,7 @@ pub async fn ingest_internal_stream(stream_name: String, body: Bytes) -> Result<
             tags: String::default(),
             metadata: String::default(),
         };
+        // For internal streams, use old schema
         event.into_recordbatch(&schema, None, None, SchemaVersion::V0)?
     };
     event::Event {

--- a/src/handlers/http/ingest.rs
+++ b/src/handlers/http/ingest.rs
@@ -28,7 +28,7 @@ use crate::event::{
 use crate::handlers::http::modal::utils::logstream_utils::create_stream_and_schema_from_storage;
 use crate::handlers::STREAM_NAME_HEADER_KEY;
 use crate::metadata::error::stream_info::MetadataError;
-use crate::metadata::STREAM_INFO;
+use crate::metadata::{SchemaVersion, STREAM_INFO};
 use crate::option::{Mode, CONFIG};
 use crate::storage::{ObjectStorageError, StreamType};
 use crate::utils::header_parsing::ParseHeaderError;
@@ -84,7 +84,7 @@ pub async fn ingest_internal_stream(stream_name: String, body: Bytes) -> Result<
             tags: String::default(),
             metadata: String::default(),
         };
-        event.into_recordbatch(&schema, None, None)?
+        event.into_recordbatch(&schema, None, None, SchemaVersion::V0)?
     };
     event::Event {
         rb,
@@ -280,6 +280,7 @@ mod tests {
     use crate::{
         event,
         handlers::{http::modal::utils::ingest_utils::into_event_batch, PREFIX_META, PREFIX_TAGS},
+        metadata::SchemaVersion,
     };
 
     trait TestExt {
@@ -319,7 +320,15 @@ mod tests {
             .append_header((PREFIX_META.to_string() + "C", "meta1"))
             .to_http_request();
 
-        let (rb, _) = into_event_batch(&req, &json, HashMap::default(), None, None).unwrap();
+        let (rb, _) = into_event_batch(
+            &req,
+            &json,
+            HashMap::default(),
+            None,
+            None,
+            SchemaVersion::V0,
+        )
+        .unwrap();
 
         assert_eq!(rb.num_rows(), 1);
         assert_eq!(rb.num_columns(), 6);
@@ -359,7 +368,15 @@ mod tests {
 
         let req = TestRequest::default().to_http_request();
 
-        let (rb, _) = into_event_batch(&req, &json, HashMap::default(), None, None).unwrap();
+        let (rb, _) = into_event_batch(
+            &req,
+            &json,
+            HashMap::default(),
+            None,
+            None,
+            SchemaVersion::V0,
+        )
+        .unwrap();
 
         assert_eq!(rb.num_rows(), 1);
         assert_eq!(rb.num_columns(), 5);
@@ -391,7 +408,7 @@ mod tests {
 
         let req = TestRequest::default().to_http_request();
 
-        let (rb, _) = into_event_batch(&req, &json, schema, None, None).unwrap();
+        let (rb, _) = into_event_batch(&req, &json, schema, None, None, SchemaVersion::V0).unwrap();
 
         assert_eq!(rb.num_rows(), 1);
         assert_eq!(rb.num_columns(), 5);
@@ -423,7 +440,7 @@ mod tests {
 
         let req = TestRequest::default().to_http_request();
 
-        assert!(into_event_batch(&req, &json, schema, None, None).is_err());
+        assert!(into_event_batch(&req, &json, schema, None, None, SchemaVersion::V0).is_err());
     }
 
     #[test]
@@ -441,7 +458,7 @@ mod tests {
 
         let req = TestRequest::default().to_http_request();
 
-        let (rb, _) = into_event_batch(&req, &json, schema, None, None).unwrap();
+        let (rb, _) = into_event_batch(&req, &json, schema, None, None, SchemaVersion::V0).unwrap();
 
         assert_eq!(rb.num_rows(), 1);
         assert_eq!(rb.num_columns(), 3);
@@ -453,7 +470,15 @@ mod tests {
 
         let req = TestRequest::default().to_http_request();
 
-        assert!(into_event_batch(&req, &json, HashMap::default(), None, None).is_err())
+        assert!(into_event_batch(
+            &req,
+            &json,
+            HashMap::default(),
+            None,
+            None,
+            SchemaVersion::V0
+        )
+        .is_err())
     }
 
     #[test]
@@ -476,7 +501,15 @@ mod tests {
 
         let req = TestRequest::default().to_http_request();
 
-        let (rb, _) = into_event_batch(&req, &json, HashMap::default(), None, None).unwrap();
+        let (rb, _) = into_event_batch(
+            &req,
+            &json,
+            HashMap::default(),
+            None,
+            None,
+            SchemaVersion::V0,
+        )
+        .unwrap();
 
         assert_eq!(rb.num_rows(), 3);
         assert_eq!(rb.num_columns(), 6);
@@ -524,7 +557,15 @@ mod tests {
 
         let req = TestRequest::default().to_http_request();
 
-        let (rb, _) = into_event_batch(&req, &json, HashMap::default(), None, None).unwrap();
+        let (rb, _) = into_event_batch(
+            &req,
+            &json,
+            HashMap::default(),
+            None,
+            None,
+            SchemaVersion::V0,
+        )
+        .unwrap();
 
         assert_eq!(rb.num_rows(), 3);
         assert_eq!(rb.num_columns(), 6);
@@ -572,7 +613,7 @@ mod tests {
         );
         let req = TestRequest::default().to_http_request();
 
-        let (rb, _) = into_event_batch(&req, &json, schema, None, None).unwrap();
+        let (rb, _) = into_event_batch(&req, &json, schema, None, None, SchemaVersion::V0).unwrap();
 
         assert_eq!(rb.num_rows(), 3);
         assert_eq!(rb.num_columns(), 6);
@@ -621,7 +662,7 @@ mod tests {
             .into_iter(),
         );
 
-        assert!(into_event_batch(&req, &json, schema, None, None).is_err());
+        assert!(into_event_batch(&req, &json, schema, None, None, SchemaVersion::V0).is_err());
     }
 
     #[test]
@@ -649,7 +690,15 @@ mod tests {
 
         let req = TestRequest::default().to_http_request();
 
-        let (rb, _) = into_event_batch(&req, &json, HashMap::default(), None, None).unwrap();
+        let (rb, _) = into_event_batch(
+            &req,
+            &json,
+            HashMap::default(),
+            None,
+            None,
+            SchemaVersion::V0,
+        )
+        .unwrap();
 
         assert_eq!(rb.num_rows(), 4);
         assert_eq!(rb.num_columns(), 7);

--- a/src/handlers/http/ingest.rs
+++ b/src/handlers/http/ingest.rs
@@ -284,22 +284,22 @@ mod tests {
     };
 
     trait TestExt {
-        fn as_int64_arr(&self) -> &Int64Array;
-        fn as_float64_arr(&self) -> &Float64Array;
-        fn as_utf8_arr(&self) -> &StringArray;
+        fn as_int64_arr(&self) -> Option<&Int64Array>;
+        fn as_float64_arr(&self) -> Option<&Float64Array>;
+        fn as_utf8_arr(&self) -> Option<&StringArray>;
     }
 
     impl TestExt for ArrayRef {
-        fn as_int64_arr(&self) -> &Int64Array {
-            self.as_any().downcast_ref().unwrap()
+        fn as_int64_arr(&self) -> Option<&Int64Array> {
+            self.as_any().downcast_ref()
         }
 
-        fn as_float64_arr(&self) -> &Float64Array {
-            self.as_any().downcast_ref().unwrap()
+        fn as_float64_arr(&self) -> Option<&Float64Array> {
+            self.as_any().downcast_ref()
         }
 
-        fn as_utf8_arr(&self) -> &StringArray {
-            self.as_any().downcast_ref().unwrap()
+        fn as_utf8_arr(&self) -> Option<&StringArray> {
+            self.as_any().downcast_ref()
         }
     }
 
@@ -333,27 +333,29 @@ mod tests {
         assert_eq!(rb.num_rows(), 1);
         assert_eq!(rb.num_columns(), 6);
         assert_eq!(
-            rb.column_by_name("a").unwrap().as_int64_arr(),
+            rb.column_by_name("a").unwrap().as_int64_arr().unwrap(),
             &Int64Array::from_iter([1])
         );
         assert_eq!(
-            rb.column_by_name("b").unwrap().as_utf8_arr(),
+            rb.column_by_name("b").unwrap().as_utf8_arr().unwrap(),
             &StringArray::from_iter_values(["hello"])
         );
         assert_eq!(
-            rb.column_by_name("c").unwrap().as_float64_arr(),
+            rb.column_by_name("c").unwrap().as_float64_arr().unwrap(),
             &Float64Array::from_iter([4.23])
         );
         assert_eq!(
             rb.column_by_name(event::DEFAULT_TAGS_KEY)
                 .unwrap()
-                .as_utf8_arr(),
+                .as_utf8_arr()
+                .unwrap(),
             &StringArray::from_iter_values(["a=tag1"])
         );
         assert_eq!(
             rb.column_by_name(event::DEFAULT_METADATA_KEY)
                 .unwrap()
-                .as_utf8_arr(),
+                .as_utf8_arr()
+                .unwrap(),
             &StringArray::from_iter_values(["c=meta1"])
         );
     }
@@ -381,11 +383,11 @@ mod tests {
         assert_eq!(rb.num_rows(), 1);
         assert_eq!(rb.num_columns(), 5);
         assert_eq!(
-            rb.column_by_name("a").unwrap().as_int64_arr(),
+            rb.column_by_name("a").unwrap().as_int64_arr().unwrap(),
             &Int64Array::from_iter([1])
         );
         assert_eq!(
-            rb.column_by_name("b").unwrap().as_utf8_arr(),
+            rb.column_by_name("b").unwrap().as_utf8_arr().unwrap(),
             &StringArray::from_iter_values(["hello"])
         );
     }
@@ -413,11 +415,11 @@ mod tests {
         assert_eq!(rb.num_rows(), 1);
         assert_eq!(rb.num_columns(), 5);
         assert_eq!(
-            rb.column_by_name("a").unwrap().as_int64_arr(),
+            rb.column_by_name("a").unwrap().as_int64_arr().unwrap(),
             &Int64Array::from_iter([1])
         );
         assert_eq!(
-            rb.column_by_name("b").unwrap().as_utf8_arr(),
+            rb.column_by_name("b").unwrap().as_utf8_arr().unwrap(),
             &StringArray::from_iter_values(["hello"])
         );
     }
@@ -522,15 +524,15 @@ mod tests {
         assert_eq!(&*fields[3], &Field::new("c", DataType::Int64, true));
 
         assert_eq!(
-            rb.column_by_name("a").unwrap().as_int64_arr(),
+            rb.column_by_name("a").unwrap().as_int64_arr().unwrap(),
             &Int64Array::from(vec![None, Some(1), Some(1)])
         );
         assert_eq!(
-            rb.column_by_name("b").unwrap().as_utf8_arr(),
+            rb.column_by_name("b").unwrap().as_utf8_arr().unwrap(),
             &StringArray::from(vec![Some("hello"), Some("hello"), Some("hello"),])
         );
         assert_eq!(
-            rb.column_by_name("c").unwrap().as_int64_arr(),
+            rb.column_by_name("c").unwrap().as_int64_arr().unwrap(),
             &Int64Array::from(vec![None, Some(1), None])
         );
     }
@@ -570,15 +572,15 @@ mod tests {
         assert_eq!(rb.num_rows(), 3);
         assert_eq!(rb.num_columns(), 6);
         assert_eq!(
-            rb.column_by_name("a").unwrap().as_int64_arr(),
+            rb.column_by_name("a").unwrap().as_int64_arr().unwrap(),
             &Int64Array::from(vec![None, Some(1), Some(1)])
         );
         assert_eq!(
-            rb.column_by_name("b").unwrap().as_utf8_arr(),
+            rb.column_by_name("b").unwrap().as_utf8_arr().unwrap(),
             &StringArray::from(vec![Some("hello"), Some("hello"), Some("hello"),])
         );
         assert_eq!(
-            rb.column_by_name("c").unwrap().as_float64_arr(),
+            rb.column_by_name("c").unwrap().as_float64_arr().unwrap(),
             &Float64Array::from(vec![None, Some(1.22), None,])
         );
     }
@@ -618,15 +620,15 @@ mod tests {
         assert_eq!(rb.num_rows(), 3);
         assert_eq!(rb.num_columns(), 6);
         assert_eq!(
-            rb.column_by_name("a").unwrap().as_int64_arr(),
+            rb.column_by_name("a").unwrap().as_int64_arr().unwrap(),
             &Int64Array::from(vec![None, Some(1), Some(1)])
         );
         assert_eq!(
-            rb.column_by_name("b").unwrap().as_utf8_arr(),
+            rb.column_by_name("b").unwrap().as_utf8_arr().unwrap(),
             &StringArray::from(vec![Some("hello"), Some("hello"), Some("hello"),])
         );
         assert_eq!(
-            rb.column_by_name("c").unwrap().as_float64_arr(),
+            rb.column_by_name("c").unwrap().as_float64_arr().unwrap(),
             &Float64Array::from(vec![None, Some(1.22), None,])
         );
     }
@@ -703,11 +705,11 @@ mod tests {
         assert_eq!(rb.num_rows(), 4);
         assert_eq!(rb.num_columns(), 7);
         assert_eq!(
-            rb.column_by_name("a").unwrap().as_int64_arr(),
+            rb.column_by_name("a").unwrap().as_int64_arr().unwrap(),
             &Int64Array::from(vec![Some(1), Some(1), Some(1), Some(1)])
         );
         assert_eq!(
-            rb.column_by_name("b").unwrap().as_utf8_arr(),
+            rb.column_by_name("b").unwrap().as_utf8_arr().unwrap(),
             &StringArray::from(vec![
                 Some("hello"),
                 Some("hello"),
@@ -717,12 +719,12 @@ mod tests {
         );
 
         assert_eq!(
-            rb.column_by_name("c_a").unwrap().as_int64_arr(),
+            rb.column_by_name("c_a").unwrap().as_int64_arr().unwrap(),
             &Int64Array::from(vec![None, None, Some(1), Some(1)])
         );
 
         assert_eq!(
-            rb.column_by_name("c_b").unwrap().as_int64_arr(),
+            rb.column_by_name("c_b").unwrap().as_int64_arr().unwrap(),
             &Int64Array::from(vec![None, None, None, Some(2)])
         );
     }

--- a/src/handlers/http/logstream.rs
+++ b/src/handlers/http/logstream.rs
@@ -47,7 +47,7 @@ use bytes::Bytes;
 use chrono::Utc;
 use http::{HeaderName, HeaderValue};
 use serde_json::Value;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fs;
 use std::num::NonZeroU32;
 use std::str::FromStr;
@@ -113,7 +113,7 @@ pub async fn detect_schema(body: Bytes) -> Result<impl Responder, StreamError> {
 
     let mut schema = Arc::new(infer_json_schema_from_iterator(log_records.iter().map(Ok)).unwrap());
     for log_record in log_records {
-        schema = override_data_type(schema, log_record, &HashSet::new(), SchemaVersion::V1);
+        schema = override_data_type(schema, log_record, SchemaVersion::V1);
     }
     Ok((web::Json(schema), StatusCode::OK))
 }

--- a/src/handlers/http/logstream.rs
+++ b/src/handlers/http/logstream.rs
@@ -26,7 +26,7 @@ use super::modal::utils::logstream_utils::{
 use super::query::update_schema_when_distributed;
 use crate::alerts::Alerts;
 use crate::catalog::get_first_event;
-use crate::event::format::update_data_type_to_datetime;
+use crate::event::format::update_data_type_v1;
 use crate::handlers::STREAM_TYPE_KEY;
 use crate::hottier::{HotTierManager, StreamHotTier, CURRENT_HOT_TIER_VERSION};
 use crate::metadata::STREAM_INFO;
@@ -113,7 +113,7 @@ pub async fn detect_schema(body: Bytes) -> Result<impl Responder, StreamError> {
 
     let mut schema = Arc::new(infer_json_schema_from_iterator(log_records.iter().map(Ok)).unwrap());
     for log_record in log_records {
-        schema = update_data_type_to_datetime(schema, log_record, &HashSet::new());
+        schema = update_data_type_v1(schema, log_record, &HashSet::new());
     }
     Ok((web::Json(schema), StatusCode::OK))
 }

--- a/src/handlers/http/logstream.rs
+++ b/src/handlers/http/logstream.rs
@@ -517,6 +517,7 @@ pub async fn create_stream(
                 static_schema_flag.to_string(),
                 static_schema,
                 stream_type,
+                SchemaVersion::V1, // New stream
             );
         }
         Err(err) => {

--- a/src/handlers/http/logstream.rs
+++ b/src/handlers/http/logstream.rs
@@ -26,10 +26,10 @@ use super::modal::utils::logstream_utils::{
 use super::query::update_schema_when_distributed;
 use crate::alerts::Alerts;
 use crate::catalog::get_first_event;
-use crate::event::format::update_data_type_v1;
+use crate::event::format::override_data_type;
 use crate::handlers::STREAM_TYPE_KEY;
 use crate::hottier::{HotTierManager, StreamHotTier, CURRENT_HOT_TIER_VERSION};
-use crate::metadata::STREAM_INFO;
+use crate::metadata::{SchemaVersion, STREAM_INFO};
 use crate::metrics::{EVENTS_INGESTED_DATE, EVENTS_INGESTED_SIZE_DATE, EVENTS_STORAGE_SIZE_DATE};
 use crate::option::{Mode, CONFIG};
 use crate::stats::{event_labels_date, storage_size_labels_date, Stats};
@@ -113,7 +113,7 @@ pub async fn detect_schema(body: Bytes) -> Result<impl Responder, StreamError> {
 
     let mut schema = Arc::new(infer_json_schema_from_iterator(log_records.iter().map(Ok)).unwrap());
     for log_record in log_records {
-        schema = update_data_type_v1(schema, log_record, &HashSet::new());
+        schema = override_data_type(schema, log_record, &HashSet::new(), SchemaVersion::V1);
     }
     Ok((web::Json(schema), StatusCode::OK))
 }

--- a/src/handlers/http/logstream.rs
+++ b/src/handlers/http/logstream.rs
@@ -47,7 +47,7 @@ use bytes::Bytes;
 use chrono::Utc;
 use http::{HeaderName, HeaderValue};
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::num::NonZeroU32;
 use std::str::FromStr;
@@ -111,9 +111,9 @@ pub async fn detect_schema(body: Bytes) -> Result<impl Responder, StreamError> {
         }
     };
 
-    let mut schema = infer_json_schema_from_iterator(log_records.iter().map(Ok)).unwrap();
+    let mut schema = Arc::new(infer_json_schema_from_iterator(log_records.iter().map(Ok)).unwrap());
     for log_record in log_records {
-        schema = update_data_type_to_datetime(schema, log_record, Vec::new());
+        schema = update_data_type_to_datetime(schema, log_record, &HashSet::new());
     }
     Ok((web::Json(schema), StatusCode::OK))
 }

--- a/src/handlers/http/modal/utils/ingest_utils.rs
+++ b/src/handlers/http/modal/utils/ingest_utils.rs
@@ -83,7 +83,7 @@ pub async fn push_logs(
     for value in data {
         let size = serde_json::to_vec(&value).unwrap().len(); // string length need not be the same as byte length
         let parsed_timestamp = get_parsed_timestamp(&value, time_partition.as_ref());
-        let partition_values = match custom_partition.as_ref() {
+        let custom_partition_values = match custom_partition.as_ref() {
             Some(custom_partition) => {
                 let custom_partitions = custom_partition.split(',').collect_vec();
                 get_custom_partition_values(&value, &custom_partitions)
@@ -99,7 +99,7 @@ pub async fn push_logs(
             time_partition.as_ref(),
             schema_version,
             parsed_timestamp,
-            &partition_values,
+            custom_partition_values,
             size as u64,
         )
         .await?;
@@ -117,7 +117,7 @@ pub async fn create_process_record_batch(
     time_partition: Option<&String>,
     schema_version: SchemaVersion,
     parsed_timestamp: NaiveDateTime,
-    custom_partition_values: &HashMap<String, String>,
+    custom_partition_values: HashMap<String, String>,
     origin_size: u64,
 ) -> Result<(), PostError> {
     let (rb, is_first_event) = get_stream_schema(
@@ -136,7 +136,7 @@ pub async fn create_process_record_batch(
         is_first_event,
         parsed_timestamp,
         time_partition: time_partition.cloned(),
-        custom_partition_values: custom_partition_values.clone(),
+        custom_partition_values,
         stream_type: StreamType::UserDefined,
     }
     .process()

--- a/src/handlers/http/modal/utils/ingest_utils.rs
+++ b/src/handlers/http/modal/utils/ingest_utils.rs
@@ -81,7 +81,7 @@ pub async fn push_logs(
     )?;
 
     for value in data {
-        let size = value.to_string().into_bytes().len();
+        let size = serde_json::to_vec(&value).unwrap().len(); // string length need not be the same as byte length
         let parsed_timestamp = get_parsed_timestamp(&value, time_partition.as_ref());
         let partition_values = match custom_partition.as_ref() {
             Some(custom_partition) => {

--- a/src/handlers/http/modal/utils/logstream_utils.rs
+++ b/src/handlers/http/modal/utils/logstream_utils.rs
@@ -29,7 +29,7 @@ use crate::{
         CUSTOM_PARTITION_KEY, STATIC_SCHEMA_FLAG, STREAM_TYPE_KEY, TIME_PARTITION_KEY,
         TIME_PARTITION_LIMIT_KEY, UPDATE_STREAM_KEY,
     },
-    metadata::{self, STREAM_INFO},
+    metadata::{self, SchemaVersion, STREAM_INFO},
     option::{Mode, CONFIG},
     static_schema::{convert_static_schema_to_arrow_schema, StaticSchema},
     storage::{LogStream, ObjectStoreFormat, StreamType},
@@ -426,6 +426,7 @@ pub async fn create_stream(
                 static_schema_flag.to_string(),
                 static_schema,
                 stream_type,
+                SchemaVersion::V1, // New stream
             );
         }
         Err(err) => {
@@ -474,6 +475,7 @@ pub async fn create_stream_and_schema_from_storage(stream_name: &str) -> Result<
         let custom_partition = stream_metadata.custom_partition.as_deref().unwrap_or("");
         let static_schema_flag = stream_metadata.static_schema_flag.as_deref().unwrap_or("");
         let stream_type = stream_metadata.stream_type.as_deref().unwrap_or("");
+        let schema_version = stream_metadata.schema_version;
 
         metadata::STREAM_INFO.add_stream(
             stream_name.to_string(),
@@ -484,6 +486,7 @@ pub async fn create_stream_and_schema_from_storage(stream_name: &str) -> Result<
             static_schema_flag.to_string(),
             static_schema,
             stream_type,
+            schema_version,
         );
     } else {
         return Ok(false);

--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -226,12 +226,14 @@ async fn ingest_message(msg: BorrowedMessage<'_>) -> Result<(), KafkaError> {
 
     let time_partition = STREAM_INFO.get_time_partition(stream_name)?;
     let static_schema_flag = STREAM_INFO.get_static_schema_flag(stream_name)?;
+    let schema_version = STREAM_INFO.get_schema_version(stream_name)?;
 
     let (rb, is_first) = event
         .into_recordbatch(
             &schema,
             static_schema_flag.as_ref(),
             time_partition.as_ref(),
+            schema_version,
         )
         .map_err(|err| KafkaError::PostError(PostError::CustomError(err.to_string())))?;
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -47,12 +47,17 @@ pub static STREAM_INFO: Lazy<StreamInfo> = Lazy::new(StreamInfo::default);
 #[derive(Debug, Deref, DerefMut, Default)]
 pub struct StreamInfo(RwLock<HashMap<String, LogStreamMetadata>>);
 
+/// In order to support backward compatability with streams created before v1.6.4,
+/// we will consider past versions of stream schema to be v0. Streams created with
+/// v1.6.4+ will be v1.
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum SchemaVersion {
     #[default]
     V0,
+    /// Applies generic JSON flattening, ignores null data, handles all numbers as
+    /// float64 and uses the timestamp type to store compatible time information.
     V1,
 }
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -304,6 +304,7 @@ impl StreamInfo {
                 static_schema
             },
             stream_type: Some(stream_type.to_string()),
+            schema_version: SchemaVersion::V1,
             ..Default::default()
         };
         map.insert(stream_name, metadata);

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -274,6 +274,7 @@ impl StreamInfo {
         static_schema_flag: String,
         static_schema: HashMap<String, Arc<Field>>,
         stream_type: &str,
+        schema_version: SchemaVersion,
     ) {
         let mut map = self.write().expect(LOCK_EXPECT);
         let metadata = LogStreamMetadata {
@@ -304,7 +305,7 @@ impl StreamInfo {
                 static_schema
             },
             stream_type: Some(stream_type.to_string()),
-            schema_version: SchemaVersion::V1,
+            schema_version,
             ..Default::default()
         };
         map.insert(stream_name, metadata);

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -389,7 +389,7 @@ pub async fn update_data_type_time_partition(
 ) -> anyhow::Result<Schema> {
     let mut schema = schema.clone();
     if let Some(time_partition) = time_partition {
-        if let Ok(time_partition_field) = schema.field_with_name(&time_partition) {
+        if let Ok(time_partition_field) = schema.field_with_name(time_partition) {
             if time_partition_field.data_type() != &DataType::Timestamp(TimeUnit::Millisecond, None)
             {
                 let mut fields = schema

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -17,7 +17,9 @@
  */
 
 use crate::{
-    catalog::snapshot::Snapshot, metadata::error::stream_info::MetadataError, stats::FullStats,
+    catalog::snapshot::Snapshot,
+    metadata::{error::stream_info::MetadataError, SchemaVersion},
+    stats::FullStats,
 };
 
 use chrono::Local;
@@ -77,6 +79,9 @@ pub const CURRENT_SCHEMA_VERSION: &str = "v5";
 pub struct ObjectStoreFormat {
     /// Version of schema registry
     pub version: String,
+    /// Version of schema, defaults to v0 if not set
+    #[serde(default)]
+    pub schema_version: SchemaVersion,
     /// Version for change in the way how parquet are generated/stored.
     #[serde(rename = "objectstore-format")]
     pub objectstore_format: String,
@@ -176,6 +181,7 @@ impl Default for ObjectStoreFormat {
     fn default() -> Self {
         Self {
             version: CURRENT_SCHEMA_VERSION.to_string(),
+            schema_version: SchemaVersion::V1, // Newly created streams should be v1
             objectstore_format: CURRENT_OBJECT_STORE_VERSION.to_string(),
             stream_type: Some(StreamType::UserDefined.to_string()),
             created_at: Local::now().to_rfc3339(),

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -202,13 +202,6 @@ impl Default for ObjectStoreFormat {
     }
 }
 
-impl ObjectStoreFormat {
-    fn set_id(&mut self, id: String) {
-        self.owner.id.clone_from(&id);
-        self.owner.group = id;
-    }
-}
-
 #[derive(serde::Serialize, PartialEq)]
 pub struct LogStream {
     pub name: String,


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

- For streams created after the v1 update, generic flattening will be applied.
- All numbers will be stored as float64.
- All string fields with name "date"/"time" that can be parsed as timestamp will be stored as timestamp.

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
