### PR TITLE
change parquet compression algorithm

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -260,7 +260,7 @@ pub struct Options {
     #[arg(
         long = "compression-algo",
         env = "P_PARQUET_COMPRESSION_ALGO",
-        default_value = "lz4",
+        default_value = "lz4_raw",
         value_parser = validation::compression,
         help = "Parquet compression algorithm"
     )]

--- a/src/correlation.rs
+++ b/src/correlation.rs
@@ -129,10 +129,9 @@ impl Correlations {
             .await?;
 
         // Update in memory
-        self.write().await.insert(
-            correlation.id.to_owned(),
-            correlation.clone(),
-        );
+        self.write()
+            .await
+            .insert(correlation.id.to_owned(), correlation.clone());
 
         Ok(correlation)
     }

--- a/src/option.rs
+++ b/src/option.rs
@@ -168,8 +168,9 @@ pub enum Compression {
     Gzip,
     Lzo,
     Brotli,
-    #[default]
     Lz4,
+    #[default]
+    Lz4Raw,
     Zstd,
 }
 
@@ -182,6 +183,7 @@ impl From<Compression> for parquet::basic::Compression {
             Compression::Lzo => parquet::basic::Compression::LZO,
             Compression::Brotli => parquet::basic::Compression::BROTLI(BrotliLevel::default()),
             Compression::Lz4 => parquet::basic::Compression::LZ4,
+            Compression::Lz4Raw => parquet::basic::Compression::LZ4_RAW,
             Compression::Zstd => parquet::basic::Compression::ZSTD(ZstdLevel::default()),
         }
     }
@@ -277,6 +279,7 @@ pub mod validation {
             "lzo" => Ok(Compression::Lzo),
             "brotli" => Ok(Compression::Brotli),
             "lz4" => Ok(Compression::Lz4),
+            "lz4_raw" => Ok(Compression::Lz4Raw),
             "zstd" => Ok(Compression::Zstd),
             _ => Err("Invalid COMPRESSION provided".to_string()),
         }


### PR DESCRIPTION
default algorithm changed from lz4 to lz4raw
lz4 is deprecated
details here - https://issues.apache.org/jira/browse/PARQUET-2032


