### PR TITLE
refactor: utility `Minute` handles slotting by minute

### DIFF
--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -157,15 +157,15 @@ impl Stream {
             hostname.push_str(id);
         }
         let filename = format!(
-            "{}{stream_hash}.{}.minute={}.{}.{hostname}.{ARROW_FILE_EXTENSION}",
+            "{}{stream_hash}.{}.minute={}.{}{hostname}.{ARROW_FILE_EXTENSION}",
             Utc::now().format("%Y%m%dT%H%M"),
             parsed_timestamp.format("date=%Y-%m-%d.hour=%H"),
             Minute::from(parsed_timestamp).to_slot(OBJECT_STORE_DATA_GRANULARITY),
             custom_partition_values
                 .iter()
                 .sorted_by_key(|v| v.0)
-                .map(|(key, value)| format!("{key}={value}"))
-                .join(".")
+                .map(|(key, value)| format!("{key}={value}."))
+                .join("")
         );
         self.data_path.join(filename)
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -35,23 +35,6 @@ use regex::Regex;
 use sha2::{Digest, Sha256};
 use tracing::debug;
 
-/// Convert minutes to a slot range
-/// e.g. given minute = 15 and OBJECT_STORE_DATA_GRANULARITY = 10 returns "10-19"
-pub fn minute_to_slot(minute: u32, data_granularity: u32) -> Option<String> {
-    if minute >= 60 {
-        return None;
-    }
-
-    let block_n = minute / data_granularity;
-    let block_start = block_n * data_granularity;
-    if data_granularity == 1 {
-        return Some(format!("{block_start:02}"));
-    }
-
-    let block_end = (block_n + 1) * data_granularity - 1;
-    Some(format!("{block_start:02}-{block_end:02}"))
-}
-
 pub fn get_ingestor_id() -> String {
     let now = Utc::now().to_rfc3339();
     let id = get_hash(&now).to_string().split_at(15).0.to_string();

--- a/src/utils/time.rs
+++ b/src/utils/time.rs
@@ -264,7 +264,16 @@ impl TimeRange {
     }
 }
 
-/// Describes a minute block
+/// Represents a minute value (0-59) and provides methods for converting it to a slot range.
+///
+/// # Examples
+///
+/// ```
+/// use crate::utils::time::Minute;
+///
+/// let minute = Minute::try_from(15).unwrap();
+/// assert_eq!(minute.to_slot(10), "10-19");
+/// ```
 #[derive(Debug, Clone, Copy)]
 pub struct Minute {
     block: u32,

--- a/src/utils/time.rs
+++ b/src/utils/time.rs
@@ -303,7 +303,11 @@ impl From<NaiveDateTime> for Minute {
 impl Minute {
     /// Convert minutes to a slot range
     /// e.g. given minute = 15 and OBJECT_STORE_DATA_GRANULARITY = 10 returns "10-19"
+    /// 
+    /// ### PANICS
+    /// If the provided `data_granularity` value isn't cleanly divisble from 60
     pub fn to_slot(self, data_granularity: u32) -> String {
+        assert!(data_granularity % 60 == 0);
         let block_n = self.block / data_granularity;
         let block_start = block_n * data_granularity;
         if data_granularity == 1 {
@@ -499,5 +503,11 @@ mod tests {
     fn slot_30_min_from_timestamp() {
         let timestamp = NaiveDateTime::parse_from_str("2025-01-01 02:33", "%Y-%m-%d %H:%M").unwrap();
         assert_eq!(Minute::from(timestamp).to_slot(30), "30-59");
+    }
+
+    #[test]
+    #[should_panic]
+    fn illegal_slot_granularity() {
+        Minute::try_from(0).unwrap().to_slot(40);
     }
 }

--- a/src/utils/time.rs
+++ b/src/utils/time.rs
@@ -470,4 +470,34 @@ mod tests {
         let left = prefixes.iter().map(String::as_str).collect::<Vec<&str>>();
         assert_eq!(left.as_slice(), right);
     }
+
+    #[test]
+    fn valid_minute_to_minute_slot() {
+        let res = Minute::try_from(10);
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap().to_slot(1), "10");
+    }
+
+    #[test]
+    fn invalid_minute() {
+        assert!(Minute::try_from(100).is_err());
+    }
+
+    #[test]
+    fn minute_from_timestamp() {
+        let timestamp = NaiveDateTime::parse_from_str("2025-01-01 02:03", "%Y-%m-%d %H:%M").unwrap();
+        assert_eq!(Minute::from(timestamp).to_slot(1), "03");
+    }
+
+    #[test]
+    fn slot_5_min_from_timestamp() {
+        let timestamp = NaiveDateTime::parse_from_str("2025-01-01 02:03", "%Y-%m-%d %H:%M").unwrap();
+        assert_eq!(Minute::from(timestamp).to_slot(5), "00-04");
+    }
+
+    #[test]
+    fn slot_30_min_from_timestamp() {
+        let timestamp = NaiveDateTime::parse_from_str("2025-01-01 02:33", "%Y-%m-%d %H:%M").unwrap();
+        assert_eq!(Minute::from(timestamp).to_slot(30), "30-59");
+    }
 }

--- a/src/utils/time.rs
+++ b/src/utils/time.rs
@@ -307,7 +307,7 @@ impl Minute {
     /// ### PANICS
     /// If the provided `data_granularity` value isn't cleanly divisble from 60
     pub fn to_slot(self, data_granularity: u32) -> String {
-        assert!(data_granularity % 60 == 0);
+        assert!(60 % data_granularity == 0);
         let block_n = self.block / data_granularity;
         let block_start = block_n * data_granularity;
         if data_granularity == 1 {


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->
1. Time is directly formatted into the expected name format
2. Improved tests and sensible conversion to improve readability

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined file naming to use a unified format that consolidates date, hour, and minute components.
  - Enhanced time-handling logic for consistent filename generation.

- **Chores**
  - Removed the outdated time conversion utility.

- **Tests**
  - Adjusted validation tests to reflect the new file naming format.
  - Added new tests for the `Minute` struct to validate functionality.

- **New Features**
  - Introduced a new `Minute` struct for improved minute handling and slot generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->