### PR TITLE
refactor: assosicate flattening with JSON data

### DIFF
--- a/src/connectors/kafka/processor.rs
+++ b/src/connectors/kafka/processor.rs
@@ -56,11 +56,12 @@ impl ParseableSinkProcessor {
         let schema_version = STREAM_INFO.get_schema_version(stream_name)?;
 
         let (json_vec, total_payload_size) = Self::json_vec(records);
-        let batch_json_event = format::json::Event {
-            data: Value::Array(json_vec.to_vec()),
-        };
 
-        let (rb, is_first) = batch_json_event.into_recordbatch(
+        let (rb, is_first) = format::json::Event {
+            data: Value::Array(json_vec.to_vec()),
+            source: LogSource::Json,
+        }
+        .into_recordbatch(
             &schema,
             static_schema_flag,
             time_partition.as_ref(),


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

Ingestion in the case of JSON data happens as a flattened data, with this change we are headed towards handling ingestion as unflattened JSON that is internally transformed(not externally), encapsulating all flattening logic into one place and restricting the code-spread

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
