### PR TITLE
feat: rename API `datebin` to `counts`

### DIFF
--- a/src/handlers/http/modal/query_server.rs
+++ b/src/handlers/http/modal/query_server.rs
@@ -52,7 +52,6 @@ impl ParseableServer for QueryServer {
         config
             .service(
                 web::scope(&base_path())
-                    .service(Server::get_date_bin())
                     .service(Server::get_correlation_webscope())
                     .service(Server::get_query_factory())
                     .service(Server::get_liveness_factory())
@@ -65,6 +64,7 @@ impl ParseableServer for QueryServer {
                     .service(Server::get_llm_webscope())
                     .service(Server::get_oauth_webscope(oidc_client))
                     .service(Self::get_user_role_webscope())
+                    .service(Server::get_counts_webscope())
                     .service(Server::get_metrics_webscope())
                     .service(Self::get_cluster_web_scope()),
             )

--- a/src/handlers/http/modal/server.rs
+++ b/src/handlers/http/modal/server.rs
@@ -80,7 +80,7 @@ impl ParseableServer for Server {
                     .service(Self::get_llm_webscope())
                     .service(Self::get_oauth_webscope(oidc_client))
                     .service(Self::get_user_role_webscope())
-                    .service(Self::get_date_bin())
+                    .service(Self::get_counts_webscope())
                     .service(Self::get_metrics_webscope()),
             )
             .service(Self::get_ingest_otel_factory())
@@ -267,9 +267,8 @@ impl Server {
                     ),
             )
     }
-    pub fn get_date_bin() -> Resource {
-        web::resource("/datebin")
-            .route(web::post().to(query::get_date_bin).authorize(Action::Query))
+    pub fn get_counts_webscope() -> Resource {
+        web::resource("/counts").route(web::post().to(query::get_counts).authorize(Action::Query))
     }
 
     // get the query factory

--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -104,6 +104,7 @@ pub async fn query(req: HttpRequest, query_request: Query) -> Result<HttpRespons
     user_auth_for_query(&permissions, &tables)?;
 
     let time = Instant::now();
+    // Intercept `count(*)`` queries and use the counts API
     if let Some(column_name) = query.is_logical_plan_count_without_filters() {
         let counts_req = CountsRequest {
             stream: table_name.clone(),

--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -41,7 +41,7 @@ use crate::event::commit_schema;
 use crate::metrics::QUERY_EXECUTE_TIME;
 use crate::option::{Mode, CONFIG};
 use crate::query::error::ExecuteError;
-use crate::query::{DateBinRequest, DateBinResponse, Query as LogicalQuery};
+use crate::query::{CountsRequest, CountsResponse, Query as LogicalQuery};
 use crate::query::{TableScanVisitor, QUERY_SESSION};
 use crate::rbac::Users;
 use crate::response::QueryResponse;
@@ -105,20 +105,20 @@ pub async fn query(req: HttpRequest, query_request: Query) -> Result<HttpRespons
 
     let time = Instant::now();
     if let Some(column_name) = query.is_logical_plan_count_without_filters() {
-        let date_bin_request = DateBinRequest {
+        let counts_req = CountsRequest {
             stream: table_name.clone(),
             start_time: query_request.start_time.clone(),
             end_time: query_request.end_time.clone(),
             num_bins: 1,
         };
-        let date_bin_records = date_bin_request.get_bin_density().await?;
+        let count_records = counts_req.get_bin_density().await?;
         let response = if query_request.fields {
             json!({
                 "fields": vec![&column_name],
-                "records": vec![json!({column_name: date_bin_records[0].log_count})]
+                "records": vec![json!({column_name: count_records[0].log_count})]
             })
         } else {
-            Value::Array(vec![json!({column_name: date_bin_records[0].log_count})])
+            Value::Array(vec![json!({column_name: count_records[0].log_count})])
         };
 
         let time = time.elapsed().as_secs_f64();
@@ -148,21 +148,21 @@ pub async fn query(req: HttpRequest, query_request: Query) -> Result<HttpRespons
     Ok(response)
 }
 
-pub async fn get_date_bin(
+pub async fn get_counts(
     req: HttpRequest,
-    date_bin: Json<DateBinRequest>,
+    counts_request: Json<CountsRequest>,
 ) -> Result<impl Responder, QueryError> {
     let creds = extract_session_key_from_req(&req)?;
     let permissions = Users.get_permissions(&creds);
 
     // does user have access to table?
-    user_auth_for_query(&permissions, &[date_bin.stream.clone()])?;
+    user_auth_for_query(&permissions, &[counts_request.stream.clone()])?;
 
-    let date_bin_records = date_bin.get_bin_density().await?;
+    let count_records = counts_request.get_bin_density().await?;
 
-    Ok(web::Json(DateBinResponse {
-        fields: vec!["date_bin_timestamp".into(), "log_count".into()],
-        records: date_bin_records,
+    Ok(web::Json(CountsResponse {
+        fields: vec!["counts_timestamp".into(), "log_count".into()],
+        records: count_records,
     }))
 }
 

--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -159,11 +159,11 @@ pub async fn get_counts(
     // does user have access to table?
     user_auth_for_query(&permissions, &[counts_request.stream.clone()])?;
 
-    let count_records = counts_request.get_bin_density().await?;
+    let records = counts_request.get_bin_density().await?;
 
     Ok(web::Json(CountsResponse {
         fields: vec!["counts_timestamp".into(), "log_count".into()],
-        records: count_records,
+        records,
     }))
 }
 

--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -113,13 +113,15 @@ pub async fn query(req: HttpRequest, query_request: Query) -> Result<HttpRespons
             num_bins: 1,
         };
         let count_records = counts_req.get_bin_density().await?;
+        // NOTE: this should not panic, since there is atleast one bin, always
+        let log_count = count_records[0].log_count;
         let response = if query_request.fields {
             json!({
-                "fields": vec![&column_name],
-                "records": vec![json!({column_name: count_records[0].log_count})]
+                "fields": [&column_name],
+                "records": [json!({column_name: log_count})]
             })
         } else {
-            Value::Array(vec![json!({column_name: count_records[0].log_count})])
+            Value::Array(vec![json!({column_name: log_count})])
         };
 
         let time = time.elapsed().as_secs_f64();


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

It makes more sense to call it what it is, an API to figure out the count of logs in a certain time period, at a certain frequency. Previously it was called `datebins` when it didn't really adhere to the time limits associated with a "date", which is semantically wrong.

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
