### PR TITLE
fix: hierarchical json flattening restriction

### DIFF
--- a/src/utils/json/flatten.rs
+++ b/src/utils/json/flatten.rs
@@ -637,13 +637,13 @@ mod tests {
     #[test]
     fn unacceptable_levels_of_nested_json() {
         let value = json!({"a":{"b":{"c":{"d":{"e":["a","b"]}}}}});
-        assert_eq!(has_more_than_four_levels(&value, 1), true);
+        assert!(has_more_than_four_levels(&value, 1));
     }
 
     #[test]
     fn acceptable_levels_of_nested_json() {
         let value = json!({"a":{"b":{"e":["a","b"]}}});
-        assert_eq!(has_more_than_four_levels(&value, 1), false);
+        assert!(!has_more_than_four_levels(&value, 1));
     }
 
     #[test]

--- a/src/utils/json/mod.rs
+++ b/src/utils/json/mod.rs
@@ -18,6 +18,7 @@
 
 use std::num::NonZeroU32;
 
+use flatten::{convert_to_array, generic_flattening};
 use serde_json;
 use serde_json::Value;
 
@@ -37,9 +38,11 @@ pub fn flatten_json_body(
     validation_required: bool,
 ) -> Result<Value, anyhow::Error> {
     let mut nested_value = if schema_version == SchemaVersion::V1 {
-        flatten::generic_flattening(&body)
-            .map(flatten::convert_to_array)
-            .unwrap_or(Ok(body))?
+        if let Ok(flattened_json) = generic_flattening(&body) {
+            convert_to_array(flattened_json)?
+        } else {
+            body
+        }
     } else {
         body
     };

--- a/src/utils/json/mod.rs
+++ b/src/utils/json/mod.rs
@@ -37,7 +37,9 @@ pub fn flatten_json_body(
     validation_required: bool,
 ) -> Result<Value, anyhow::Error> {
     let mut nested_value = if schema_version == SchemaVersion::V1 {
-        flatten::generic_flattening(body)?
+        flatten::generic_flattening(&body)
+            .map(flatten::convert_to_array)
+            .unwrap_or(Ok(body))?
     } else {
         body
     };
@@ -105,7 +107,15 @@ mod tests {
         let value = json!({"a":{"b":{"e":["a","b"]}}});
         let expected = json!([{"a_b_e": "a"}, {"a_b_e": "b"}]);
         assert_eq!(
-            flatten_json_body(value, None, None, None, crate::metadata::SchemaVersion::V1, false).unwrap(),
+            flatten_json_body(
+                value,
+                None,
+                None,
+                None,
+                crate::metadata::SchemaVersion::V1,
+                false
+            )
+            .unwrap(),
             expected
         );
     }
@@ -115,7 +125,15 @@ mod tests {
         let value = json!({"a":{"b":{"c":{"d":{"e":["a","b"]}}}}});
         let expected = json!({"a_b_c_d_e": ["a","b"]});
         assert_eq!(
-            flatten_json_body(value, None, None, None,crate::metadata::SchemaVersion::V1, false).unwrap(),
+            flatten_json_body(
+                value,
+                None,
+                None,
+                None,
+                crate::metadata::SchemaVersion::V1,
+                false
+            )
+            .unwrap(),
             expected
         );
     }


### PR DESCRIPTION
get the level of hierarchy from the json
perform generic flattening only if level of nesting is <=4
