### PR TITLE
fix: run `fields_mismatch` against `static_schema` data also

### DIFF
--- a/src/event/format/json.rs
+++ b/src/event/format/json.rs
@@ -44,7 +44,6 @@ impl EventFormat for Event {
     fn to_data(
         self,
         schema: &HashMap<String, Arc<Field>>,
-        static_schema_flag: bool,
         time_partition: Option<&String>,
         schema_version: SchemaVersion,
     ) -> Result<(Self::Data, Vec<Arc<Field>>, bool), anyhow::Error> {

--- a/src/event/format/json.rs
+++ b/src/event/format/json.rs
@@ -94,8 +94,7 @@ impl EventFormat for Event {
             }
         };
 
-        if !static_schema_flag
-            && value_arr
+        if value_arr
                 .iter()
                 .any(|value| fields_mismatch(&schema, value, schema_version))
         {

--- a/src/event/format/mod.rs
+++ b/src/event/format/mod.rs
@@ -81,7 +81,6 @@ pub trait EventFormat: Sized {
     fn to_data(
         self,
         schema: &HashMap<String, Arc<Field>>,
-        static_schema_flag: bool,
         time_partition: Option<&String>,
         schema_version: SchemaVersion,
     ) -> Result<(Self::Data, EventSchema, bool), AnyError>;
@@ -97,7 +96,6 @@ pub trait EventFormat: Sized {
     ) -> Result<(RecordBatch, bool), AnyError> {
         let (data, mut schema, is_first) = self.to_data(
             storage_schema,
-            static_schema_flag,
             time_partition,
             schema_version,
         )?;


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

Don't cast floats as int on streams with `static_schema_flag` set
<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

### Testing Methodology
1. Start parseable.
2. Create new static schema stream with an int field.
3. Push data on the static schema stream with float value.

Without the fix, value is being rounded out, which is wrong as we lose data.

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
