### PR TITLE
Cleanup post user deletion.

### DIFF
--- a/src/correlation.rs
+++ b/src/correlation.rs
@@ -198,6 +198,30 @@ impl Correlations {
 
         Ok(())
     }
+
+    pub async fn delete_correlations_for_user(
+        &self,
+        user_id: &str,
+        session_key: &SessionKey,
+    ) -> Result<(), CorrelationError> {
+        let user_correlations =
+            CORRELATIONS
+                .list_correlations(&session_key)
+                .await
+                .map_err(|error| {
+                    CorrelationError::AnyhowError(anyhow::Error::msg(error.to_string()))
+                })?;
+
+        for correlation in user_correlations.iter() {
+            CORRELATIONS
+                .delete(&correlation.id, &user_id)
+                .await
+                .map_err(|error| {
+                    CorrelationError::AnyhowError(anyhow::Error::msg(error.to_string()))
+                })?;
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/src/handlers/http/modal/ingest/ingestor_rbac.rs
+++ b/src/handlers/http/modal/ingest/ingestor_rbac.rs
@@ -18,7 +18,7 @@
 
 use std::collections::HashSet;
 
-use actix_web::{web, Responder};
+use actix_web::{web, HttpRequest, Responder};
 use tokio::sync::Mutex;
 
 use crate::{
@@ -28,6 +28,7 @@ use crate::{
         Users,
     },
     storage,
+    utils::delete_correlations_filters_dashboards_for_user,
 };
 
 // async aware lock for updating storage metadata and user map atomicically
@@ -55,13 +56,22 @@ pub async fn post_user(
 }
 
 // Handler for DELETE /api/v1/user/delete/{username}
-pub async fn delete_user(username: web::Path<String>) -> Result<impl Responder, RBACError> {
+pub async fn delete_user(
+    req: HttpRequest,
+    username: web::Path<String>,
+) -> Result<impl Responder, RBACError> {
     let username = username.into_inner();
     let _ = UPDATE_LOCK.lock().await;
     // fail this request if the user does not exists
     if !Users.contains(&username) {
         return Err(RBACError::UserDoesNotExist);
     };
+
+    // Deleting Correlations, Dashboards, Filters created by user
+    delete_correlations_filters_dashboards_for_user(&req)
+        .await
+        .map_err(|err| RBACError::Anyhow(anyhow::Error::msg(err.to_string())))?;
+
     // delete from parseable.json first
     let mut metadata = get_metadata().await?;
     metadata.users.retain(|user| user.username() != username);

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -25,10 +25,13 @@ pub mod time;
 pub mod uid;
 pub mod update;
 
+use crate::correlation::CORRELATIONS;
 use crate::handlers::http::rbac::RBACError;
 use crate::option::CONFIG;
 use crate::rbac::role::{Action, Permission};
 use crate::rbac::Users;
+use crate::users::dashboards::DASHBOARDS;
+use crate::users::filters::FILTERS;
 use actix::extract_session_key_from_req;
 use actix_web::HttpRequest;
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime, Utc};
@@ -155,6 +158,30 @@ pub fn get_user_from_request(req: &HttpRequest) -> Result<String, RBACError> {
     }
     let user_id = user_id.unwrap();
     Ok(user_id)
+}
+
+pub async fn delete_correlations_filters_dashboards_for_user(
+    req: &HttpRequest,
+) -> Result<(), RBACError> {
+    let session_key = extract_session_key_from_req(&req)
+        .map_err(|err| RBACError::Anyhow(anyhow::Error::msg(err.to_string())))?;
+
+    let user_id = get_user_from_request(&req).map(|s| get_hash(&s.to_string()))?;
+    CORRELATIONS
+        .delete_correlations_for_user(&user_id, &session_key)
+        .await
+        .map_err(|err| RBACError::Anyhow(anyhow::Error::msg(err.to_string())))?;
+
+    let dashboards = DASHBOARDS.list_dashboards_by_user(&user_id);
+    for dash in dashboards.iter() {
+        DASHBOARDS.delete_dashboard(dash.dashboard_id.as_ref().unwrap());
+    }
+
+    let filters = FILTERS.list_filters_by_user(&get_hash(&user_id));
+    for filter in filters {
+        FILTERS.delete_filter(filter.filter_id.as_ref().unwrap());
+    }
+    Ok(())
 }
 
 pub fn get_hash(key: &str) -> String {


### PR DESCRIPTION
Fixes #1137 

### Description

- Cleaning up correlations, dashboards and filters of user post User deletion.

- I need more information regarding what to cleanup after stream deletion, Can someone suggest? @nitisht @de-sh 

<hr>

This PR has:
- [ ] Cleans up correlations. dashboards and filters created by user, after user deletion
- [ ] To Do: Need to clean up things after stream deletion. 
