### PR TITLE
fix: otel traces flattening fix

### DIFF
--- a/src/otel/traces.rs
+++ b/src/otel/traces.rs
@@ -292,7 +292,7 @@ fn flatten_span_record(span_record: &Span) -> Vec<Map<String, Value>> {
     if let Some(status) = &span_record.status {
         span_record_json.extend(flatten_status(status));
     }
-    
+
     // if span_record.events is null, code should still flatten other elements in the span record - this is handled in the if block
     // else block handles the flattening the span record that includes events and links records in each span record
     if span_records_json.is_empty() {

--- a/src/otel/traces.rs
+++ b/src/otel/traces.rs
@@ -292,7 +292,9 @@ fn flatten_span_record(span_record: &Span) -> Vec<Map<String, Value>> {
     if let Some(status) = &span_record.status {
         span_record_json.extend(flatten_status(status));
     }
-
+    
+    // if span_record.events is null, code should still flatten other elements in the span record - this is handled in the if block
+    // else block handles the flattening the span record that includes events and links records in each span record
     if span_records_json.is_empty() {
         span_records_json = vec![span_record_json];
     } else {

--- a/src/otel/traces.rs
+++ b/src/otel/traces.rs
@@ -293,9 +293,13 @@ fn flatten_span_record(span_record: &Span) -> Vec<Map<String, Value>> {
         span_record_json.extend(flatten_status(status));
     }
 
-    for span_json in &mut span_records_json {
-        for (key, value) in &span_record_json {
-            span_json.insert(key.clone(), value.clone());
+    if span_records_json.is_empty() {
+        span_records_json = vec![span_record_json];
+    } else {
+        for span_json in &mut span_records_json {
+            for (key, value) in &span_record_json {
+                span_json.insert(key.clone(), value.clone());
+            }
         }
     }
 


### PR DESCRIPTION
flatten otel traces for empty `Events` or `Links` object in span




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Streamlined telemetry data processing to directly initialize records when no previous data exists, reducing unnecessary operations and enhancing overall efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->