### PR TITLE
fix: listing, no manifest setup

### DIFF
--- a/src/query/listing_table_builder.rs
+++ b/src/query/listing_table_builder.rs
@@ -100,7 +100,7 @@ impl ListingTableBuilder {
         let mut all_resolve = Vec::new();
         for prefix in prefixes {
             let path = relative_path::RelativePathBuf::from(format!("{}/{}", &self.stream, prefix));
-            storage.absolute_url(path.as_relative_path()).to_string();
+            let prefix = storage.absolute_url(path.as_relative_path()).to_string();
             if let Some(pos) = prefix.rfind("minute") {
                 let hour_prefix = &prefix[..pos];
                 minute_resolve

--- a/src/query/stream_schema_provider.rs
+++ b/src/query/stream_schema_provider.rs
@@ -679,6 +679,10 @@ fn return_listing_time_filters(
     manifest_list: &[ManifestItem],
     time_filters: &mut Vec<PartialTimeFilter>,
 ) -> Option<Vec<PartialTimeFilter>> {
+    if manifest_list.is_empty() {
+        return Some(time_filters.clone());
+    }
+
     // vec to hold timestamps for listing
     let mut vec_listing_timestamps = Vec::new();
 


### PR DESCRIPTION
the PR solves cases where entire data has no manifest
also fixes the prefix creation for listing

how to verify:

1. checkout parseable main branch
2. run parseable locally  with minio
3. open another terminal and run mc trace to analyse the API calls happening to minio
4. load some data in a stream
5. use query API - provide the start date and end date as old date where there was no data in the stream
6. analyse in mc trace that list calls do not happen at all -- this is because of the 1st bug where listing does not happen when entire time range of the query is before the manifest creation date
7. again use the query API - this time, prove the start date as old date where there was no data in the stream, end date can be today's date
8. analyse in mc trace that the list calls happen now but the prefix does not contain the stream name

now, when you checkout this PR, you will find both the issues have been fixed.
