### PR TITLE
update: remove time partition stream creation

### DIFF
--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -462,13 +462,6 @@ impl Parseable {
             validate_custom_partition(custom_partition)?;
         }
 
-        if !time_partition.is_empty() && custom_partition.is_some() {
-            return Err(StreamError::Custom {
-                msg: "Cannot set both time partition and custom partition".to_string(),
-                status: StatusCode::BAD_REQUEST,
-            });
-        }
-
         let schema = validate_static_schema(
             body,
             stream_name,

--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -451,11 +451,12 @@ impl Parseable {
                 .await;
         }
 
-        let time_partition_in_days = if !time_partition_limit.is_empty() {
-            Some(validate_time_partition_limit(&time_partition_limit)?)
-        } else {
-            None
-        };
+        if !time_partition.is_empty() || !time_partition_limit.is_empty() {
+            return Err(StreamError::Custom {
+                msg: "Creating stream with time partition is not supported anymore".to_string(),
+                status: StatusCode::BAD_REQUEST,
+            });
+        }
 
         if let Some(custom_partition) = &custom_partition {
             validate_custom_partition(custom_partition)?;
@@ -479,7 +480,7 @@ impl Parseable {
         self.create_stream(
             stream_name.to_string(),
             &time_partition,
-            time_partition_in_days,
+            None,
             custom_partition.as_ref(),
             static_schema_flag,
             schema,


### PR DESCRIPTION
gives error if user tries to create a stream with a time partition 
updating time partition limit is still allowed for older streams


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Stream creation now returns a clear error when unsupported time partition options are provided.

- **Refactor**
  - Simplified the validation and error handling process for stream creation, ensuring consistent responses when time partition inputs are used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->