### PR TITLE
feat: add custom fields to events

### DIFF
--- a/src/connectors/kafka/processor.rs
+++ b/src/connectors/kafka/processor.rs
@@ -16,12 +16,12 @@
  *
  */
 
-use std::sync::Arc;
-
 use async_trait::async_trait;
 use futures_util::StreamExt;
 use rdkafka::consumer::{CommitMode, Consumer};
 use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Arc;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, error};
 
@@ -29,7 +29,7 @@ use crate::{
     connectors::common::processor::Processor,
     event::{
         format::{json, EventFormat, LogSourceEntry},
-        Event as ParseableEvent,
+        Event as ParseableEvent, USER_AGENT_KEY,
     },
     parseable::PARSEABLE,
     storage::StreamType,
@@ -76,6 +76,9 @@ impl ParseableSinkProcessor {
             }
         }
 
+        let mut p_custom_fields = HashMap::new();
+        p_custom_fields.insert(USER_AGENT_KEY.to_string(), "kafka".to_string());
+
         let p_event = json::Event::new(Value::Array(json_vec)).into_event(
             stream_name.to_string(),
             total_payload_size,
@@ -85,6 +88,7 @@ impl ParseableSinkProcessor {
             time_partition.as_ref(),
             schema_version,
             StreamType::UserDefined,
+            &p_custom_fields,
         )?;
 
         Ok(p_event)

--- a/src/event/format/json.rs
+++ b/src/event/format/json.rs
@@ -149,6 +149,7 @@ impl EventFormat for Event {
         time_partition: Option<&String>,
         schema_version: SchemaVersion,
         stream_type: StreamType,
+        p_custom_fields: &HashMap<String, String>,
     ) -> Result<super::Event, anyhow::Error> {
         let custom_partition_values = match custom_partitions.as_ref() {
             Some(custom_partition) => {
@@ -168,6 +169,7 @@ impl EventFormat for Event {
             static_schema_flag,
             time_partition,
             schema_version,
+            p_custom_fields,
         )?;
 
         Ok(super::Event {

--- a/src/event/format/mod.rs
+++ b/src/event/format/mod.rs
@@ -148,7 +148,7 @@ pub trait EventFormat: Sized {
         p_custom_fields: &HashMap<String, String>,
     ) -> Result<(RecordBatch, bool), AnyError> {
         let p_timestamp = self.get_p_timestamp();
-        let (data, mut schema, is_first) = self.to_data(
+        let (data, schema, is_first) = self.to_data(
             storage_schema,
             time_partition,
             schema_version,
@@ -172,7 +172,7 @@ pub trait EventFormat: Sized {
 
         let rb = Self::decode(data, new_schema.clone())?;
 
-        let rb = add_parseable_fields(rb, p_timestamp, p_custom_fields);
+        let rb = add_parseable_fields(rb, p_timestamp, p_custom_fields)?;
 
         Ok((rb, is_first))
     }

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -37,6 +37,7 @@ use std::collections::HashMap;
 pub const DEFAULT_TIMESTAMP_KEY: &str = "p_timestamp";
 pub const USER_AGENT_KEY: &str = "p_user_agent";
 pub const SOURCE_IP_KEY: &str = "p_src_ip";
+pub const FORMAT_KEY: &str = "p_format";
 
 #[derive(Clone)]
 pub struct Event {

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -35,6 +35,8 @@ use chrono::NaiveDateTime;
 use std::collections::HashMap;
 
 pub const DEFAULT_TIMESTAMP_KEY: &str = "p_timestamp";
+pub const USER_AGENT_KEY: &str = "p_user_agent";
+pub const SOURCE_IP_KEY: &str = "p_src_ip";
 
 #[derive(Clone)]
 pub struct Event {

--- a/src/handlers/http/audit.rs
+++ b/src/handlers/http/audit.rs
@@ -23,6 +23,7 @@ use actix_web::{
     middleware::Next,
 };
 use actix_web_httpauth::extractors::basic::BasicAuth;
+use http::header::USER_AGENT;
 use ulid::Ulid;
 
 use crate::{
@@ -85,7 +86,7 @@ pub async fn audit_log_middleware(
         )
         .with_user_agent(
             req.headers()
-                .get("User-Agent")
+                .get(USER_AGENT)
                 .and_then(|a| a.to_str().ok())
                 .unwrap_or_default(),
         )


### PR DESCRIPTION
p_user_agent - fetch user_agent from request header 
p_src_ip - fetch source ip from connection info from request header

user can add additional headers to the ingest apis in the below format `x-p-<key-name>: <value>`
e.g.  `x-p-environment:dev`

server adds `environment` in the events with the value `dev` \
user can add multiple custom headers to be inserted as separate fields in the event



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Extended event processing and log ingestion to support customizable fields.
  - Now extracts additional header information, including user agent and source IP, for enhanced logging.

- **Refactor**
  - Streamlined schema handling by integrating custom fields directly into records.
  - Improved header access by standardizing key references for better consistency.
  - Added a new function for managing custom fields in log processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->