### PR TITLE
perf: don't construct a tokio runtime for each query

### DIFF
--- a/src/alerts/alerts_utils.rs
+++ b/src/alerts/alerts_utils.rs
@@ -31,6 +31,7 @@ use tracing::trace;
 
 use crate::{
     alerts::AggregateCondition,
+    parseable::PARSEABLE,
     query::{TableScanVisitor, QUERY_SESSION},
     rbac::{
         map::SessionKey,
@@ -137,8 +138,9 @@ async fn execute_base_query(
         AlertError::CustomError(format!("Table name not found in query- {}", original_query))
     })?;
 
+    let time_partition = PARSEABLE.get_stream(&stream_name)?.get_time_partition();
     query
-        .get_dataframe(stream_name)
+        .get_dataframe(time_partition.as_ref())
         .await
         .map_err(|err| AlertError::CustomError(err.to_string()))
 }

--- a/src/handlers/airplane.rs
+++ b/src/handlers/airplane.rs
@@ -216,11 +216,12 @@ impl FlightService for AirServiceImpl {
         })?;
         let time = Instant::now();
 
-        let stream = PARSEABLE
+        let time_partition = PARSEABLE
             .get_stream(&stream_name)
-            .map_err(|err| Status::internal(err.to_string()))?;
+            .map_err(|err| Status::internal(err.to_string()))?
+            .get_time_partition();
         let (records, _) = query
-            .execute(&stream)
+            .execute(time_partition.as_ref())
             .await
             .map_err(|err| Status::internal(err.to_string()))?;
 

--- a/src/handlers/airplane.rs
+++ b/src/handlers/airplane.rs
@@ -216,13 +216,13 @@ impl FlightService for AirServiceImpl {
         })?;
         let time = Instant::now();
 
-        let stream_name_clone = stream_name.clone();
-        let (records, _) =
-            match tokio::task::spawn_blocking(move || query.execute(stream_name_clone)).await {
-                Ok(Ok((records, fields))) => (records, fields),
-                Ok(Err(e)) => return Err(Status::internal(e.to_string())),
-                Err(err) => return Err(Status::internal(err.to_string())),
-            };
+        let stream = PARSEABLE
+            .get_stream(&stream_name)
+            .map_err(|err| Status::internal(err.to_string()))?;
+        let (records, _) = query
+            .execute(&stream)
+            .await
+            .map_err(|err| Status::internal(err.to_string()))?;
 
         /*
         * INFO: No returning the schema with the data.

--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -41,7 +41,7 @@ use crate::metrics::QUERY_EXECUTE_TIME;
 use crate::option::Mode;
 use crate::parseable::{StreamNotFound, PARSEABLE};
 use crate::query::error::ExecuteError;
-use crate::query::{CountsRequest, CountsResponse, Query as LogicalQuery};
+use crate::query::{execute, CountsRequest, CountsResponse, Query as LogicalQuery};
 use crate::query::{TableScanVisitor, QUERY_SESSION};
 use crate::rbac::Users;
 use crate::response::QueryResponse;
@@ -131,8 +131,7 @@ pub async fn query(req: HttpRequest, query_request: Query) -> Result<HttpRespons
         return Ok(HttpResponse::Ok().json(response));
     }
 
-    let time_partition = PARSEABLE.get_stream(&table_name)?.get_time_partition();
-    let (records, fields) = query.execute(time_partition.as_ref()).await?;
+    let (records, fields) = execute(query, &table_name).await?;
 
     let response = QueryResponse {
         records,

--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -19,7 +19,6 @@
 use actix_web::http::header::ContentType;
 use actix_web::web::{self, Json};
 use actix_web::{FromRequest, HttpRequest, HttpResponse, Responder};
-use arrow_array::RecordBatch;
 use chrono::{DateTime, Utc};
 use datafusion::common::tree_node::TreeNode;
 use datafusion::error::DataFusionError;
@@ -40,7 +39,7 @@ use crate::handlers::http::fetch_schema;
 use crate::event::commit_schema;
 use crate::metrics::QUERY_EXECUTE_TIME;
 use crate::option::Mode;
-use crate::parseable::PARSEABLE;
+use crate::parseable::{StreamNotFound, PARSEABLE};
 use crate::query::error::ExecuteError;
 use crate::query::{CountsRequest, CountsResponse, Query as LogicalQuery};
 use crate::query::{TableScanVisitor, QUERY_SESSION};
@@ -131,7 +130,9 @@ pub async fn query(req: HttpRequest, query_request: Query) -> Result<HttpRespons
 
         return Ok(HttpResponse::Ok().json(response));
     }
-    let (records, fields) = execute_query(query, table_name.clone()).await?;
+
+    let stream = PARSEABLE.get_stream(&table_name)?;
+    let (records, fields) = query.execute(&stream).await?;
 
     let response = QueryResponse {
         records,
@@ -148,17 +149,6 @@ pub async fn query(req: HttpRequest, query_request: Query) -> Result<HttpRespons
         .observe(time);
 
     Ok(response)
-}
-
-async fn execute_query(
-    query: LogicalQuery,
-    stream_name: String,
-) -> Result<(Vec<RecordBatch>, Vec<String>), QueryError> {
-    match tokio::task::spawn_blocking(move || query.execute(stream_name)).await {
-        Ok(Ok(result)) => Ok(result),
-        Ok(Err(e)) => Err(QueryError::Execute(e)),
-        Err(e) => Err(QueryError::Anyhow(anyhow::Error::msg(e.to_string()))),
-    }
 }
 
 pub async fn get_counts(
@@ -330,6 +320,8 @@ Description: {0}"#
     ActixError(#[from] actix_web::Error),
     #[error("Error: {0}")]
     Anyhow(#[from] anyhow::Error),
+    #[error("Error: {0}")]
+    StreamNotFound(#[from] StreamNotFound)
 }
 
 impl actix_web::ResponseError for QueryError {

--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -131,8 +131,8 @@ pub async fn query(req: HttpRequest, query_request: Query) -> Result<HttpRespons
         return Ok(HttpResponse::Ok().json(response));
     }
 
-    let stream = PARSEABLE.get_stream(&table_name)?;
-    let (records, fields) = query.execute(&stream).await?;
+    let time_partition = PARSEABLE.get_stream(&table_name)?.get_time_partition();
+    let (records, fields) = query.execute(time_partition.as_ref()).await?;
 
     let response = QueryResponse {
         records,
@@ -321,7 +321,7 @@ Description: {0}"#
     #[error("Error: {0}")]
     Anyhow(#[from] anyhow::Error),
     #[error("Error: {0}")]
-    StreamNotFound(#[from] StreamNotFound)
+    StreamNotFound(#[from] StreamNotFound),
 }
 
 impl actix_web::ResponseError for QueryError {

--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -28,7 +28,7 @@ use http::{header::CONTENT_TYPE, HeaderName, HeaderValue, StatusCode};
 use once_cell::sync::Lazy;
 pub use staging::StagingError;
 use streams::StreamRef;
-pub use streams::{StreamNotFound, Streams};
+pub use streams::{StreamNotFound, Streams, Stream};
 use tracing::error;
 
 #[cfg(feature = "kafka")]

--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -28,7 +28,7 @@ use http::{header::CONTENT_TYPE, HeaderName, HeaderValue, StatusCode};
 use once_cell::sync::Lazy;
 pub use staging::StagingError;
 use streams::StreamRef;
-pub use streams::{StreamNotFound, Streams, Stream};
+pub use streams::{Stream, StreamNotFound, Streams};
 use tracing::error;
 
 #[cfg(feature = "kafka")]

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -61,10 +61,13 @@ use crate::utils::time::TimeRange;
 pub static QUERY_SESSION: Lazy<SessionContext> =
     Lazy::new(|| Query::create_session_context(PARSEABLE.storage()));
 
-/// Dedicated multi-threaded runtime to run
+/// Dedicated multi-threaded runtime to run all queries on
 pub static QUERY_RUNTIME: Lazy<Runtime> =
     Lazy::new(|| Runtime::new().expect("Runtime should be constructible"));
 
+
+/// This function executes a query on the dedicated runtime, ensuring that the query is not isolated to a single CPU
+/// at a time and has access to the entire thread, enabling better concurrent processing, and thus quicker results.
 pub async fn execute(
     query: Query,
     stream_name: &str,

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -66,8 +66,8 @@ pub static QUERY_RUNTIME: Lazy<Runtime> =
     Lazy::new(|| Runtime::new().expect("Runtime should be constructible"));
 
 
-/// This function executes a query on the dedicated runtime, ensuring that the query is not isolated to a single CPU
-/// at a time and has access to the entire thread, enabling better concurrent processing, and thus quicker results.
+/// This function executes a query on the dedicated runtime, ensuring that the query is not isolated to a single thread/CPU
+/// at a time and has access to the entire thread pool, enabling better concurrent processing, and thus quicker results.
 pub async fn execute(
     query: Query,
     stream_name: &str,

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -53,7 +53,7 @@ use crate::catalog::Snapshot as CatalogSnapshot;
 use crate::event;
 use crate::handlers::http::query::QueryError;
 use crate::option::Mode;
-use crate::parseable::PARSEABLE;
+use crate::parseable::{Stream, PARSEABLE};
 use crate::storage::{ObjectStorageProvider, ObjectStoreFormat, STREAM_ROOT_DIRECTORY};
 use crate::utils::time::TimeRange;
 
@@ -129,12 +129,11 @@ impl Query {
         SessionContext::new_with_state(state)
     }
 
-    #[tokio::main(flavor = "multi_thread")]
     pub async fn execute(
         &self,
-        stream_name: String,
+        stream: &Stream,
     ) -> Result<(Vec<RecordBatch>, Vec<String>), ExecuteError> {
-        let time_partition = PARSEABLE.get_stream(&stream_name)?.get_time_partition();
+        let time_partition = stream.get_time_partition();
 
         let df = QUERY_SESSION
             .execute_logical_plan(self.final_logical_plan(&time_partition))


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Extended the public interface to support direct streaming, offering more precise notifications when a data stream is unavailable.
  - Introduced a new error variant, `StreamNotFound`, for enhanced error reporting related to stream retrieval issues.

- **Refactor**
  - Streamlined query execution by shifting to fully asynchronous processing, reducing overhead and complexity.
  - Unified error handling for clearer and faster responses during query operations.
  - Simplified control flow in alert handling by improving stream name retrieval logic.
  - Enhanced data retrieval by utilizing time partitions for more accurate data access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->