### PR TITLE
feat: dont allow custom and time partition together

### DIFF
--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -468,21 +468,10 @@ impl Parseable {
         }
 
         if !time_partition.is_empty() && custom_partition.is_some() {
-            let custom_partition_list = custom_partition
-                .as_ref()
-                .unwrap()
-                .split(',')
-                .collect::<Vec<&str>>();
-            if custom_partition_list.contains(&time_partition.as_str()) {
-                return Err(CreateStreamError::Custom {
-                    msg: format!(
-                        "time partition {} cannot be set as custom partition",
-                        time_partition
-                    ),
-                    status: StatusCode::BAD_REQUEST,
-                }
-                .into());
-            }
+            return Err(StreamError::Custom {
+                msg: "Cannot set both time partition and custom partition".to_string(),
+                status: StatusCode::BAD_REQUEST,
+            });
         }
 
         let schema = validate_static_schema(
@@ -630,9 +619,17 @@ impl Parseable {
         stream_name: &str,
         custom_partition: Option<&String>,
     ) -> Result<(), StreamError> {
+        let stream = self.get_stream(stream_name).expect(STREAM_EXISTS);
+        if stream.get_time_partition().is_some() {
+            return Err(StreamError::Custom {
+                msg: "Cannot set both time partition and custom partition".to_string(),
+                status: StatusCode::BAD_REQUEST,
+            });
+        }
         if let Some(custom_partition) = custom_partition {
             validate_custom_partition(custom_partition)?;
         }
+
         self.update_custom_partition_in_stream(stream_name.to_string(), custom_partition)
             .await?;
 
@@ -829,9 +826,9 @@ pub fn validate_time_partition_limit(
 
 pub fn validate_custom_partition(custom_partition: &str) -> Result<(), CreateStreamError> {
     let custom_partition_list = custom_partition.split(',').collect::<Vec<&str>>();
-    if custom_partition_list.len() > 3 {
+    if custom_partition_list.len() > 1 {
         return Err(CreateStreamError::Custom {
-            msg: "Maximum 3 custom partition keys are supported".to_string(),
+            msg: "Maximum 1 custom partition key is supported".to_string(),
             status: StatusCode::BAD_REQUEST,
         });
     }


### PR DESCRIPTION
stream creation should fail if time and custom partition flags are set
also, allow only one field for custom partition

update stream should fail if user tries to set custom partition when time partition already exists

needs change in console as well
currently console allows 3 custom partition fields that need to be updated to allow 1 field



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Stream partition validation now provides clearer error messages when both time and custom partitions are configured.
  - Custom partition settings are limited to one key to ensure a more straightforward configuration experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->