### PR TITLE
feat: add sysinfo metrics

### DIFF
--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -77,7 +77,6 @@ impl Event {
             &self.rb,
             self.parsed_timestamp,
             &self.custom_partition_values,
-            self.stream_type,
         )?;
 
         update_stats(
@@ -101,7 +100,6 @@ impl Event {
             &self.rb,
             self.parsed_timestamp,
             &self.custom_partition_values,
-            self.stream_type,
         )?;
 
         Ok(())

--- a/src/handlers/http/cluster/mod.rs
+++ b/src/handlers/http/cluster/mod.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use actix_web::http::header::{self, HeaderMap};
-use actix_web::web::Path;
+use actix_web::web::{Json, Path};
 use actix_web::Responder;
 use bytes::Bytes;
 use chrono::Utc;
@@ -867,7 +867,6 @@ where
             let text = res.text().await.map_err(PostError::NetworkError)?;
             let lines: Vec<Result<String, std::io::Error>> =
                 text.lines().map(|line| Ok(line.to_owned())).collect_vec();
-
             let sample = prometheus_parse::Scrape::parse(lines.into_iter())
                 .map_err(|err| PostError::CustomError(err.to_string()))?
                 .samples;
@@ -993,7 +992,7 @@ async fn fetch_cluster_metrics() -> Result<Vec<Metrics>, PostError> {
     Ok(all_metrics)
 }
 
-pub fn init_cluster_metrics_schedular() -> Result<(), PostError> {
+pub async fn init_cluster_metrics_scheduler() -> Result<(), PostError> {
     info!("Setting up schedular for cluster metrics ingestion");
     let mut scheduler = AsyncScheduler::new();
     scheduler
@@ -1002,25 +1001,12 @@ pub fn init_cluster_metrics_schedular() -> Result<(), PostError> {
             let result: Result<(), PostError> = async {
                 let cluster_metrics = fetch_cluster_metrics().await;
                 if let Ok(metrics) = cluster_metrics {
-                    if !metrics.is_empty() {
-                        info!("Cluster metrics fetched successfully from all ingestors");
-                        if let Ok(metrics_bytes) = serde_json::to_vec(&metrics) {
-                            if matches!(
-                                ingest_internal_stream(
-                                    INTERNAL_STREAM_NAME.to_string(),
-                                    bytes::Bytes::from(metrics_bytes),
-                                )
-                                .await,
-                                Ok(())
-                            ) {
-                                info!("Cluster metrics successfully ingested into internal stream");
-                            } else {
-                                error!("Failed to ingest cluster metrics into internal stream");
-                            }
-                        } else {
-                            error!("Failed to serialize cluster metrics");
-                        }
-                    }
+                    let json_value = serde_json::to_value(metrics)
+                        .map_err(|e| anyhow::anyhow!("Failed to serialize metrics: {}", e))?;
+
+                    ingest_internal_stream(INTERNAL_STREAM_NAME.to_string(), Json(json_value))
+                        .await
+                        .map_err(|e| anyhow::anyhow!("Failed to ingest metrics: {}", e))?;
                 }
                 Ok(())
             }

--- a/src/handlers/http/ingest.rs
+++ b/src/handlers/http/ingest.rs
@@ -18,10 +18,27 @@
 
 use std::collections::{HashMap, HashSet};
 
+use super::logstream::error::{CreateStreamError, StreamError};
+use super::modal::utils::ingest_utils::{flatten_and_push_logs, push_logs};
+use super::users::dashboards::DashboardError;
+use super::users::filters::FiltersError;
+use crate::event::format::{self, EventFormat, LogSource};
+use crate::event::{self, error::EventError};
+use crate::handlers::http::modal::utils::logstream_utils::create_stream_and_schema_from_storage;
+use crate::handlers::{LOG_SOURCE_KEY, STREAM_NAME_HEADER_KEY};
+use crate::metadata::error::stream_info::MetadataError;
+use crate::metadata::{SchemaVersion, STREAM_INFO};
+use crate::option::{Mode, CONFIG};
+use crate::otel::logs::flatten_otel_logs;
+use crate::otel::metrics::flatten_otel_metrics;
+use crate::otel::traces::flatten_otel_traces;
+use crate::storage::{ObjectStorageError, StreamType};
+use crate::utils::header_parsing::ParseHeaderError;
+use crate::utils::json::convert_array_to_object;
+use crate::utils::json::flatten::{convert_to_array, JsonFlattenError};
 use actix_web::web::{Json, Path};
 use actix_web::{http::header::ContentType, HttpRequest, HttpResponse};
 use arrow_array::RecordBatch;
-use bytes::Bytes;
 use chrono::Utc;
 use http::StatusCode;
 use serde_json::Value;

--- a/src/handlers/http/modal/ingest_server.rs
+++ b/src/handlers/http/modal/ingest_server.rs
@@ -31,6 +31,7 @@ use tokio::sync::oneshot;
 use tokio::sync::OnceCell;
 
 use crate::handlers::http::modal::NodeType;
+use crate::metrics::init_system_metrics_scheduler;
 use crate::{
     analytics,
     handlers::{
@@ -119,7 +120,7 @@ impl ParseableServer for IngestServer {
         thread::spawn(|| sync::handler(cancel_rx));
 
         tokio::spawn(airplane::server());
-
+        init_system_metrics_scheduler().await?;
         // Ingestors shouldn't have to deal with OpenId auth flow
         let result = self.start(shutdown_rx, prometheus.clone(), None).await;
         // Cancel sync jobs

--- a/src/handlers/http/modal/query_server.rs
+++ b/src/handlers/http/modal/query_server.rs
@@ -117,6 +117,8 @@ impl ParseableServer for QueryServer {
         // track all parquet files already in the data directory
         storage::retention::load_retention_from_global();
 
+        metrics::init_system_metrics_scheduler().await?;
+        cluster::init_cluster_metrics_scheduler().await?;
         // all internal data structures populated now.
         // start the analytics scheduler if enabled
         if PARSEABLE.options.send_analytics {

--- a/src/handlers/http/modal/server.rs
+++ b/src/handlers/http/modal/server.rs
@@ -30,6 +30,7 @@ use crate::handlers::http::users::dashboards;
 use crate::handlers::http::users::filters;
 use crate::hottier::HotTierManager;
 use crate::metrics;
+use crate::metrics::init_system_metrics_scheduler;
 use crate::migration;
 use crate::storage;
 use crate::sync;
@@ -133,6 +134,8 @@ impl ParseableServer for Server {
         if PARSEABLE.options.send_analytics {
             analytics::init_analytics_scheduler()?;
         }
+
+        init_system_metrics_scheduler().await?;
 
         tokio::spawn(handlers::livetail::server());
         tokio::spawn(handlers::airplane::server());

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -18,15 +18,25 @@
 
 pub mod prom_utils;
 pub mod storage;
+use actix_web::HttpResponse;
+use clokwerk::{AsyncScheduler, Interval};
+use http::StatusCode;
+use serde::Serialize;
+use std::{path::Path, time::Duration};
+use sysinfo::{Disks, System};
+use tracing::{error, info};
 
-use crate::{handlers::http::metrics_path, stats::FullStats};
+use crate::{handlers::http::metrics_path, option::CONFIG, stats::FullStats};
 use actix_web::Responder;
 use actix_web_prometheus::{PrometheusMetrics, PrometheusMetricsBuilder};
 use error::MetricsError;
 use once_cell::sync::Lazy;
-use prometheus::{HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts, Registry};
+use prometheus::{
+    GaugeVec, HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts, Registry,
+};
 
 pub const METRICS_NAMESPACE: &str = env!("CARGO_PKG_NAME");
+const SYSTEM_METRICS_INTERVAL_SECONDS: Interval = clokwerk::Interval::Minutes(1);
 
 pub static EVENTS_INGESTED: Lazy<IntGaugeVec> = Lazy::new(|| {
     IntGaugeVec::new(
@@ -182,6 +192,42 @@ pub static ALERTS_STATES: Lazy<IntCounterVec> = Lazy::new(|| {
     .expect("metric can be created")
 });
 
+pub static TOTAL_DISK: Lazy<IntGaugeVec> = Lazy::new(|| {
+    IntGaugeVec::new(
+        Opts::new("total_disk", "Total Disk Size").namespace(METRICS_NAMESPACE),
+        &["volume"],
+    )
+    .expect("metric can be created")
+});
+pub static USED_DISK: Lazy<IntGaugeVec> = Lazy::new(|| {
+    IntGaugeVec::new(
+        Opts::new("used_disk", "Used Disk Size").namespace(METRICS_NAMESPACE),
+        &["volume"],
+    )
+    .expect("metric can be created")
+});
+pub static AVAILABLE_DISK: Lazy<IntGaugeVec> = Lazy::new(|| {
+    IntGaugeVec::new(
+        Opts::new("available_disk", "Available Disk Size").namespace(METRICS_NAMESPACE),
+        &["volume"],
+    )
+    .expect("metric can be created")
+});
+pub static MEMORY: Lazy<IntGaugeVec> = Lazy::new(|| {
+    IntGaugeVec::new(
+        Opts::new("memory_usage", "Memory Usage").namespace(METRICS_NAMESPACE),
+        &["memory_usage"],
+    )
+    .expect("metric can be created")
+});
+pub static CPU: Lazy<GaugeVec> = Lazy::new(|| {
+    GaugeVec::new(
+        Opts::new("cpu_usage", "CPU Usage").namespace(METRICS_NAMESPACE),
+        &["cpu_usage"],
+    )
+    .expect("metric can be created")
+});
+
 fn custom_metrics(registry: &Registry) {
     registry
         .register(Box::new(EVENTS_INGESTED.clone()))
@@ -230,6 +276,21 @@ fn custom_metrics(registry: &Registry) {
         .expect("metric can be registered");
     registry
         .register(Box::new(ALERTS_STATES.clone()))
+        .expect("metric can be registered");
+    registry
+        .register(Box::new(TOTAL_DISK.clone()))
+        .expect("metric can be registered");
+    registry
+        .register(Box::new(USED_DISK.clone()))
+        .expect("metric can be registered");
+    registry
+        .register(Box::new(AVAILABLE_DISK.clone()))
+        .expect("metric can be registered");
+    registry
+        .register(Box::new(MEMORY.clone()))
+        .expect("metric can be registered");
+    registry
+        .register(Box::new(CPU.clone()))
         .expect("metric can be registered");
 }
 
@@ -290,10 +351,194 @@ pub async fn fetch_stats_from_storage(stream_name: &str, stats: FullStats) {
         .set(stats.lifetime_stats.storage as i64);
 }
 
-use actix_web::HttpResponse;
-
 pub async fn get() -> Result<impl Responder, MetricsError> {
     Ok(HttpResponse::Ok().body(format!("{:?}", build_metrics_handler())))
+}
+
+#[derive(Debug, Serialize, Default, Clone)]
+pub struct DiskMetrics {
+    total: u64,
+    used: u64,
+    available: u64,
+}
+
+#[derive(Debug, Serialize, Default, Clone)]
+pub struct SystemMetrics {
+    memory: MemoryMetrics,
+    cpu: Vec<CpuMetrics>,
+}
+
+#[derive(Debug, Serialize, Default, Clone)]
+pub struct MemoryMetrics {
+    total: u64,
+    used: u64,
+    total_swap: u64,
+    used_swap: u64,
+}
+
+#[derive(Debug, Serialize, Default, Clone)]
+pub struct CpuMetrics {
+    name: String,
+    usage: f64,
+}
+
+// Scheduler for collecting all system metrics
+pub async fn init_system_metrics_scheduler() -> Result<(), MetricsError> {
+    info!("Setting up scheduler for capturing system metrics");
+    let mut scheduler = AsyncScheduler::new();
+
+    scheduler
+        .every(SYSTEM_METRICS_INTERVAL_SECONDS)
+        .run(move || async {
+            if let Err(err) = collect_all_metrics().await {
+                error!("Error in capturing system metrics: {:#}", err);
+            }
+        });
+
+    tokio::spawn(async move {
+        loop {
+            scheduler.run_pending().await;
+            tokio::time::sleep(Duration::from_secs(10)).await;
+        }
+    });
+
+    Ok(())
+}
+
+// Function to collect memory, CPU and disk usage metrics
+pub async fn collect_all_metrics() -> Result<(), MetricsError> {
+    // Collect system metrics (CPU and memory)
+    collect_system_metrics().await?;
+
+    // Collect disk metrics for all volumes
+    collect_disk_metrics().await?;
+
+    Ok(())
+}
+
+// Function to collect disk usage metrics
+async fn collect_disk_metrics() -> Result<(), MetricsError> {
+    // collect staging volume metrics
+    collect_volume_disk_usage("staging", CONFIG.staging_dir())?;
+    // Collect data volume metrics for local storage
+    if CONFIG.get_storage_mode_string() == "Local drive" {
+        collect_volume_disk_usage("data", Path::new(&CONFIG.storage().get_endpoint()))?;
+    }
+
+    // Collect hot tier volume metrics if configured
+    if let Some(hot_tier_dir) = CONFIG.hot_tier_dir() {
+        collect_volume_disk_usage("hot_tier", hot_tier_dir)?;
+    }
+
+    Ok(())
+}
+
+// Function to collect disk usage metrics for a specific volume
+fn collect_volume_disk_usage(label: &str, path: &Path) -> Result<(), MetricsError> {
+    let metrics = get_volume_disk_usage(path)?;
+
+    TOTAL_DISK
+        .with_label_values(&[label])
+        .set(metrics.total as i64);
+    USED_DISK
+        .with_label_values(&[label])
+        .set(metrics.used as i64);
+    AVAILABLE_DISK
+        .with_label_values(&[label])
+        .set(metrics.available as i64);
+
+    Ok(())
+}
+
+// Function to get disk usage for a specific volume
+fn get_volume_disk_usage(path: &Path) -> Result<DiskMetrics, MetricsError> {
+    let mut disks = Disks::new_with_refreshed_list();
+    disks.sort_by(|a, b| {
+        b.mount_point()
+            .to_str()
+            .unwrap_or("")
+            .len()
+            .cmp(&a.mount_point().to_str().unwrap_or("").len())
+    });
+
+    for disk in disks.iter() {
+        let mount_point = disk.mount_point().to_str().unwrap();
+
+        if path.starts_with(mount_point) {
+            return Ok(DiskMetrics {
+                total: disk.total_space(),
+                used: disk.total_space() - disk.available_space(),
+                available: disk.available_space(),
+            });
+        }
+    }
+
+    Err(MetricsError::Custom(
+        format!("No matching disk found for path: {:?}", path),
+        StatusCode::INTERNAL_SERVER_ERROR,
+    ))
+}
+
+// Function to collect CPU and memory usage metrics
+async fn collect_system_metrics() -> Result<(), MetricsError> {
+    let metrics = get_system_metrics()?;
+
+    // Set memory metrics
+    MEMORY
+        .with_label_values(&["total_memory"])
+        .set(metrics.memory.total as i64);
+    MEMORY
+        .with_label_values(&["used_memory"])
+        .set(metrics.memory.used as i64);
+    MEMORY
+        .with_label_values(&["total_swap"])
+        .set(metrics.memory.total_swap as i64);
+    MEMORY
+        .with_label_values(&["used_swap"])
+        .set(metrics.memory.used_swap as i64);
+
+    // Set CPU metrics
+    for cpu in metrics.cpu {
+        CPU.with_label_values(&[&cpu.name]).set(cpu.usage);
+    }
+
+    Ok(())
+}
+
+// Get system metrics
+fn get_system_metrics() -> Result<SystemMetrics, MetricsError> {
+    let mut sys = System::new_all();
+    sys.refresh_all();
+
+    // Collect memory metrics
+    let memory = MemoryMetrics {
+        total: sys.total_memory(),
+        used: sys.used_memory(),
+        total_swap: sys.total_swap(),
+        used_swap: sys.used_swap(),
+    };
+
+    // Collect CPU metrics
+    let mut cpu_metrics = Vec::new();
+
+    // Add global CPU usage
+    cpu_metrics.push(CpuMetrics {
+        name: "global".to_string(),
+        usage: sys.global_cpu_usage() as f64,
+    });
+
+    // Add individual CPU usage
+    for cpu in sys.cpus() {
+        cpu_metrics.push(CpuMetrics {
+            name: cpu.name().to_string(),
+            usage: cpu.cpu_usage() as f64,
+        });
+    }
+
+    Ok(SystemMetrics {
+        memory,
+        cpu: cpu_metrics,
+    })
 }
 
 pub mod error {

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -26,7 +26,7 @@ use std::{path::Path, time::Duration};
 use sysinfo::{Disks, System};
 use tracing::{error, info};
 
-use crate::{handlers::http::metrics_path, option::CONFIG, stats::FullStats};
+use crate::{handlers::http::metrics_path, parseable::PARSEABLE, stats::FullStats};
 use actix_web::Responder;
 use actix_web_prometheus::{PrometheusMetrics, PrometheusMetricsBuilder};
 use error::MetricsError;
@@ -419,14 +419,14 @@ pub async fn collect_all_metrics() -> Result<(), MetricsError> {
 // Function to collect disk usage metrics
 async fn collect_disk_metrics() -> Result<(), MetricsError> {
     // collect staging volume metrics
-    collect_volume_disk_usage("staging", CONFIG.staging_dir())?;
+    collect_volume_disk_usage("staging", PARSEABLE.options.staging_dir())?;
     // Collect data volume metrics for local storage
-    if CONFIG.get_storage_mode_string() == "Local drive" {
-        collect_volume_disk_usage("data", Path::new(&CONFIG.storage().get_endpoint()))?;
+    if PARSEABLE.get_storage_mode_string() == "Local drive" {
+        collect_volume_disk_usage("data", Path::new(&PARSEABLE.storage().get_endpoint()))?;
     }
 
     // Collect hot tier volume metrics if configured
-    if let Some(hot_tier_dir) = CONFIG.hot_tier_dir() {
+    if let Some(hot_tier_dir) = PARSEABLE.hot_tier_dir() {
         collect_volume_disk_usage("hot_tier", hot_tier_dir)?;
     }
 


### PR DESCRIPTION
collect CPU usage, memory usage of the server
collect disk usage of the volume - data, staging, hot-tier 
add these metrics to Prometheus Metrics

export these metrics to cluster metrics API
add the metrics to pmeta stream
add the querier node's sysinfo metrics to pmeta and cluster metrics API



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added comprehensive system metrics collection, including disk, memory, and CPU usage, with Prometheus integration for real-time monitoring.
- **Improvements**
  - Enhanced metrics endpoints to include system and disk resource usage details.
  - Streamlined internal log ingestion for improved performance.
  - Initialization processes now consistently start system and cluster metrics schedulers asynchronously.
- **Refactor**
  - Simplified stream writing logic by always writing records to disk, removing conditional checks based on stream type.
- **Bug Fixes**
  - Corrected naming and usage of metrics scheduler functions for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->