### PR TITLE
feat: merge finish `.arrows` and convert to `.parquet`

### DIFF
--- a/src/handlers/http/modal/mod.rs
+++ b/src/handlers/http/modal/mod.rs
@@ -136,26 +136,6 @@ pub trait ParseableServer {
 
             health_check::shutdown().await;
 
-            // Perform S3 sync and wait for completion
-            info!("Starting data sync to S3...");
-
-            if let Err(e) = PARSEABLE.streams.prepare_parquet(true) {
-                warn!("Failed to convert arrow files to parquet. {:?}", e);
-            } else {
-                info!("Successfully converted arrow files to parquet.");
-            }
-
-            if let Err(e) = PARSEABLE
-                .storage
-                .get_object_store()
-                .upload_files_from_staging()
-                .await
-            {
-                warn!("Failed to sync local data with object store. {:?}", e);
-            } else {
-                info!("Successfully synced all data to S3.");
-            }
-
             // Initiate graceful shutdown
             info!("Graceful shutdown of HTTP server triggered");
             srv_handle.stop(true).await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,8 +59,15 @@ use reqwest::{Client, ClientBuilder};
 // It is very unlikely that panic will occur when dealing with locks.
 pub const LOCK_EXPECT: &str = "Thread shouldn't panic while holding a lock";
 
-pub const STORAGE_CONVERSION_INTERVAL: u64 = 60;
-pub const STORAGE_UPLOAD_INTERVAL: u64 = 30;
+/// Describes the duration at the end of which in-memory buffers are flushed,
+/// arrows files are "finished" and compacted into parquet files.
+pub const LOCAL_SYNC_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Duration used to configure prefix generation.
+pub const OBJECT_STORE_DATA_GRANULARITY: u32 = LOCAL_SYNC_INTERVAL.as_secs() as u32 / 60;
+
+/// Describes the duration at the end of which parquets are pushed into objectstore.
+pub const STORAGE_UPLOAD_INTERVAL: Duration = Duration::from_secs(60);
 
 // A single HTTP client for all outgoing HTTP requests from the parseable server
 static HTTP_CLIENT: Lazy<Client> = Lazy::new(|| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub const LOCAL_SYNC_INTERVAL: Duration = Duration::from_secs(60);
 pub const OBJECT_STORE_DATA_GRANULARITY: u32 = LOCAL_SYNC_INTERVAL.as_secs() as u32 / 60;
 
 /// Describes the duration at the end of which parquets are pushed into objectstore.
-pub const STORAGE_UPLOAD_INTERVAL: Duration = Duration::from_secs(60);
+pub const STORAGE_UPLOAD_INTERVAL: Duration = Duration::from_secs(30);
 
 // A single HTTP client for all outgoing HTTP requests from the parseable server
 static HTTP_CLIENT: Lazy<Client> = Lazy::new(|| {

--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -179,16 +179,6 @@ impl Parseable {
                     .unwrap_or_default())
     }
 
-    /// Writes all streams in staging onto disk, awaiting conversion into parquet.
-    /// Deletes all in memory recordbatches, freeing up rows in mem-writer.
-    pub fn flush_all_streams(&self) {
-        let streams = self.streams.read().unwrap();
-
-        for staging in streams.values() {
-            staging.flush()
-        }
-    }
-
     // validate the storage, if the proper path for staging directory is provided
     // if the proper data directory is provided, or s3 bucket is provided etc
     pub async fn validate_storage(&self) -> Result<Option<Bytes>, ObjectStorageError> {

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -49,11 +49,9 @@ use crate::{
     metadata::{LogStreamMetadata, SchemaVersion},
     metrics,
     option::Mode,
-    storage::{
-        object_storage::to_bytes, retention::Retention, StreamType, OBJECT_STORE_DATA_GRANULARITY,
-    },
+    storage::{object_storage::to_bytes, retention::Retention, StreamType},
     utils::minute_to_slot,
-    LOCK_EXPECT,
+    LOCK_EXPECT, OBJECT_STORE_DATA_GRANULARITY,
 };
 
 use super::{

--- a/src/query/listing_table_builder.rs
+++ b/src/query/listing_table_builder.rs
@@ -32,9 +32,8 @@ use itertools::Itertools;
 use object_store::{path::Path, ObjectMeta, ObjectStore};
 
 use crate::{
-    event::DEFAULT_TIMESTAMP_KEY,
-    storage::{ObjectStorage, OBJECT_STORE_DATA_GRANULARITY},
-    utils::time::TimeRange,
+    event::DEFAULT_TIMESTAMP_KEY, storage::ObjectStorage, utils::time::TimeRange,
+    OBJECT_STORE_DATA_GRANULARITY,
 };
 
 use super::PartialTimeFilter;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -57,14 +57,6 @@ pub const SCHEMA_FILE_NAME: &str = ".schema";
 pub const ALERTS_ROOT_DIRECTORY: &str = ".alerts";
 pub const MANIFEST_FILE: &str = "manifest.json";
 
-/// local sync interval to move data.records to /tmp dir of that stream.
-/// 60 sec is a reasonable value.
-pub const LOCAL_SYNC_INTERVAL: u64 = 60;
-
-/// duration used to configure prefix in objectstore and local disk structure
-/// used for storage. Defaults to 1 min.
-pub const OBJECT_STORE_DATA_GRANULARITY: u32 = (LOCAL_SYNC_INTERVAL as u32) / 60;
-
 // max concurrent request allowed for datafusion object store
 const MAX_OBJECT_STORE_REQUESTS: usize = 1000;
 

--- a/src/storage/object_storage.rs
+++ b/src/storage/object_storage.rs
@@ -712,7 +712,7 @@ pub trait ObjectStorage: Debug + Send + Sync + 'static {
     }
 
     async fn upload_files_from_staging(&self) -> Result<(), ObjectStorageError> {
-        if !Path::new(&PARSEABLE.options.staging_dir()).exists() {
+        if !PARSEABLE.options.staging_dir().exists() {
             return Ok(());
         }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -86,7 +86,7 @@ pub async fn handler(mut cancel_rx: oneshot::Receiver<()>) -> anyhow::Result<()>
                 remote_sync_inbox.send(()).unwrap_or(());
                 localsync_inbox.send(()).unwrap_or(());
                 if let Err(e) = localsync_handler.await {
-                    error!("Error joining remote_sync_handler: {e:?}");
+                    error!("Error joining localsync_handler: {e:?}");
                 }
                 if let Err(e) = remote_sync_handler.await {
                     error!("Error joining remote_sync_handler: {e:?}");

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -63,7 +63,7 @@ where
                 if warned_once {
                     warn!(
                         "Task '{task_name}' took longer than expected: {:?} (threshold: {threshold:?})",
-                        start_time.elapsed() - threshold
+                        start_time.elapsed()
                     );
                 }
                 break res.expect("Task handle shouldn't error");


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

Currently we have two parallel tasks where we first finish `.arrows` files and then in another, 5s later, we compact them into `.parquet`, with this PR we will do both tasks, one after the other and ensure that arrows are not lost due to missed sync and thus don't have to wait for the next minute.

This PR also parallelizes localsync, ensuring each stream gets flushed onto disk and compacted from arrow to parquet in a parallel fashion.

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved time interval management for synchronization by redefining constants for better type safety.
	- Streamlined the synchronization workflow with enhanced asynchronous processing for data conversion tasks.
	- Removed redundant constants and updated synchronization methods for clarity and efficiency.
	- Consolidated import statements for better organization and readability.
	- Enhanced error handling and logging during the shutdown process.
	- Removed the `flush_all_streams` method, optimizing memory management during data processing.
- **Bug Fixes**
	- Removed unused constants that may have caused confusion in data granularity handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->