### PR TITLE
fix: oidc connection

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -369,6 +369,7 @@ pub struct OidcConfig {
     #[arg(
         long = "oidc-client-id",
         env = "P_OIDC_CLIENT_ID",
+        required = false,
         help = "Client id for OIDC provider"
     )]
     pub client_id: String,
@@ -376,6 +377,7 @@ pub struct OidcConfig {
     #[arg(
         long = "oidc-client-secret",
         env = "P_OIDC_CLIENT_SECRET",
+        required = false,
         help = "Client secret for OIDC provider"
     )]
     pub secret: String,
@@ -383,6 +385,7 @@ pub struct OidcConfig {
     #[arg(
         long = "oidc-issuer",
         env = "P_OIDC_ISSUER",
+        required = false,
         value_parser = validation::url,
         help = "OIDC provider's host address"
     )]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -299,8 +299,6 @@ pub struct Options {
         long,
         long = "oidc-client",
         env = "P_OIDC_CLIENT_ID",
-        requires = "oidc",
-        group = "oidc",
         help = "Client id for OIDC provider"
     )]
     oidc_client_id: Option<String>,
@@ -308,8 +306,6 @@ pub struct Options {
     #[arg(
         long,
         env = "P_OIDC_CLIENT_SECRET",
-        requires = "oidc",
-        group = "oidc",
         help = "Client secret for OIDC provider"
     )]
     oidc_client_secret: Option<String>,
@@ -318,8 +314,6 @@ pub struct Options {
         long,
         env = "P_OIDC_ISSUER",
         value_parser = validation::url,
-        requires = "oidc",
-        group = "oidc",
         help = "OIDC provider's host address"
     )]
     oidc_issuer: Option<Url>,


### PR DESCRIPTION
removed requires and group from oidc related args
we are anyways checking in the `openid()` if all three exists
then set OpenidConfig, else None

