### PR TITLE
prepare for release v1.7.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3447,7 +3447,7 @@ dependencies = [
 
 [[package]]
 name = "parseable"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,8 +139,8 @@ arrow = "54.0.0"
 temp-dir = "0.1.14"
 
 [package.metadata.parseable_ui]
-assets-url = "https://github.com/parseablehq/console/releases/download/v0.9.19/build.zip"
-assets-sha1 = "9a2627d7991ff5d7b645986989abb84706dc66ca"
+assets-url = "https://github.com/parseablehq/console/releases/download/v0.9.20/build.zip"
+assets-sha1 = "58eb74bdb6727b5df04d6f9f339cf370c0bf4eec"
 
 [features]
 debug = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parseable"
-version = "1.7.3"
+version = "1.7.4"
 authors = ["Parseable Team <hi@parseable.com>"]
 edition = "2021"
 rust-version = "1.83.0"
@@ -139,8 +139,8 @@ arrow = "54.0.0"
 temp-dir = "0.1.14"
 
 [package.metadata.parseable_ui]
-assets-url = "https://github.com/parseablehq/console/releases/download/v0.9.18/build.zip"
-assets-sha1 = "4516db38c8e556707b29b33569f9b1e53d5165f2"
+assets-url = "https://github.com/parseablehq/console/releases/download/v0.9.19/build.zip"
+assets-sha1 = "9a2627d7991ff5d7b645986989abb84706dc66ca"
 
 [features]
 debug = []


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Bumped package version from 1.7.3 to 1.7.4.
  - Updated UI asset metadata to reference the latest release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->