### PR TITLE
refactor: remove use of `lazy_static`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3478,7 +3478,6 @@ dependencies = [
  "humantime",
  "humantime-serde",
  "itertools 0.14.0",
- "lazy_static",
  "num_cpus",
  "object_store",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,6 @@ bytes = "1.4"
 clokwerk = "0.4"
 derive_more = { version = "1", features = ["full"] }
 itertools = "0.14"
-lazy_static = "1.4"
 once_cell = "1.20"
 rand = "0.8.5"
 regex = "1.7.3"

--- a/src/handlers/http/health_check.rs
+++ b/src/handlers/http/health_check.rs
@@ -27,15 +27,14 @@ use actix_web::{
     HttpResponse,
 };
 use http::StatusCode;
+use once_cell::sync::Lazy;
 use tokio::{sync::Mutex, task::JoinSet};
 use tracing::{error, info, warn};
 
 use crate::parseable::PARSEABLE;
 
 // Create a global variable to store signal status
-lazy_static::lazy_static! {
-    pub static ref SIGNAL_RECEIVED: Arc<Mutex<bool>> = Arc::new(Mutex::new(false));
-}
+static SIGNAL_RECEIVED: Lazy<Arc<Mutex<bool>>> = Lazy::new(|| Arc::new(Mutex::new(false)));
 
 pub async fn liveness() -> HttpResponse {
     HttpResponse::new(StatusCode::OK)


### PR DESCRIPTION
ref: https://github.com/rust-lang-nursery/lazy-static.rs/issues/214

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chore**
  - Removed an outdated dependency to streamline internal code maintenance.
- **Refactor**
  - Enhanced internal state management by updating initialization routines and encapsulating key variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->