### PR TITLE
fix: ensure panic safety

### DIFF
--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -58,6 +58,9 @@ use crate::{
 mod staging;
 mod streams;
 
+/// File extension for arrow files in staging
+const ARROW_FILE_EXTENSION: &str = "data.arrows";
+
 /// Name of a Stream
 /// NOTE: this used to be a struct, flattened out for simplicity
 pub type LogStream = String;

--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -59,7 +59,7 @@ mod staging;
 mod streams;
 
 /// File extension for arrow files in staging
-const ARROW_FILE_EXTENSION: &str = "data.arrows";
+const ARROW_FILE_EXTENSION: &str = "arrows";
 
 /// Name of a Stream
 /// NOTE: this used to be a struct, flattened out for simplicity

--- a/src/parseable/staging/reader.rs
+++ b/src/parseable/staging/reader.rs
@@ -263,7 +263,7 @@ pub fn get_reverse_reader<T: Read + Seek>(
                 messages.push((header, offset, size));
                 offset += size;
             }
-            Err(err) if err.kind() == io::ErrorKind::UnexpectedEof => break,
+            Err(err) if err.kind() == io::ErrorKind::UnexpectedEof && messages.len() > 0 => break,
             Err(err) => return Err(err),
         }
     }

--- a/src/parseable/staging/reader.rs
+++ b/src/parseable/staging/reader.rs
@@ -263,7 +263,7 @@ pub fn get_reverse_reader<T: Read + Seek>(
                 messages.push((header, offset, size));
                 offset += size;
             }
-            Err(err) if err.kind() == io::ErrorKind::UnexpectedEof && messages.len() > 0 => break,
+            Err(err) if err.kind() == io::ErrorKind::UnexpectedEof && !messages.is_empty() => break,
             Err(err) => return Err(err),
         }
     }

--- a/src/parseable/staging/reader.rs
+++ b/src/parseable/staging/reader.rs
@@ -85,14 +85,17 @@ impl MergedReverseRecordReader {
     pub fn try_new(file_paths: &[PathBuf]) -> Self {
         let mut readers = Vec::with_capacity(file_paths.len());
         for path in file_paths {
-            let Ok(file) = File::open(&path) else {
+            let Ok(file) = File::open(path) else {
                 warn!("Error when trying to read file: {path:?}");
                 continue;
             };
 
-            let Ok(reader) = get_reverse_reader(file) else {
-                error!("Invalid file detected, ignoring it: {path:?}");
-                continue;
+            let reader = match get_reverse_reader(file) {
+                Ok(r) => r,
+                Err(err) => {
+                    error!("Invalid file detected, ignoring it: {path:?}; error = {err}");
+                    continue;
+                }
             };
 
             readers.push(reader);

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -154,7 +154,7 @@ impl Stream {
             hostname.push_str(id);
         }
         let filename = format!(
-            "{}{stream_hash}.date={}.hour={:02}.minute={}.{}{hostname}.{ARROW_FILE_EXTENSION}",
+            "{}{stream_hash}.date={}.hour={:02}.minute={}.{}{hostname}.data.{ARROW_FILE_EXTENSION}",
             Utc::now().format("%Y%m%dT%H%M"),
             parsed_timestamp.date(),
             parsed_timestamp.hour(),
@@ -881,7 +881,7 @@ mod tests {
         );
 
         let expected_path = staging.data_path.join(format!(
-            "{}{stream_hash}.date={}.hour={:02}.minute={}.{}.{ARROW_FILE_EXTENSION}",
+            "{}{stream_hash}.date={}.hour={:02}.minute={}.{}.data.{ARROW_FILE_EXTENSION}",
             Utc::now().format("%Y%m%dT%H%M"),
             parsed_timestamp.date(),
             parsed_timestamp.hour(),
@@ -916,7 +916,7 @@ mod tests {
         );
 
         let expected_path = staging.data_path.join(format!(
-            "{}{stream_hash}.date={}.hour={:02}.minute={}.key1=value1.key2=value2.{}.{ARROW_FILE_EXTENSION}",
+            "{}{stream_hash}.date={}.hour={:02}.minute={}.key1=value1.key2=value2.{}.data.{ARROW_FILE_EXTENSION}",
             Utc::now().format("%Y%m%dT%H%M"),
             parsed_timestamp.date(),
             parsed_timestamp.hour(),

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -505,7 +505,7 @@ impl Stream {
                         Ok(meta) => meta.len(),
                         Err(err) => {
                             warn!(
-                                "Looks like the file ({}) was removed; Error = {err}",
+                                "File ({}) not found; Error = {err}",
                                 file.display()
                             );
                             continue;

--- a/src/storage/object_storage.rs
+++ b/src/storage/object_storage.rs
@@ -461,16 +461,12 @@ pub trait ObjectStorage: Debug + Send + Sync + 'static {
     ) -> Result<Option<Manifest>, ObjectStorageError> {
         let path = manifest_path(path.as_str());
         match self.get_object(&path).await {
-            Ok(bytes) => Ok(Some(
-                serde_json::from_slice(&bytes).expect("manifest is valid json"),
-            )),
-            Err(err) => {
-                if matches!(err, ObjectStorageError::NoSuchKey(_)) {
-                    Ok(None)
-                } else {
-                    Err(err)
-                }
+            Ok(bytes) => {
+                let manifest = serde_json::from_slice(&bytes)?;
+                Ok(Some(manifest))
             }
+            Err(ObjectStorageError::NoSuchKey(_)) => Ok(None),
+            Err(err) => Err(err),
         }
     }
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description
Don't panic when file metadata can't be extracted because file doesn't exist

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling to ensure smoother file processing and reduce unexpected interruptions. Users benefit from a more resilient system that gracefully handles issues during file data retrieval.

- **Refactor**
  - Streamlined logging messages and standardized internal reporting labels for consistency and clarity, enhancing overall operational stability without affecting visible functionality.
  - Introduced a new constant for arrow file extensions to standardize file handling.
  - Enhanced clarity in method parameters for better understanding of expected inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->