### PR TITLE
fix: query staging(in-mem) when concerned with the past 5 minutes

### DIFF
--- a/src/query/stream_schema_provider.rs
+++ b/src/query/stream_schema_provider.rs
@@ -739,14 +739,12 @@ pub fn include_now(filters: &[Expr], time_partition: &Option<String>) -> bool {
 
     let time_filters = extract_primary_filter(filters, time_partition);
 
-    let upper_bound_matches = time_filters.iter().any(|filter| match filter {
+    if time_filters.iter().any(|filter| match filter {
         PartialTimeFilter::High(Bound::Excluded(time))
         | PartialTimeFilter::High(Bound::Included(time))
-        | PartialTimeFilter::Eq(time) => time > &current_minute,
+        | PartialTimeFilter::Eq(time) => time >= &current_minute,
         _ => false,
-    });
-
-    if upper_bound_matches {
+    }) {
         return true;
     }
 

--- a/src/query/stream_schema_provider.rs
+++ b/src/query/stream_schema_provider.rs
@@ -27,7 +27,7 @@ use crate::{
 use arrow_array::RecordBatch;
 use arrow_schema::{Schema, SchemaRef, SortOptions};
 use bytes::Bytes;
-use chrono::{DateTime, NaiveDateTime, Timelike, Utc};
+use chrono::{DateTime, NaiveDateTime, TimeDelta, Timelike, Utc};
 use datafusion::catalog::Session;
 use datafusion::common::stats::Precision;
 use datafusion::logical_expr::utils::conjunction;
@@ -442,7 +442,7 @@ impl TableProvider for StandardTableProvider {
             return Err(DataFusionError::Plan("potentially unbounded query on time range. Table scanning requires atleast one time bound".to_string()));
         }
 
-        if include_now(filters, &time_partition) {
+        if is_within_staging_window(&time_filters) {
             if let Ok(staging) = PARSEABLE.get_stream(&self.stream) {
                 let records = staging.recordbatches_cloned(&self.schema);
                 let reversed_mem_table = reversed_mem_table(records, self.schema.clone())?;
@@ -730,19 +730,19 @@ fn return_listing_time_filters(
     }
 }
 
-pub fn include_now(filters: &[Expr], time_partition: &Option<String>) -> bool {
-    let current_minute = Utc::now()
+/// We should consider data in staging for queries concerning a time period,
+/// ending within 5 minutes from now. e.g. If current time is 5
+pub fn is_within_staging_window(time_filters: &[PartialTimeFilter]) -> bool {
+    let five_minutes_back = (Utc::now() - TimeDelta::minutes(5))
         .with_second(0)
         .and_then(|x| x.with_nanosecond(0))
         .expect("zeroed value is valid")
         .naive_utc();
 
-    let time_filters = extract_primary_filter(filters, time_partition);
-
     if time_filters.iter().any(|filter| match filter {
         PartialTimeFilter::High(Bound::Excluded(time))
         | PartialTimeFilter::High(Bound::Included(time))
-        | PartialTimeFilter::Eq(time) => time >= &current_minute,
+        | PartialTimeFilter::Eq(time) => time >= &five_minutes_back,
         _ => false,
     }) {
         return true;
@@ -826,7 +826,7 @@ pub async fn collect_manifest_files(
 }
 
 // Extract start time and end time from filter predicate
-fn extract_primary_filter(
+pub fn extract_primary_filter(
     filters: &[Expr],
     time_partition: &Option<String>,
 ) -> Vec<PartialTimeFilter> {

--- a/src/utils/arrow/flight.rs
+++ b/src/utils/arrow/flight.rs
@@ -20,7 +20,7 @@ use crate::event::Event;
 use crate::handlers::http::ingest::push_logs_unchecked;
 use crate::handlers::http::query::Query as QueryJson;
 use crate::parseable::PARSEABLE;
-use crate::query::stream_schema_provider::include_now;
+use crate::query::stream_schema_provider::{extract_primary_filter, is_within_staging_window};
 use crate::{handlers::http::modal::IngestorMetadata, option::Mode};
 
 use arrow_array::RecordBatch;
@@ -131,9 +131,9 @@ pub fn send_to_ingester(start: i64, end: i64) -> bool {
         datafusion::logical_expr::Operator::Lt,
         Box::new(filter_end),
     );
-    let ex = [Expr::BinaryExpr(ex1), Expr::BinaryExpr(ex2)];
-
-    PARSEABLE.options.mode == Mode::Query && include_now(&ex, &None)
+    let time_filters =
+        extract_primary_filter(&[Expr::BinaryExpr(ex1), Expr::BinaryExpr(ex2)], &None);
+    PARSEABLE.options.mode == Mode::Query && is_within_staging_window(&time_filters)
 }
 
 fn lit_timestamp_milli(time: i64) -> Expr {


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

Currently we aren't considering the possibility of data that is in staging due to slow network or slow compaction.
Another PR will consider files inside parquet files not pushed into object store as well.

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced time filtering logic to accurately determine if queries fall within the specified staging window.
  - Improved processing of filter expressions for more efficient query operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->