### PR TITLE
feat: API for date_bin query

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,7 +23,8 @@ use url::Url;
 
 use crate::{
     oidc::{self, OpenidConfig},
-    option::{validation, Compression, Mode}, storage::{AzureBlobConfig, FSConfig, S3Config},
+    option::{validation, Compression, Mode},
+    storage::{AzureBlobConfig, FSConfig, S3Config},
 };
 
 #[cfg(any(
@@ -42,7 +43,6 @@ use std::string::String as KafkaSslProtocol;
 /// NOTE: obviously not recommended for production
 pub const DEFAULT_USERNAME: &str = "admin";
 pub const DEFAULT_PASSWORD: &str = "admin";
-
 
 #[derive(Parser)]
 #[command(
@@ -81,11 +81,11 @@ pub struct Cli {
 #[derive(Parser)]
 pub enum StorageOptions {
     #[command(name = "local-store")]
-     Local(LocalStoreArgs),
-    
+    Local(LocalStoreArgs),
+
     #[command(name = "s3-store")]
     S3(S3StoreArgs),
-    
+
     #[command(name = "blob-store")]
     Blob(BlobStoreArgs),
 }
@@ -125,7 +125,7 @@ pub struct Options {
 
     // Server configuration
     #[arg(
-        long, 
+        long,
         env = "P_ADDR", 
         default_value = "0.0.0.0:8000",
         value_parser = validation::socket_addr,
@@ -381,13 +381,13 @@ pub struct Options {
     )]
     pub audit_logger: Option<Url>,
 
-    #[arg(long ,env = "P_AUDIT_USERNAME", help = "Audit logger username")]
+    #[arg(long, env = "P_AUDIT_USERNAME", help = "Audit logger username")]
     pub audit_username: Option<String>,
 
-    #[arg(long ,env = "P_AUDIT_PASSWORD", help = "Audit logger password")]
+    #[arg(long, env = "P_AUDIT_PASSWORD", help = "Audit logger password")]
     pub audit_password: Option<String>,
 
-    #[arg(long ,env = "P_MS_CLARITY_TAG", help = "Tag for MS Clarity")]
+    #[arg(long, env = "P_MS_CLARITY_TAG", help = "Tag for MS Clarity")]
     pub ms_clarity_tag: Option<String>,
 }
 
@@ -405,7 +405,11 @@ impl Options {
     }
 
     pub fn openid(&self) -> Option<OpenidConfig> {
-        match (&self.oidc_client_id, &self.oidc_client_secret, &self.oidc_issuer) {
+        match (
+            &self.oidc_client_id,
+            &self.oidc_client_secret,
+            &self.oidc_issuer,
+        ) {
             (Some(id), Some(secret), Some(issuer)) => {
                 let origin = if let Some(url) = self.domain_address.clone() {
                     oidc::Origin::Production(url)

--- a/src/handlers/http/modal/query_server.rs
+++ b/src/handlers/http/modal/query_server.rs
@@ -52,6 +52,7 @@ impl ParseableServer for QueryServer {
         config
             .service(
                 web::scope(&base_path())
+                    .service(Server::get_date_bin())
                     .service(Server::get_correlation_webscope())
                     .service(Server::get_query_factory())
                     .service(Server::get_liveness_factory())

--- a/src/handlers/http/modal/server.rs
+++ b/src/handlers/http/modal/server.rs
@@ -80,6 +80,7 @@ impl ParseableServer for Server {
                     .service(Self::get_llm_webscope())
                     .service(Self::get_oauth_webscope(oidc_client))
                     .service(Self::get_user_role_webscope())
+                    .service(Self::get_date_bin())
                     .service(Self::get_metrics_webscope()),
             )
             .service(Self::get_ingest_otel_factory())
@@ -265,6 +266,10 @@ impl Server {
                             .authorize(Action::CreateFilter),
                     ),
             )
+    }
+    pub fn get_date_bin() -> Resource {
+        web::resource("/datebin").route(web::post().to(query::get_date_bin).authorize(Action::Query)
+    )
     }
 
     // get the query factory

--- a/src/handlers/http/modal/server.rs
+++ b/src/handlers/http/modal/server.rs
@@ -268,8 +268,8 @@ impl Server {
             )
     }
     pub fn get_date_bin() -> Resource {
-        web::resource("/datebin").route(web::post().to(query::get_date_bin).authorize(Action::Query)
-    )
+        web::resource("/datebin")
+            .route(web::post().to(query::get_date_bin).authorize(Action::Query))
     }
 
     // get the query factory

--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -230,25 +230,23 @@ fn is_logical_plan_aggregate_without_filters(plan: &LogicalPlan) -> (bool, Strin
     match plan {
         LogicalPlan::Projection(Projection { input, expr, .. }) => {
             if let LogicalPlan::Aggregate(Aggregate { input, .. }) = &**input {
-                if let LogicalPlan::TableScan { .. } = &**input {
-                    if expr.len() == 1 {
-                        return match &expr[0] {
-                            Expr::Column(Column { name, .. }) => (name == "count(*)", name.clone()),
-                            Expr::Alias(Alias {
-                                expr: inner_expr,
-                                name,
-                                ..
-                            }) => {
-                                let alias_name = name;
-                                if let Expr::Column(Column { name, .. }) = &**inner_expr {
-                                    (name == "count(*)", alias_name.to_string())
-                                } else {
-                                    (false, "".to_string())
-                                }
+                if matches!(&**input, LogicalPlan::TableScan { .. }) && expr.len() == 1 {
+                    return match &expr[0] {
+                        Expr::Column(Column { name, .. }) => (name == "count(*)", name.clone()),
+                        Expr::Alias(Alias {
+                            expr: inner_expr,
+                            name,
+                            ..
+                        }) => {
+                            let alias_name = name;
+                            if let Expr::Column(Column { name, .. }) = &**inner_expr {
+                                (name == "count(*)", alias_name.to_string())
+                            } else {
+                                (false, "".to_string())
                             }
-                            _ => (false, "".to_string()),
-                        };
-                    }
+                        }
+                        _ => (false, "".to_string()),
+                    };
                 }
             }
         }

--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -41,7 +41,7 @@ use crate::event::commit_schema;
 use crate::metrics::QUERY_EXECUTE_TIME;
 use crate::option::{Mode, CONFIG};
 use crate::query::error::ExecuteError;
-use crate::query::{DateBinRecord, DateBinRequest, Query as LogicalQuery};
+use crate::query::{DateBinRequest, DateBinResponse, Query as LogicalQuery};
 use crate::query::{TableScanVisitor, QUERY_SESSION};
 use crate::rbac::Users;
 use crate::response::QueryResponse;
@@ -66,12 +66,6 @@ pub struct Query {
     pub fields: bool,
     #[serde(skip)]
     pub filter_tags: Option<Vec<String>>,
-}
-/// DateBin Response.
-#[derive(Debug, Serialize, Clone)]
-pub struct DateBinResponse {
-    pub fields: Vec<String>,
-    pub records: Vec<DateBinRecord>,
 }
 
 pub async fn query(req: HttpRequest, query_request: Query) -> Result<HttpResponse, QueryError> {

--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -177,17 +177,17 @@ pub async fn query(req: HttpRequest, query_request: Query) -> Result<HttpRespons
     Ok(response)
 }
 
-pub async fn get_date_bin(req: HttpRequest, body: Bytes) -> Result<impl Responder, QueryError> {
-    let date_bin_request: DateBin =
-        serde_json::from_slice(&body).map_err(|err| anyhow::Error::msg(err.to_string()))?;
-
+pub async fn get_date_bin(
+    req: HttpRequest,
+    date_bin: Json<DateBinRequest>,
+) -> Result<impl Responder, QueryError> {
     let creds = extract_session_key_from_req(&req)?;
     let permissions = Users.get_permissions(&creds);
 
     // does user have access to table?
-    user_auth_for_query(&permissions, &[date_bin_request.stream.clone()])?;
+    user_auth_for_query(&permissions, &[date_bin.stream.clone()])?;
 
-    let date_bin_records = date_bin_request.get_bin_density().await?;
+    let date_bin_records = date_bin.get_bin_density().await?;
 
     Ok(web::Json(DateBinResponse {
         fields: vec!["date_bin_timestamp".into(), "log_count".into()],

--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -100,8 +100,10 @@ pub async fn query(req: HttpRequest, query_request: Query) -> Result<HttpRespons
     let table_name = query
         .first_table_name()
         .ok_or_else(|| QueryError::MalformedQuery("No table name found in query"))?;
-    let time = Instant::now();
 
+    user_auth_for_query(&permissions, &tables)?;
+
+    let time = Instant::now();
     if let Some(column_name) = query.is_logical_plan_count_without_filters() {
         let date_bin_request = DateBinRequest {
             stream: table_name.clone(),
@@ -127,9 +129,6 @@ pub async fn query(req: HttpRequest, query_request: Query) -> Result<HttpRespons
 
         return Ok(HttpResponse::Ok().json(response));
     }
-
-    user_auth_for_query(&permissions, &tables)?;
-
     let (records, fields) = query.execute(table_name.clone()).await?;
 
     let response = QueryResponse {

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -311,14 +311,14 @@ impl DateBin {
         if have_remainder {
             final_date_bins.push([
                 PartialTimeFilter::Low(Bound::Included(start.naive_utc())),
-                PartialTimeFilter::High(Bound::Included(
+                PartialTimeFilter::High(Bound::Excluded(
                     (start + Duration::minutes(remainder)).naive_utc(),
                 )),
             ]);
         } else {
             final_date_bins.push([
                 PartialTimeFilter::Low(Bound::Included(start.naive_utc())),
-                PartialTimeFilter::High(Bound::Included(
+                PartialTimeFilter::High(Bound::Excluded(
                     (start + Duration::minutes(quotient)).naive_utc(),
                 )),
             ]);

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -338,8 +338,8 @@ impl DateBinRequest {
             .num_minutes() as u64;
 
         // divide minutes by num bins to get minutes per bin
-        let quotient = (total_minutes / self.num_bins) as i64;
-        let remainder = (total_minutes % self.num_bins) as i64;
+        let quotient = total_minutes / self.num_bins;
+        let remainder = total_minutes % self.num_bins;
         let have_remainder = remainder > 0;
 
         // now create multiple bins [startTime, endTime)
@@ -355,7 +355,7 @@ impl DateBinRequest {
         };
 
         for _ in 0..loop_end {
-            let bin_end = start + Duration::minutes(quotient);
+            let bin_end = start + Duration::minutes(quotient as i64);
             final_date_bins.push([
                 PartialTimeFilter::Low(Bound::Included(start.naive_utc())),
                 PartialTimeFilter::High(Bound::Excluded(bin_end.naive_utc())),
@@ -371,14 +371,14 @@ impl DateBinRequest {
             final_date_bins.push([
                 PartialTimeFilter::Low(Bound::Included(start.naive_utc())),
                 PartialTimeFilter::High(Bound::Excluded(
-                    (start + Duration::minutes(remainder)).naive_utc(),
+                    (start + Duration::minutes(remainder as i64)).naive_utc(),
                 )),
             ]);
         } else {
             final_date_bins.push([
                 PartialTimeFilter::Low(Bound::Included(start.naive_utc())),
                 PartialTimeFilter::High(Bound::Excluded(
-                    (start + Duration::minutes(quotient)).naive_utc(),
+                    (start + Duration::minutes(quotient as i64)).naive_utc(),
                 )),
             ]);
         }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -387,6 +387,13 @@ impl DateBinRequest {
     }
 }
 
+/// DateBin Response.
+#[derive(Debug, Serialize, Clone)]
+pub struct DateBinResponse {
+    pub fields: Vec<String>,
+    pub records: Vec<DateBinRecord>,
+}
+
 #[derive(Debug, Default)]
 pub(crate) struct TableScanVisitor {
     tables: Vec<String>,

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -33,6 +33,7 @@ use datafusion::prelude::*;
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use relative_path::RelativePathBuf;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::ops::Bound;
@@ -48,7 +49,7 @@ use crate::catalog::manifest::Manifest;
 use crate::catalog::snapshot::Snapshot;
 use crate::catalog::Snapshot as CatalogSnapshot;
 use crate::event;
-use crate::handlers::http::query::{DateBin, DateBinRecord, QueryError};
+use crate::handlers::http::query::QueryError;
 use crate::metadata::STREAM_INFO;
 use crate::option::{Mode, CONFIG};
 use crate::storage::{ObjectStorageProvider, ObjectStoreFormat, StorageDir, STREAM_ROOT_DIRECTORY};
@@ -201,7 +202,24 @@ impl Query {
     }
 }
 
-impl DateBin {
+/// DateBinRecord
+#[derive(Debug, Serialize, Clone)]
+pub struct DateBinRecord {
+    pub date_bin_timestamp: String,
+    pub log_count: u64,
+}
+
+/// DateBin Request.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DateBinRequest {
+    pub stream: String,
+    pub start_time: String,
+    pub end_time: String,
+    pub num_bins: u64,
+}
+
+impl DateBinRequest {
     /// This function is supposed to read maninfest files for the given stream,
     /// get the sum of `num_rows` between the `startTime` and `endTime`,
     /// divide that by number of bins and return in a manner acceptable for the console

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -209,14 +209,11 @@ impl DateBin {
         let time_partition = STREAM_INFO
             .get_time_partition(&self.stream.clone())
             .map_err(|err| anyhow::Error::msg(err.to_string()))?
-            .unwrap_or(event::DEFAULT_TIMESTAMP_KEY.to_owned());
+            .unwrap_or_else(|| event::DEFAULT_TIMESTAMP_KEY.to_owned());
 
         // get time range
         let time_range = TimeRange::parse_human_time(&self.start_time, &self.end_time)?;
         let all_manifest_files = get_manifest_list(&self.stream, &time_range).await?;
-        if time_range.start > time_range.end {
-            todo!()
-        }
         // get final date bins
         let final_date_bins = self.get_bins(&time_range);
 
@@ -383,7 +380,7 @@ pub async fn get_manifest_list(
     let mut merged_snapshot: Snapshot = Snapshot::default();
 
     // get a list of manifests
-    if CONFIG.parseable.mode == Mode::Query {
+    if CONFIG.options.mode == Mode::Query {
         let path = RelativePathBuf::from_iter([stream_name, STREAM_ROOT_DIRECTORY]);
         let obs = glob_storage
             .get_objects(

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -32,28 +32,27 @@ use datafusion::logical_expr::{Explain, Filter, LogicalPlan, PlanType, ToStringi
 use datafusion::prelude::*;
 use itertools::Itertools;
 use once_cell::sync::Lazy;
-use tracing::warn;
-use crate::catalog::snapshot::Snapshot;
-use crate::catalog::Snapshot as _;
 use relative_path::RelativePathBuf;
 use serde_json::{json, Value};
-use stream_schema_provider::collect_manifest_files;
 use std::collections::HashMap;
 use std::ops::Bound;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use stream_schema_provider::collect_manifest_files;
 use sysinfo::System;
 
 use self::error::ExecuteError;
 use self::stream_schema_provider::GlobalSchemaProvider;
 pub use self::stream_schema_provider::PartialTimeFilter;
+use crate::catalog::manifest::Manifest;
+use crate::catalog::snapshot::Snapshot;
+use crate::catalog::Snapshot as CatalogSnapshot;
 use crate::event;
 use crate::handlers::http::query::{DateBin, DateBinRecord, QueryError};
 use crate::metadata::STREAM_INFO;
 use crate::option::{Mode, CONFIG};
 use crate::storage::{ObjectStorageProvider, ObjectStoreFormat, StorageDir, STREAM_ROOT_DIRECTORY};
 use crate::utils::time::TimeRange;
-
 pub static QUERY_SESSION: Lazy<SessionContext> =
     Lazy::new(|| Query::create_session_context(CONFIG.storage()));
 
@@ -207,85 +206,19 @@ impl DateBin {
     /// get the sum of `num_rows` between the `startTime` and `endTime`,
     /// divide that by number of bins and return in a manner acceptable for the console
     pub async fn get_bin_density(&self) -> Result<Vec<DateBinRecord>, QueryError> {
-        let time_partition = STREAM_INFO.get_time_partition(&self.stream)
-            .map_err(|err|anyhow::Error::msg(err.to_string()))?
+        let time_partition = STREAM_INFO
+            .get_time_partition(&self.stream.clone())
+            .map_err(|err| anyhow::Error::msg(err.to_string()))?
             .unwrap_or(event::DEFAULT_TIMESTAMP_KEY.to_owned());
-
-        let glob_storage = CONFIG.storage().get_object_store();
-
-        let object_store = QUERY_SESSION.state()
-            .runtime_env()
-            .object_store_registry
-            .get_store(&glob_storage.store_url())
-            .unwrap();
 
         // get time range
         let time_range = TimeRange::parse_human_time(&self.start_time, &self.end_time)?;
-
+        let all_manifest_files = get_manifest_list(&self.stream, &time_range).await?;
         if time_range.start > time_range.end {
             todo!()
         }
-
-        // get object store
-        let object_store_format = glob_storage
-            .get_object_store_format(&self.stream)
-            .await
-            .map_err(|err| DataFusionError::Plan(err.to_string()))?;
-
-        // all the manifests will go here
-        let mut merged_snapshot: Snapshot = Snapshot::default();
-        
-        // get a list of manifests
-        if CONFIG.parseable.mode == Mode::Query {
-            let path = RelativePathBuf::from_iter([&self.stream, STREAM_ROOT_DIRECTORY]);
-            let obs = glob_storage
-                .get_objects(
-                    Some(&path),
-                    Box::new(|file_name| file_name.ends_with("stream.json")),
-                )
-                .await;
-            if let Ok(obs) = obs {
-                for ob in obs {
-                    if let Ok(object_store_format) =
-                        serde_json::from_slice::<ObjectStoreFormat>(&ob)
-                    {
-                        let snapshot = object_store_format.snapshot;
-                        for manifest in snapshot.manifest_list {
-                            merged_snapshot.manifest_list.push(manifest);
-                        }
-                    }
-                }
-            }
-        } else {
-            merged_snapshot = object_store_format.snapshot;
-        }
-
         // get final date bins
         let final_date_bins = self.get_bins(&time_range);
-
-        // Download all the manifest files
-        let time_filter = [
-            PartialTimeFilter::Low(
-                Bound::Included(time_range.start.naive_utc())
-            ),
-            PartialTimeFilter::High(
-                Bound::Included(time_range.end.naive_utc())
-            )
-        ];
-
-        let start = Utc::now();
-        let all_manifest_files = collect_manifest_files(
-            object_store,
-            merged_snapshot.manifests(&time_filter)
-                .into_iter()
-                .sorted_by_key(|file| file.time_lower_bound)
-                .map(|item| item.manifest_path)
-                .collect(),
-        )
-        .await
-        .map_err(|err|anyhow::Error::msg(err.to_string()))?;
-        let end = Utc::now();
-        warn!("time taken fetch menifest files- {:?}",end.signed_duration_since(start));
 
         // we have start and end times for each bin
         // we also have all the manifest files for the given time range
@@ -294,109 +227,58 @@ impl DateBin {
         // we sum up the num_rows
         let mut date_bin_records = Vec::new();
 
-        let start = Utc::now();
         for bin in final_date_bins {
-            // warn!("bin-\n{bin:?}\n");
             let date_bin_timestamp = match &bin[0] {
-                PartialTimeFilter::Low(bound) => {
-                    match bound {
-                        Bound::Included(ts) => ts.and_utc().timestamp_millis(),
-                        _ => unreachable!()
-                    }
-                },
-                _ => unreachable!()
+                PartialTimeFilter::Low(Bound::Included(ts)) => ts.and_utc().timestamp_millis(),
+                _ => unreachable!(),
             };
 
             // extract start and end time to compare
             let bin_start = match &bin[0] {
-                PartialTimeFilter::Low(bound) => {
-                    match bound {
-                        Bound::Included(ts) => ts,
-                        _ => unreachable!()
-                    }
-                },
-                _ => unreachable!()
+                PartialTimeFilter::Low(Bound::Included(ts)) => ts,
+                _ => unreachable!(),
             };
             let bin_end = match &bin[1] {
-                PartialTimeFilter::High(bound) => {
-                    match bound {
-                        Bound::Included(ts)|
-                        Bound::Excluded(ts) => ts,
-                        _ => unreachable!()
-                    }
-                },
-                _ => unreachable!()
+                PartialTimeFilter::High(Bound::Included(ts) | Bound::Excluded(ts)) => ts,
+                _ => unreachable!(),
             };
 
-            let manifests_for_time_range = merged_snapshot.manifests(&bin);
-            // warn!("manifests_for_time_range-\n{manifests_for_time_range:?}\n");
-
-            let total_num_rows = all_manifest_files
+            let total_num_rows: u64 = all_manifest_files
                 .iter()
-                .map(|m| {
-                    m.files
-                        .iter()
-                        .filter(|f| {
-                            let mut default = false;
-                            // warn!("Entering new file with num_rows- {}\n",f.num_rows);
-                            for c in &f.columns {
-                                default = if c.name == time_partition {
-                                    match &c.stats {
-                                        Some(stats) => {
-                                            match stats {
-                                                crate::catalog::column::TypedStatistics::Int(int64_type) => {
-                                                    let min = DateTime::from_timestamp_millis(int64_type.min).unwrap().naive_utc();
-                                                    let max = DateTime::from_timestamp_millis(int64_type.max).unwrap().naive_utc();
-                                                    
-                                                    if (bin_start <= &min) && (bin_end >= &min) {
-                                                        // warn!("true for\nmin- {min:?}\nmax- {max:?}\n");
-                                                        true
-                                                    } else {
-                                                        // warn!("false for\nmin- {min:?}\nmax- {max:?}\n");
-                                                        false
-                                                    }
-                                                },
-                                                _ => false
-                                            }
-                                        },
-                                        None => false,
-                                    }
-                                } else {
-                                    default
-                                };
-                                if default {
-                                    break
+                .flat_map(|m| &m.files)
+                .filter(|f| {
+                    f.columns.iter().any(|c| {
+                        c.name == time_partition
+                            && match &c.stats {
+                                Some(crate::catalog::column::TypedStatistics::Int(int64_type)) => {
+                                    let min = DateTime::from_timestamp_millis(int64_type.min)
+                                        .unwrap()
+                                        .naive_utc();
+                                    bin_start <= &min && bin_end >= &min
                                 }
+                                _ => false,
                             }
-                            default
-                        })
-                        .map(|f|f.num_rows)
-                        .sum::<u64>()
+                    })
                 })
-                .sum::<u64>();
-            
-            date_bin_records.push(
-                DateBinRecord{
-                    date_bin_timestamp: DateTime::from_timestamp_millis(date_bin_timestamp).unwrap().to_rfc3339(),
-                    log_count: total_num_rows,
-                }
-            );
-            // warn!("\ntotal_num_rows- {total_num_rows}");
+                .map(|f| f.num_rows)
+                .sum();
+
+            date_bin_records.push(DateBinRecord {
+                date_bin_timestamp: DateTime::from_timestamp_millis(date_bin_timestamp)
+                    .unwrap()
+                    .to_rfc3339(),
+                log_count: total_num_rows,
+            });
         }
-        let end = Utc::now();
-        warn!("time taken by for loop- {:?}",end.signed_duration_since(start));
-
-        let min = 1736063097889;
-        let max = 1736063100024;
-        warn!("p_timestamp\nmin- {:?}\nmax- {:?}", DateTime::from_timestamp_millis(min),DateTime::from_timestamp_millis(max));
-
         Ok(date_bin_records)
     }
 
     /// calculate the endTime for each bin based on num bins
-    fn get_bins(&self, time_range: &TimeRange) -> Vec<[PartialTimeFilter; 2]> {        
+    fn get_bins(&self, time_range: &TimeRange) -> Vec<[PartialTimeFilter; 2]> {
         // get total minutes elapsed between start and end time
-        let total_minutes = time_range.end.signed_duration_since(time_range.start)
+        let total_minutes = time_range
+            .end
+            .signed_duration_since(time_range.start)
             .num_minutes() as u64;
 
         // divide minutes by num bins to get minutes per bin
@@ -404,15 +286,12 @@ impl DateBin {
         let remainder = (total_minutes % self.num_bins) as i64;
         let have_remainder = remainder > 0;
 
-        warn!("get_bins");
-        warn!("quotient- {quotient}\nremainder- {remainder}\n");
-
         // now create multiple bins [startTime, endTime)
         // Should we exclude the last one???
         let mut final_date_bins = vec![];
-        
+
         let mut start = time_range.start;
-        
+
         let loop_end = if have_remainder {
             self.num_bins
         } else {
@@ -422,12 +301,8 @@ impl DateBin {
         for _ in 0..loop_end {
             let bin_end = start + Duration::minutes(quotient);
             final_date_bins.push([
-                PartialTimeFilter::Low(
-                    Bound::Included(start.naive_utc())
-                ),
-                PartialTimeFilter::High(
-                    Bound::Excluded(bin_end.naive_utc())
-                )
+                PartialTimeFilter::Low(Bound::Included(start.naive_utc())),
+                PartialTimeFilter::High(Bound::Excluded(bin_end.naive_utc())),
             ]);
 
             start = bin_end;
@@ -438,27 +313,22 @@ impl DateBin {
         // else it will be as long as the quotient
         if have_remainder {
             final_date_bins.push([
-                PartialTimeFilter::Low(
-                    Bound::Included(start.naive_utc())
-                ),
-                PartialTimeFilter::High(
-                    Bound::Included((start + Duration::minutes(remainder)).naive_utc())
-                )
+                PartialTimeFilter::Low(Bound::Included(start.naive_utc())),
+                PartialTimeFilter::High(Bound::Included(
+                    (start + Duration::minutes(remainder)).naive_utc(),
+                )),
             ]);
         } else {
             final_date_bins.push([
-                PartialTimeFilter::Low(
-                    Bound::Included(start.naive_utc())
-                ),
-                PartialTimeFilter::High(
-                    Bound::Included((start + Duration::minutes(quotient)).naive_utc())
-                )
+                PartialTimeFilter::Low(Bound::Included(start.naive_utc())),
+                PartialTimeFilter::High(Bound::Included(
+                    (start + Duration::minutes(quotient)).naive_utc(),
+                )),
             ]);
         }
-        
-        final_date_bins
-    } 
 
+        final_date_bins
+    }
 }
 
 #[derive(Debug, Default)]
@@ -488,6 +358,72 @@ impl TreeNodeVisitor<'_> for TableScanVisitor {
             _ => Ok(TreeNodeRecursion::Continue),
         }
     }
+}
+
+pub async fn get_manifest_list(
+    stream_name: &str,
+    time_range: &TimeRange,
+) -> Result<Vec<Manifest>, QueryError> {
+    let glob_storage = CONFIG.storage().get_object_store();
+
+    let object_store = QUERY_SESSION
+        .state()
+        .runtime_env()
+        .object_store_registry
+        .get_store(&glob_storage.store_url())
+        .unwrap();
+
+    // get object store
+    let object_store_format = glob_storage
+        .get_object_store_format(stream_name)
+        .await
+        .map_err(|err| DataFusionError::Plan(err.to_string()))?;
+
+    // all the manifests will go here
+    let mut merged_snapshot: Snapshot = Snapshot::default();
+
+    // get a list of manifests
+    if CONFIG.parseable.mode == Mode::Query {
+        let path = RelativePathBuf::from_iter([stream_name, STREAM_ROOT_DIRECTORY]);
+        let obs = glob_storage
+            .get_objects(
+                Some(&path),
+                Box::new(|file_name| file_name.ends_with("stream.json")),
+            )
+            .await;
+        if let Ok(obs) = obs {
+            for ob in obs {
+                if let Ok(object_store_format) = serde_json::from_slice::<ObjectStoreFormat>(&ob) {
+                    let snapshot = object_store_format.snapshot;
+                    for manifest in snapshot.manifest_list {
+                        merged_snapshot.manifest_list.push(manifest);
+                    }
+                }
+            }
+        }
+    } else {
+        merged_snapshot = object_store_format.snapshot;
+    }
+
+    // Download all the manifest files
+    let time_filter = [
+        PartialTimeFilter::Low(Bound::Included(time_range.start.naive_utc())),
+        PartialTimeFilter::High(Bound::Included(time_range.end.naive_utc())),
+    ];
+
+    let all_manifest_files = collect_manifest_files(
+        object_store,
+        merged_snapshot
+            .manifests(&time_filter)
+            .into_iter()
+            .sorted_by_key(|file| file.time_lower_bound)
+            .map(|item| item.manifest_path)
+            .collect(),
+    )
+    .await
+    .map_err(|err| anyhow::Error::msg(err.to_string()))?;
+
+    Ok(all_manifest_files)
 }
 
 fn transform(

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -217,14 +217,14 @@ impl Query {
         };
 
         // Ensure the input of the Aggregate is a TableScan and there is exactly one expression: SELECT COUNT(*)
-        if !matches!(&**input, LogicalPlan::TableScan { .. }) || expr.len() == 1 {
+        if !matches!(&**input, LogicalPlan::TableScan { .. }) || expr.len() != 1 {
             return None;
         }
 
         // Check if the expression is a column or an alias for COUNT(*)
         match &expr[0] {
             // Direct column check
-            Expr::Column(Column { name, .. }) if name == "count(*)" => Some(name),
+            Expr::Column(Column { name, .. }) if name.to_lowercase() == "count(*)" => Some(name),
             // Alias for COUNT(*)
             Expr::Alias(Alias {
                 expr: inner_expr,
@@ -232,7 +232,7 @@ impl Query {
                 ..
             }) => {
                 if let Expr::Column(Column { name, .. }) = &**inner_expr {
-                    if name == "count(*)" {
+                    if name.to_lowercase() == "count(*)" {
                         return Some(alias_name);
                     }
                 }

--- a/src/query/stream_schema_provider.rs
+++ b/src/query/stream_schema_provider.rs
@@ -799,7 +799,7 @@ fn extract_timestamp_bound(
     }
 }
 
-async fn collect_manifest_files(
+pub async fn collect_manifest_files(
     storage: Arc<dyn ObjectStore>,
     manifest_urls: Vec<String>,
 ) -> Result<Vec<Manifest>, object_store::Error> {

--- a/src/response.rs
+++ b/src/response.rs
@@ -23,7 +23,7 @@ use crate::{
         record_batches_to_json,
     },
 };
-use actix_web::{web, Responder};
+use actix_web::HttpResponse;
 use datafusion::arrow::record_batch::RecordBatch;
 use itertools::Itertools;
 use serde_json::{json, Value};
@@ -38,7 +38,7 @@ pub struct QueryResponse {
 }
 
 impl QueryResponse {
-    pub fn to_http(&self) -> Result<impl Responder, QueryError> {
+    pub fn to_http(&self) -> Result<HttpResponse, QueryError> {
         info!("{}", "Returning query results");
         let records: Vec<&RecordBatch> = self.records.iter().collect();
         let mut json_records = record_batches_to_json(&records)?;
@@ -63,7 +63,7 @@ impl QueryResponse {
             Value::Array(values)
         };
 
-        Ok(web::Json(response))
+        Ok(HttpResponse::Ok().json(response))
     }
 
     #[allow(dead_code)]


### PR DESCRIPTION
new API to get the count(*) for the graph query
API - POST `/datebin`
sample request JSON -
```{"stream":"frontend", "startTime":"2025-01-08T10:10:00.000Z","endTime":"2026-01-08T23:20:00.000Z", "numBins":10}```
sample response JSON -
```
{
    "fields": [
        "date_bin_timestamp",
        "log_count"
    ],
    "records": [
        {
            "date_bin_timestamp": "2025-01-08T10:10:00+00:00",
            "log_count": 1250
        }
    ]
}
```
console sends the number of ticks to show in the graph based on the time range provided by the user
server fetches the stream.json and all manifest.jsons to get the count
avoid datafusion as query demands the count which is available in the catalog

leverage the same flow to get the count(*) queries without filters from query API
eg. `select count(*) from frontend` or `select count(*) as count from frontend`