### PR TITLE
fix: arg name and error print

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -367,7 +367,8 @@ pub struct Options {
 #[derive(Parser, Debug)]
 pub struct OidcConfig {
     #[arg(
-        long = "oidc-client-id",
+        long = "oidc-client",
+        name = "oidc-client",
         env = "P_OIDC_CLIENT_ID",
         required = false,
         help = "Client id for OIDC provider"
@@ -376,6 +377,7 @@ pub struct OidcConfig {
 
     #[arg(
         long = "oidc-client-secret",
+        name = "oidc-client-secret",
         env = "P_OIDC_CLIENT_SECRET",
         required = false,
         help = "Client secret for OIDC provider"
@@ -384,6 +386,7 @@ pub struct OidcConfig {
 
     #[arg(
         long = "oidc-issuer",
+        name = "oidc-issuer",
         env = "P_OIDC_ISSUER",
         required = false,
         value_parser = validation::url,


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

Before: 
```
$ parseable local-store --oidc-client-id ...
```
<img width="650" alt="Screenshot 2025-01-19 at 1 44 43 PM" src="https://github.com/user-attachments/assets/a5f824e1-d9be-43a3-ba63-e8216eed5067" />



After:
```
$ parseable local-store --oidc-client ...
```
<img width="674" alt="Screenshot 2025-01-19 at 1 43 00 PM" src="https://github.com/user-attachments/assets/ca4e0304-eee5-416b-8646-8046bb9b73b2" />


<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
