### PR TITLE
fix: convert int to string for otel attributes

### DIFF
--- a/src/otel/otel_utils.rs
+++ b/src/otel/otel_utils.rs
@@ -31,7 +31,7 @@ pub fn collect_json_from_value(key: &String, value: OtelValue) -> BTreeMap<Strin
             value_json.insert(key.to_string(), Value::Bool(bool_val));
         }
         OtelValue::IntValue(int_val) => {
-            value_json.insert(key.to_string(), Value::Number(int_val.into()));
+            value_json.insert(key.to_string(), Value::String(int_val.to_string()));
         }
         OtelValue::DoubleValue(double_val) => {
             if let Some(number) = serde_json::Number::from_f64(double_val) {


### PR DESCRIPTION
The OTEL collector intermittently sends the intValue attribute as both a string and as an integer
Schema merge fails in Parseable because of error -
 `from data_type = Float64 does not equal Utf8`

A few field attributes that cause such issues are -
 `server.port`, `http.status_code`, `status` etc

hence, it is safe to treat the intValue as string

