### PR TITLE
fix: multi threaded query execution

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -264,7 +264,7 @@ pub struct Options {
     #[arg(
         long,
         env = "P_PARQUET_ROW_GROUP_SIZE",
-        default_value = "1048576",
+        default_value = "262144",
         help = "Number of rows in a row group"
     )]
     pub row_group_size: usize,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -260,7 +260,8 @@ pub struct Options {
         help = "Set a fixed memory limit for query in GiB"
     )]
     pub query_memory_pool_size: Option<usize>,
-
+    // reduced the max row group size from 1048576
+    // smaller row groups help in faster query performance in multi threaded query
     #[arg(
         long,
         env = "P_PARQUET_ROW_GROUP_SIZE",

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -91,7 +91,6 @@ impl Query {
         let mut config = SessionConfig::default()
             .with_parquet_pruning(true)
             .with_prefer_existing_sort(true)
-            .with_information_schema(true)
             .with_batch_size(1000000)
             .with_coalesce_batches(true);
 
@@ -142,9 +141,7 @@ impl Query {
             .execute_logical_plan(self.final_logical_plan(&time_partition))
             .await?;
 
-        let optimised_df = df.repartition(Partitioning::RoundRobinBatch(16))?;
-
-        let fields = optimised_df
+        let fields = df
             .schema()
             .fields()
             .iter()
@@ -156,7 +153,7 @@ impl Query {
             return Ok((vec![], fields));
         }
 
-        let results = optimised_df.collect().await?;
+        let results = df.collect().await?;
         Ok((results, fields))
     }
 

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -114,6 +114,8 @@ impl Query {
             .parquet
             .schema_force_view_types = true;
 
+        config.options_mut().execution.parquet.binary_as_string = true;
+
         let state = SessionStateBuilder::new()
             .with_default_features()
             .with_config(config)

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -91,9 +91,7 @@ impl Query {
         let mut config = SessionConfig::default()
             .with_parquet_pruning(true)
             .with_prefer_existing_sort(true)
-            .with_batch_size(1000000)
-            .with_coalesce_batches(true);
-
+            .with_batch_size(1000000);
         // For more details refer https://datafusion.apache.org/user-guide/configs.html
 
         // Pushdown filters allows DF to push the filters as far down in the plan as possible

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -91,7 +91,8 @@ impl Query {
         let mut config = SessionConfig::default()
             .with_parquet_pruning(true)
             .with_prefer_existing_sort(true)
-            .with_round_robin_repartition(true);
+            .with_round_robin_repartition(true)
+            .with_batch_size(8192);
 
         // For more details refer https://datafusion.apache.org/user-guide/configs.html
 
@@ -135,6 +136,7 @@ impl Query {
         SessionContext::new_with_state(state)
     }
 
+    #[tokio::main(flavor = "multi_thread")]
     pub async fn execute(
         &self,
         stream_name: String,

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -88,11 +88,12 @@ impl Query {
         let runtime_config = runtime_config.with_memory_limit(pool_size, fraction);
         let runtime = Arc::new(runtime_config.build().unwrap());
 
+        // All the config options are explained here -
+        // https://datafusion.apache.org/user-guide/configs.html
         let mut config = SessionConfig::default()
             .with_parquet_pruning(true)
             .with_prefer_existing_sort(true)
             .with_batch_size(1000000);
-        // For more details refer https://datafusion.apache.org/user-guide/configs.html
 
         // Pushdown filters allows DF to push the filters as far down in the plan as possible
         // and thus, reducing the number of rows decoded


### PR DESCRIPTION
add multi threading execution to query execute method 
allows datafusion to use multiple threads to perform parallel execution of plans 
improves query performance




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved query processing to run in asynchronous mode for enhanced responsiveness.
  - Updated error handling to capture and report issues more effectively.
  - Refined system configuration to optimize concurrent data processing and performance.
  - Introduced new session configuration options for better execution strategies.

- **Chores**
  - Changed default value for row group size to 262144 to optimize data processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->