### PR TITLE
feat: query parquet files still in staging

### DIFF
--- a/src/query/stream_schema_provider.rs
+++ b/src/query/stream_schema_provider.rs
@@ -218,7 +218,7 @@ impl StandardTableProvider {
         Ok(())
     }
 
-    /// Create an exection plan over the records in arrows and parquet that are still in staging, awaiting push to object storage
+    /// Create an execution plan over the records in arrows and parquet that are still in staging, awaiting push to object storage
     async fn get_staging_execution_plan(
         &self,
         execution_plans: &mut Vec<Arc<dyn ExecutionPlan>>,

--- a/src/query/stream_schema_provider.rs
+++ b/src/query/stream_schema_provider.rs
@@ -218,6 +218,7 @@ impl StandardTableProvider {
         Ok(())
     }
 
+    /// Create an exection plan over the records in arrows and parquet that are still in staging, awaiting push to object storage
     async fn get_staging_execution_plan(
         &self,
         execution_plans: &mut Vec<Arc<dyn ExecutionPlan>>,


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

Currently parquet files that are still lying around in staging are not query-able, this PR fixes it.
<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an asynchronous method for creating execution plans based on records from a staging area, improving data query capabilities.

- **Refactor**
  - Enhanced modularity and clarity by reorganizing methods related to staging data handling.
  - Improved error handling for better resilience during staging data retrieval.
  - Updated method signatures for improved readability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->