### PR TITLE
fix: correlations CRUD operations

### DIFF
--- a/src/handlers/http/correlation.rs
+++ b/src/handlers/http/correlation.rs
@@ -17,25 +17,27 @@
  */
 
 use actix_web::{web, HttpRequest, HttpResponse, Responder};
+use anyhow::Error;
 use bytes::Bytes;
 use itertools::Itertools;
-use relative_path::RelativePathBuf;
 
 use crate::rbac::Users;
-use crate::utils::user_auth_for_query;
-use crate::{
-    option::CONFIG, storage::CORRELATIONS_ROOT_DIRECTORY,
-    utils::actix::extract_session_key_from_req,
-};
+use crate::storage::object_storage::correlation_path;
+use crate::utils::{get_hash, get_user_from_request, user_auth_for_query};
+use crate::{option::CONFIG, utils::actix::extract_session_key_from_req};
 
 use crate::correlation::{CorrelationConfig, CorrelationError, CorrelationRequest, CORRELATIONS};
 
 pub async fn list(req: HttpRequest) -> Result<impl Responder, CorrelationError> {
     let session_key = extract_session_key_from_req(&req)
-        .map_err(|err| CorrelationError::AnyhowError(anyhow::Error::msg(err.to_string())))?;
+        .map_err(|err| CorrelationError::AnyhowError(Error::msg(err.to_string())))?;
+
+    let user_id = get_user_from_request(&req)
+        .map(|s| get_hash(&s.to_string()))
+        .map_err(|err| CorrelationError::AnyhowError(Error::msg(err.to_string())))?;
 
     let correlations = CORRELATIONS
-        .list_correlations_for_user(&session_key)
+        .list_correlations_for_user(&session_key, &user_id)
         .await?;
 
     Ok(web::Json(correlations))
@@ -43,14 +45,20 @@ pub async fn list(req: HttpRequest) -> Result<impl Responder, CorrelationError> 
 
 pub async fn get(req: HttpRequest) -> Result<impl Responder, CorrelationError> {
     let session_key = extract_session_key_from_req(&req)
-        .map_err(|err| CorrelationError::AnyhowError(anyhow::Error::msg(err.to_string())))?;
+        .map_err(|err| CorrelationError::AnyhowError(Error::msg(err.to_string())))?;
+
+    let user_id = get_user_from_request(&req)
+        .map(|s| get_hash(&s.to_string()))
+        .map_err(|err| CorrelationError::AnyhowError(Error::msg(err.to_string())))?;
 
     let correlation_id = req
         .match_info()
         .get("correlation_id")
         .ok_or(CorrelationError::Metadata("No correlation ID Provided"))?;
 
-    let correlation = CORRELATIONS.get_correlation_by_id(correlation_id).await?;
+    let correlation = CORRELATIONS
+        .get_correlation(correlation_id, &user_id)
+        .await?;
 
     let permissions = Users.get_permissions(&session_key);
 
@@ -68,16 +76,24 @@ pub async fn get(req: HttpRequest) -> Result<impl Responder, CorrelationError> {
 pub async fn post(req: HttpRequest, body: Bytes) -> Result<impl Responder, CorrelationError> {
     let session_key = extract_session_key_from_req(&req)
         .map_err(|err| CorrelationError::AnyhowError(anyhow::Error::msg(err.to_string())))?;
+    let user_id = get_user_from_request(&req)
+        .map(|s| get_hash(&s.to_string()))
+        .map_err(|err| CorrelationError::AnyhowError(Error::msg(err.to_string())))?;
 
     let correlation_request: CorrelationRequest = serde_json::from_slice(&body)?;
 
     correlation_request.validate(&session_key).await?;
 
-    let correlation: CorrelationConfig = correlation_request.into();
+    let mut correlation: CorrelationConfig = correlation_request.into();
+    correlation.user_id = user_id.clone();
+    let correlation_id = &correlation.id;
+    let path = correlation_path(&user_id, &format!("{}.json", correlation_id));
 
-    // Save to disk
     let store = CONFIG.storage().get_object_store();
-    store.put_correlation(&correlation).await?;
+    let correlation_bytes = serde_json::to_vec(&correlation)?;
+    store
+        .put_object(&path, Bytes::from(correlation_bytes))
+        .await?;
 
     // Save to memory
     CORRELATIONS.update(&correlation).await?;
@@ -88,6 +104,9 @@ pub async fn post(req: HttpRequest, body: Bytes) -> Result<impl Responder, Corre
 pub async fn modify(req: HttpRequest, body: Bytes) -> Result<impl Responder, CorrelationError> {
     let session_key = extract_session_key_from_req(&req)
         .map_err(|err| CorrelationError::AnyhowError(anyhow::Error::msg(err.to_string())))?;
+    let user_id = get_user_from_request(&req)
+        .map(|s| get_hash(&s.to_string()))
+        .map_err(|err| CorrelationError::AnyhowError(Error::msg(err.to_string())))?;
 
     let correlation_id = req
         .match_info()
@@ -95,7 +114,9 @@ pub async fn modify(req: HttpRequest, body: Bytes) -> Result<impl Responder, Cor
         .ok_or(CorrelationError::Metadata("No correlation ID Provided"))?;
 
     // validate whether user has access to this correlation object or not
-    let correlation = CORRELATIONS.get_correlation_by_id(correlation_id).await?;
+    let correlation = CORRELATIONS
+        .get_correlation(correlation_id, &user_id)
+        .await?;
     let permissions = Users.get_permissions(&session_key);
     let tables = &correlation
         .table_configs
@@ -108,11 +129,17 @@ pub async fn modify(req: HttpRequest, body: Bytes) -> Result<impl Responder, Cor
     let correlation_request: CorrelationRequest = serde_json::from_slice(&body)?;
     correlation_request.validate(&session_key).await?;
 
-    let correlation = correlation_request.generate_correlation_config(correlation_id.to_owned());
+    let correlation =
+        correlation_request.generate_correlation_config(correlation_id.to_owned(), user_id.clone());
 
-    // Save to disk
+    let correlation_id = &correlation.id;
+    let path = correlation_path(&user_id, &format!("{}.json", correlation_id));
+
     let store = CONFIG.storage().get_object_store();
-    store.put_correlation(&correlation).await?;
+    let correlation_bytes = serde_json::to_vec(&correlation)?;
+    store
+        .put_object(&path, Bytes::from(correlation_bytes))
+        .await?;
 
     // Save to memory
     CORRELATIONS.update(&correlation).await?;
@@ -123,13 +150,18 @@ pub async fn modify(req: HttpRequest, body: Bytes) -> Result<impl Responder, Cor
 pub async fn delete(req: HttpRequest) -> Result<impl Responder, CorrelationError> {
     let session_key = extract_session_key_from_req(&req)
         .map_err(|err| CorrelationError::AnyhowError(anyhow::Error::msg(err.to_string())))?;
+    let user_id = get_user_from_request(&req)
+        .map(|s| get_hash(&s.to_string()))
+        .map_err(|err| CorrelationError::AnyhowError(Error::msg(err.to_string())))?;
 
     let correlation_id = req
         .match_info()
         .get("correlation_id")
         .ok_or(CorrelationError::Metadata("No correlation ID Provided"))?;
 
-    let correlation = CORRELATIONS.get_correlation_by_id(correlation_id).await?;
+    let correlation = CORRELATIONS
+        .get_correlation(correlation_id, &user_id)
+        .await?;
 
     // validate user's query auth
     let permissions = Users.get_permissions(&session_key);
@@ -141,12 +173,10 @@ pub async fn delete(req: HttpRequest) -> Result<impl Responder, CorrelationError
 
     user_auth_for_query(&permissions, tables)?;
 
-    // Delete from disk
+    let correlation_id = &correlation.id;
+    let path = correlation_path(&user_id, &format!("{}.json", correlation_id));
+
     let store = CONFIG.storage().get_object_store();
-    let path = RelativePathBuf::from_iter([
-        CORRELATIONS_ROOT_DIRECTORY,
-        &format!("{}.json", correlation_id),
-    ]);
     store.delete_object(&path).await?;
 
     // Delete from memory

--- a/src/handlers/http/correlation.rs
+++ b/src/handlers/http/correlation.rs
@@ -85,7 +85,7 @@ pub async fn post(req: HttpRequest, body: Bytes) -> Result<impl Responder, Corre
     correlation_request.validate(&session_key).await?;
 
     let mut correlation: CorrelationConfig = correlation_request.into();
-    correlation.user_id = user_id.clone();
+    correlation.user_id.clone_from(&user_id);
     let correlation_id = &correlation.id;
     let path = correlation_path(&user_id, &format!("{}.json", correlation_id));
 

--- a/src/handlers/http/users/mod.rs
+++ b/src/handlers/http/users/mod.rs
@@ -22,3 +22,4 @@ pub mod filters;
 pub const USERS_ROOT_DIR: &str = ".users";
 pub const DASHBOARDS_DIR: &str = "dashboards";
 pub const FILTER_DIR: &str = "filters";
+pub const CORRELATION_DIR: &str = "correlations";

--- a/src/storage/azure_blob.rs
+++ b/src/storage/azure_blob.rs
@@ -678,10 +678,8 @@ impl ObjectStorage for BlobStore {
             .map(|name| name.as_ref().to_string())
             .collect::<Vec<_>>();
         for user in users {
-            let user_dashboard_path = object_store::path::Path::from(format!(
-                "{}/{}/{}",
-                USERS_ROOT_DIR, user, "dashboards"
-            ));
+            let user_dashboard_path =
+                object_store::path::Path::from(format!("{USERS_ROOT_DIR}/{user}/dashboards"));
             let dashboards_path = RelativePathBuf::from(&user_dashboard_path);
             let dashboard_bytes = self
                 .get_objects(
@@ -716,10 +714,8 @@ impl ObjectStorage for BlobStore {
             .map(|name| name.as_ref().to_string())
             .collect::<Vec<_>>();
         for user in users {
-            let user_filters_path = object_store::path::Path::from(format!(
-                "{}/{}/{}",
-                USERS_ROOT_DIR, user, "filters"
-            ));
+            let user_filters_path =
+                object_store::path::Path::from(format!("{USERS_ROOT_DIR}/{user}/filters",));
             let resp = self
                 .client
                 .list_with_delimiter(Some(&user_filters_path))
@@ -767,10 +763,8 @@ impl ObjectStorage for BlobStore {
             .map(|name| name.as_ref().to_string())
             .collect::<Vec<_>>();
         for user in users {
-            let user_correlation_path = object_store::path::Path::from(format!(
-                "{}/{}/{}",
-                USERS_ROOT_DIR, user, "correlations"
-            ));
+            let user_correlation_path =
+                object_store::path::Path::from(format!("{USERS_ROOT_DIR}/{user}/correlations"));
             let correlations_path = RelativePathBuf::from(&user_correlation_path);
             let correlation_bytes = self
                 .get_objects(

--- a/src/storage/azure_blob.rs
+++ b/src/storage/azure_blob.rs
@@ -1,8 +1,3 @@
-use bytes::Bytes;
-use datafusion::datasource::listing::ListingTableUrl;
-use futures::stream::FuturesUnordered;
-use futures::{StreamExt, TryStreamExt};
-use tracing::{error, info};
 /*
  * Parseable Server (C) 2022 - 2024 Parseable, Inc.
  *
@@ -26,14 +21,19 @@ use super::{
     SCHEMA_FILE_NAME, STREAM_METADATA_FILE_NAME, STREAM_ROOT_DIRECTORY,
 };
 use async_trait::async_trait;
+use bytes::Bytes;
+use datafusion::datasource::listing::ListingTableUrl;
 use datafusion::datasource::object_store::{
     DefaultObjectStoreRegistry, ObjectStoreRegistry, ObjectStoreUrl,
 };
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+use futures::stream::FuturesUnordered;
+use futures::{StreamExt, TryStreamExt};
 use object_store::azure::{MicrosoftAzure, MicrosoftAzureBuilder};
 use object_store::{BackoffConfig, ClientOptions, ObjectStore, PutPayload, RetryConfig};
 use relative_path::{RelativePath, RelativePathBuf};
 use std::path::Path as StdPath;
+use tracing::{error, info};
 use url::Url;
 
 use super::metrics_layer::MetricLayer;
@@ -747,6 +747,45 @@ impl ObjectStorage for BlobStore {
         Ok(filters)
     }
 
+    ///fetch all correlations uploaded in object store
+    /// return the correlation file path and all correlation json bytes for each file path
+    async fn get_all_correlations(
+        &self,
+    ) -> Result<HashMap<RelativePathBuf, Vec<Bytes>>, ObjectStorageError> {
+        let mut correlations: HashMap<RelativePathBuf, Vec<Bytes>> = HashMap::new();
+        let users_root_path = object_store::path::Path::from(USERS_ROOT_DIR);
+        let resp = self
+            .client
+            .list_with_delimiter(Some(&users_root_path))
+            .await?;
+
+        let users = resp
+            .common_prefixes
+            .iter()
+            .flat_map(|path| path.parts())
+            .filter(|name| name.as_ref() != USERS_ROOT_DIR)
+            .map(|name| name.as_ref().to_string())
+            .collect::<Vec<_>>();
+        for user in users {
+            let user_correlation_path = object_store::path::Path::from(format!(
+                "{}/{}/{}",
+                USERS_ROOT_DIR, user, "correlations"
+            ));
+            let correlations_path = RelativePathBuf::from(&user_correlation_path);
+            let correlation_bytes = self
+                .get_objects(
+                    Some(&correlations_path),
+                    Box::new(|file_name| file_name.ends_with(".json")),
+                )
+                .await?;
+
+            correlations
+                .entry(correlations_path)
+                .or_default()
+                .extend(correlation_bytes);
+        }
+        Ok(correlations)
+    }
     fn get_bucket_name(&self) -> String {
         self.container.clone()
     }

--- a/src/storage/localfs.rs
+++ b/src/storage/localfs.rs
@@ -39,9 +39,8 @@ use crate::{
 };
 
 use super::{
-    LogStream, ObjectStorage, ObjectStorageError, ObjectStorageProvider,
-    CORRELATIONS_ROOT_DIRECTORY, PARSEABLE_ROOT_DIRECTORY, SCHEMA_FILE_NAME,
-    STREAM_METADATA_FILE_NAME, STREAM_ROOT_DIRECTORY,
+    LogStream, ObjectStorage, ObjectStorageError, ObjectStorageProvider, PARSEABLE_ROOT_DIRECTORY,
+    SCHEMA_FILE_NAME, STREAM_METADATA_FILE_NAME, STREAM_ROOT_DIRECTORY,
 };
 
 #[derive(Debug, Clone, clap::Args)]
@@ -297,12 +296,7 @@ impl ObjectStorage for LocalFS {
     }
 
     async fn list_streams(&self) -> Result<Vec<LogStream>, ObjectStorageError> {
-        let ignore_dir = &[
-            "lost+found",
-            PARSEABLE_ROOT_DIRECTORY,
-            USERS_ROOT_DIR,
-            CORRELATIONS_ROOT_DIRECTORY,
-        ];
+        let ignore_dir = &["lost+found", PARSEABLE_ROOT_DIRECTORY, USERS_ROOT_DIR];
         let directories = ReadDirStream::new(fs::read_dir(&self.root).await?);
         let entries: Vec<DirEntry> = directories.try_collect().await?;
         let entries = entries
@@ -322,11 +316,7 @@ impl ObjectStorage for LocalFS {
     }
 
     async fn list_old_streams(&self) -> Result<Vec<LogStream>, ObjectStorageError> {
-        let ignore_dir = &[
-            "lost+found",
-            PARSEABLE_ROOT_DIRECTORY,
-            CORRELATIONS_ROOT_DIRECTORY,
-        ];
+        let ignore_dir = &["lost+found", PARSEABLE_ROOT_DIRECTORY];
         let directories = ReadDirStream::new(fs::read_dir(&self.root).await?);
         let entries: Vec<DirEntry> = directories.try_collect().await?;
         let entries = entries
@@ -431,6 +421,38 @@ impl ObjectStorage for LocalFS {
             }
         }
         Ok(filters)
+    }
+
+    ///fetch all correlations stored in disk
+    /// return the correlation file path and all correlation json bytes for each file path
+    async fn get_all_correlations(
+        &self,
+    ) -> Result<HashMap<RelativePathBuf, Vec<Bytes>>, ObjectStorageError> {
+        let mut correlations: HashMap<RelativePathBuf, Vec<Bytes>> = HashMap::new();
+        let users_root_path = self.root.join(USERS_ROOT_DIR);
+        let directories = ReadDirStream::new(fs::read_dir(&users_root_path).await?);
+        let users: Vec<DirEntry> = directories.try_collect().await?;
+        for user in users {
+            if !user.path().is_dir() {
+                continue;
+            }
+            let correlations_path = users_root_path.join(user.path()).join("correlations");
+            let directories = ReadDirStream::new(fs::read_dir(&correlations_path).await?);
+            let correlations_files: Vec<DirEntry> = directories.try_collect().await?;
+            for correlation in correlations_files {
+                let correlation_absolute_path = correlation.path();
+                let file = fs::read(correlation_absolute_path.clone()).await?;
+                let correlation_relative_path = correlation_absolute_path
+                    .strip_prefix(self.root.as_path())
+                    .unwrap();
+
+                correlations
+                    .entry(RelativePathBuf::from_path(correlation_relative_path).unwrap())
+                    .or_default()
+                    .push(file.into());
+            }
+        }
+        Ok(correlations)
     }
 
     async fn list_dates(&self, stream_name: &str) -> Result<Vec<String>, ObjectStorageError> {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -56,7 +56,6 @@ pub const PARSEABLE_ROOT_DIRECTORY: &str = ".parseable";
 pub const SCHEMA_FILE_NAME: &str = ".schema";
 pub const ALERT_FILE_NAME: &str = ".alert.json";
 pub const MANIFEST_FILE: &str = "manifest.json";
-pub const CORRELATIONS_ROOT_DIRECTORY: &str = ".correlations";
 
 /// local sync interval to move data.records to /tmp dir of that stream.
 /// 60 sec is a reasonable value.

--- a/src/storage/object_storage.rs
+++ b/src/storage/object_storage.rs
@@ -21,15 +21,13 @@ use super::{
     ObjectStoreFormat, Permisssion, StorageDir, StorageMetadata,
 };
 use super::{
-    Owner, ALERT_FILE_NAME, CORRELATIONS_ROOT_DIRECTORY, MANIFEST_FILE,
-    PARSEABLE_METADATA_FILE_NAME, PARSEABLE_ROOT_DIRECTORY, SCHEMA_FILE_NAME,
-    STREAM_METADATA_FILE_NAME, STREAM_ROOT_DIRECTORY,
+    Owner, ALERT_FILE_NAME, MANIFEST_FILE, PARSEABLE_METADATA_FILE_NAME, PARSEABLE_ROOT_DIRECTORY,
+    SCHEMA_FILE_NAME, STREAM_METADATA_FILE_NAME, STREAM_ROOT_DIRECTORY,
 };
 
-use crate::correlation::{CorrelationConfig, CorrelationError};
 use crate::event::format::LogSource;
 use crate::handlers::http::modal::ingest_server::INGESTOR_META;
-use crate::handlers::http::users::{DASHBOARDS_DIR, FILTER_DIR, USERS_ROOT_DIR};
+use crate::handlers::http::users::{CORRELATION_DIR, DASHBOARDS_DIR, FILTER_DIR, USERS_ROOT_DIR};
 use crate::metadata::SchemaVersion;
 use crate::metrics::{EVENTS_STORAGE_SIZE_DATE, LIFETIME_EVENTS_STORAGE_SIZE};
 use crate::option::Mode;
@@ -100,6 +98,9 @@ pub trait ObjectStorage: Debug + Send + Sync + 'static {
         &self,
     ) -> Result<HashMap<RelativePathBuf, Vec<Bytes>>, ObjectStorageError>;
     async fn get_all_dashboards(
+        &self,
+    ) -> Result<HashMap<RelativePathBuf, Vec<Bytes>>, ObjectStorageError>;
+    async fn get_all_correlations(
         &self,
     ) -> Result<HashMap<RelativePathBuf, Vec<Bytes>>, ObjectStorageError>;
     async fn list_dates(&self, stream_name: &str) -> Result<Vec<String>, ObjectStorageError>;
@@ -624,30 +625,6 @@ pub trait ObjectStorage: Debug + Send + Sync + 'static {
 
     // pick a better name
     fn get_bucket_name(&self) -> String;
-
-    async fn put_correlation(
-        &self,
-        correlation: &CorrelationConfig,
-    ) -> Result<(), ObjectStorageError> {
-        let path = RelativePathBuf::from_iter([
-            CORRELATIONS_ROOT_DIRECTORY,
-            &format!("{}.json", correlation.id),
-        ]);
-        self.put_object(&path, to_bytes(correlation)).await?;
-        Ok(())
-    }
-
-    async fn get_correlations(&self) -> Result<Vec<Bytes>, CorrelationError> {
-        let correlation_path = RelativePathBuf::from_iter([CORRELATIONS_ROOT_DIRECTORY]);
-        let correlation_bytes = self
-            .get_objects(
-                Some(&correlation_path),
-                Box::new(|file_name| file_name.ends_with(".json")),
-            )
-            .await?;
-
-        Ok(correlation_bytes)
-    }
 }
 
 pub async fn commit_schema_to_storage(
@@ -718,6 +695,15 @@ pub fn filter_path(user_id: &str, stream_name: &str, filter_file_name: &str) -> 
         FILTER_DIR,
         stream_name,
         filter_file_name,
+    ])
+}
+
+pub fn correlation_path(user_id: &str, correlation_file_name: &str) -> RelativePathBuf {
+    RelativePathBuf::from_iter([
+        USERS_ROOT_DIR,
+        user_id,
+        CORRELATION_DIR,
+        correlation_file_name,
     ])
 }
 

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -811,10 +811,8 @@ impl ObjectStorage for S3 {
             .map(|name| name.as_ref().to_string())
             .collect::<Vec<_>>();
         for user in users {
-            let user_dashboard_path = object_store::path::Path::from(format!(
-                "{}/{}/{}",
-                USERS_ROOT_DIR, user, "dashboards"
-            ));
+            let user_dashboard_path =
+                object_store::path::Path::from(format!("{USERS_ROOT_DIR}/{user}/dashboards"));
             let dashboards_path = RelativePathBuf::from(&user_dashboard_path);
             let dashboard_bytes = self
                 .get_objects(
@@ -849,10 +847,8 @@ impl ObjectStorage for S3 {
             .map(|name| name.as_ref().to_string())
             .collect::<Vec<_>>();
         for user in users {
-            let user_filters_path = object_store::path::Path::from(format!(
-                "{}/{}/{}",
-                USERS_ROOT_DIR, user, "filters"
-            ));
+            let user_filters_path =
+                object_store::path::Path::from(format!("{USERS_ROOT_DIR}/{user}/filters",));
             let resp = self
                 .client
                 .list_with_delimiter(Some(&user_filters_path))
@@ -900,10 +896,8 @@ impl ObjectStorage for S3 {
             .map(|name| name.as_ref().to_string())
             .collect::<Vec<_>>();
         for user in users {
-            let user_correlation_path = object_store::path::Path::from(format!(
-                "{}/{}/{}",
-                USERS_ROOT_DIR, user, "correlations"
-            ));
+            let user_correlation_path =
+                object_store::path::Path::from(format!("{USERS_ROOT_DIR}/{user}/correlations",));
             let correlations_path = RelativePathBuf::from(&user_correlation_path);
             let correlation_bytes = self
                 .get_objects(

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -880,6 +880,46 @@ impl ObjectStorage for S3 {
         Ok(filters)
     }
 
+    ///fetch all correlations stored in object store
+    /// return the correlation file path and all correlation json bytes for each file path
+    async fn get_all_correlations(
+        &self,
+    ) -> Result<HashMap<RelativePathBuf, Vec<Bytes>>, ObjectStorageError> {
+        let mut correlations: HashMap<RelativePathBuf, Vec<Bytes>> = HashMap::new();
+        let users_root_path = object_store::path::Path::from(USERS_ROOT_DIR);
+        let resp = self
+            .client
+            .list_with_delimiter(Some(&users_root_path))
+            .await?;
+
+        let users = resp
+            .common_prefixes
+            .iter()
+            .flat_map(|path| path.parts())
+            .filter(|name| name.as_ref() != USERS_ROOT_DIR)
+            .map(|name| name.as_ref().to_string())
+            .collect::<Vec<_>>();
+        for user in users {
+            let user_correlation_path = object_store::path::Path::from(format!(
+                "{}/{}/{}",
+                USERS_ROOT_DIR, user, "correlations"
+            ));
+            let correlations_path = RelativePathBuf::from(&user_correlation_path);
+            let correlation_bytes = self
+                .get_objects(
+                    Some(&correlations_path),
+                    Box::new(|file_name| file_name.ends_with(".json")),
+                )
+                .await?;
+
+            correlations
+                .entry(correlations_path)
+                .or_default()
+                .extend(correlation_bytes);
+        }
+        Ok(correlations)
+    }
+
     fn get_bucket_name(&self) -> String {
         self.bucket.clone()
     }


### PR DESCRIPTION
save correlations to .users/<hash of userid>/correlations directory remove version from correlation request
add user_id to config, store as hash of user_id
server loads / saves the correlation against user_id from the incoming request


