### PR TITLE
feat: add log source to stream info

### DIFF
--- a/src/event/format/mod.rs
+++ b/src/event/format/mod.rs
@@ -26,6 +26,7 @@ use anyhow::{anyhow, Error as AnyError};
 use arrow_array::RecordBatch;
 use arrow_schema::{DataType, Field, Schema, TimeUnit};
 use chrono::DateTime;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{metadata::SchemaVersion, utils::arrow::get_field};
@@ -38,7 +39,7 @@ static TIME_FIELD_NAME_PARTS: [&str; 2] = ["time", "date"];
 type EventSchema = Vec<Arc<Field>>;
 
 /// Source of the logs, used to perform special processing for certain sources
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LogSource {
     // AWS Kinesis sends logs in the format of a json array
     Kinesis,
@@ -51,6 +52,8 @@ pub enum LogSource {
     // OpenTelemetry sends traces according to the specification as explained here
     // https://github.com/open-telemetry/opentelemetry-proto/tree/v1.0.0/opentelemetry/proto/metrics/v1
     OtelTraces,
+    // Internal Stream format
+    Pmeta,
     #[default]
     // Json object or array
     Json,
@@ -64,7 +67,8 @@ impl From<&str> for LogSource {
             "otel-logs" => LogSource::OtelLogs,
             "otel-metrics" => LogSource::OtelMetrics,
             "otel-traces" => LogSource::OtelTraces,
-            custom => LogSource::Custom(custom.to_owned()),
+            "pmeta" => LogSource::Pmeta,
+            _ => LogSource::Json,
         }
     }
 }

--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -34,6 +34,7 @@ use std::{collections::HashMap, fmt::Debug};
 use tracing::{debug, error, info, warn};
 
 use crate::audit::AuditLogBuilder;
+use crate::event::format::LogSource;
 use crate::option::CONFIG;
 use crate::{
     event::{
@@ -180,7 +181,12 @@ async fn ingest_message(msg: BorrowedMessage<'_>) -> Result<(), KafkaError> {
     let stream_name = msg.topic();
 
     // stream should get created only if there is an incoming event, not before that
-    create_stream_if_not_exists(stream_name, &StreamType::UserDefined.to_string()).await?;
+    create_stream_if_not_exists(
+        stream_name,
+        &StreamType::UserDefined.to_string(),
+        LogSource::default(),
+    )
+    .await?;
 
     let schema = resolve_schema(stream_name)?;
     let event = format::json::Event {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -18,6 +18,7 @@
 
 use crate::{
     catalog::snapshot::Snapshot,
+    event::format::LogSource,
     metadata::{error::stream_info::MetadataError, SchemaVersion},
     stats::FullStats,
     utils::json::{deserialize_string_as_true, serialize_bool_as_true},
@@ -116,6 +117,8 @@ pub struct ObjectStoreFormat {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hot_tier_enabled: Option<bool>,
     pub stream_type: Option<String>,
+    #[serde(default)]
+    pub log_source: LogSource,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -139,6 +142,7 @@ pub struct StreamInfo {
     )]
     pub static_schema_flag: bool,
     pub stream_type: Option<String>,
+    pub log_source: LogSource,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
@@ -205,6 +209,7 @@ impl Default for ObjectStoreFormat {
             custom_partition: None,
             static_schema_flag: false,
             hot_tier_enabled: None,
+            log_source: LogSource::default(),
         }
     }
 }

--- a/src/storage/object_storage.rs
+++ b/src/storage/object_storage.rs
@@ -27,6 +27,7 @@ use super::{
 };
 
 use crate::correlation::{CorrelationConfig, CorrelationError};
+use crate::event::format::LogSource;
 use crate::handlers::http::modal::ingest_server::INGESTOR_META;
 use crate::handlers::http::users::{DASHBOARDS_DIR, FILTER_DIR, USERS_ROOT_DIR};
 use crate::metadata::SchemaVersion;
@@ -155,6 +156,7 @@ pub trait ObjectStorage: Debug + Send + Sync + 'static {
         static_schema_flag: bool,
         schema: Arc<Schema>,
         stream_type: &str,
+        log_source: LogSource,
     ) -> Result<String, ObjectStorageError> {
         let format = ObjectStoreFormat {
             created_at: Local::now().to_rfc3339(),
@@ -169,6 +171,7 @@ pub trait ObjectStorage: Debug + Send + Sync + 'static {
                 id: CONFIG.parseable.username.clone(),
                 group: CONFIG.parseable.username.clone(),
             },
+            log_source,
             ..Default::default()
         };
         let format_json = to_bytes(&format);


### PR DESCRIPTION
add additional header `X-P-Log-Source` to stream creation 
for otel logs ingestion using API `POST /v1/logs`, server adds `log_source=OtelLogs` to the stream info 
which can be verified using API `GET /logstream/{logstream}/info`

similarly, for otel metrics, `log_source=OtelMetricsLogs` 
and for otel traces, `log_source=OtelTraces` is added to the stream info 
server adds `log_souce=Json` for stream with unknown log source value 
or for the stream without the log souce header

