### PR TITLE
fix: ensure current slot data goes into current slot file and isn't flushed until end of the slot

### DIFF
--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -61,6 +61,9 @@ mod streams;
 /// File extension for arrow files in staging
 const ARROW_FILE_EXTENSION: &str = "arrows";
 
+/// File extension for incomplete arrow files
+const PART_FILE_EXTENSION: &str = "part";
+
 /// Name of a Stream
 /// NOTE: this used to be a struct, flattened out for simplicity
 pub type LogStream = String;

--- a/src/parseable/staging/reader.rs
+++ b/src/parseable/staging/reader.rs
@@ -335,11 +335,16 @@ mod tests {
         write_message, DictionaryTracker, IpcDataGenerator, IpcWriteOptions, StreamWriter,
     };
     use arrow_schema::{DataType, Field, Schema};
+    use chrono::Utc;
     use temp_dir::TempDir;
 
-    use crate::parseable::staging::{
-        reader::{MergedReverseRecordReader, OffsetReader},
-        writer::DiskWriter,
+    use crate::{
+        parseable::staging::{
+            reader::{MergedReverseRecordReader, OffsetReader},
+            writer::DiskWriter,
+        },
+        utils::time::TimeRange,
+        OBJECT_STORE_DATA_GRANULARITY,
     };
 
     use super::get_reverse_reader;
@@ -484,7 +489,9 @@ mod tests {
         schema: &Arc<Schema>,
         batches: &[RecordBatch],
     ) -> io::Result<()> {
-        let mut writer = DiskWriter::try_new(path, schema).expect("Failed to create StreamWriter");
+        let range = TimeRange::granularity_range(Utc::now(), OBJECT_STORE_DATA_GRANULARITY);
+        let mut writer =
+            DiskWriter::try_new(path, schema, range).expect("Failed to create StreamWriter");
 
         for batch in batches {
             writer.write(batch).expect("Failed to write batch");

--- a/src/parseable/staging/reader.rs
+++ b/src/parseable/staging/reader.rs
@@ -322,7 +322,6 @@ fn find_limit_and_type(
 #[cfg(test)]
 mod tests {
     use std::{
-        fs::File,
         io::{self, Cursor, Read},
         path::Path,
         sync::Arc,
@@ -338,7 +337,10 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema};
     use temp_dir::TempDir;
 
-    use crate::parseable::staging::reader::{MergedReverseRecordReader, OffsetReader};
+    use crate::parseable::staging::{
+        reader::{MergedReverseRecordReader, OffsetReader},
+        writer::DiskWriter,
+    };
 
     use super::get_reverse_reader;
 
@@ -482,15 +484,12 @@ mod tests {
         schema: &Arc<Schema>,
         batches: &[RecordBatch],
     ) -> io::Result<()> {
-        let file = File::create(path)?;
-        let mut writer =
-            StreamWriter::try_new(file, schema).expect("Failed to create StreamWriter");
+        let mut writer = DiskWriter::try_new(path, schema).expect("Failed to create StreamWriter");
 
         for batch in batches {
             writer.write(batch).expect("Failed to write batch");
         }
 
-        writer.finish().expect("Failed to finalize writer");
         Ok(())
     }
 
@@ -524,7 +523,7 @@ mod tests {
     #[test]
     fn test_merged_reverse_record_reader() -> io::Result<()> {
         let dir = TempDir::new().unwrap();
-        let file_path = dir.path().join("test.arrow");
+        let file_path = dir.path().join("test.data.arrows");
 
         // Create a schema
         let schema = Arc::new(Schema::new(vec![
@@ -627,7 +626,7 @@ mod tests {
     #[test]
     fn test_get_reverse_reader_single_message() -> io::Result<()> {
         let dir = TempDir::new().unwrap();
-        let file_path = dir.path().join("test_single.arrow");
+        let file_path = dir.path().join("test_single.data.arrows");
 
         // Create a schema
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));

--- a/src/parseable/staging/writer.rs
+++ b/src/parseable/staging/writer.rs
@@ -30,7 +30,7 @@ use arrow_ipc::writer::StreamWriter;
 use arrow_schema::Schema;
 use arrow_select::concat::concat_batches;
 use itertools::Itertools;
-use tracing::error;
+use tracing::{error, warn};
 
 use crate::{
     parseable::{ARROW_FILE_EXTENSION, PART_FILE_EXTENSION},
@@ -81,6 +81,11 @@ impl Drop for DiskWriter {
 
         let mut arrow_path = self.path.to_owned();
         arrow_path.set_extension(ARROW_FILE_EXTENSION);
+
+        if arrow_path.exists() {
+            warn!("File {arrow_path:?} exists and will be overwritten");
+        }
+
         if let Err(err) = std::fs::rename(&self.path, &arrow_path) {
             error!("Couldn't rename file {:?}, error = {err}", self.path);
         }

--- a/src/parseable/staging/writer.rs
+++ b/src/parseable/staging/writer.rs
@@ -32,7 +32,10 @@ use arrow_select::concat::concat_batches;
 use itertools::Itertools;
 use tracing::error;
 
-use crate::{parseable::ARROW_FILE_EXTENSION, utils::arrow::adapt_batch};
+use crate::{
+    parseable::{ARROW_FILE_EXTENSION, PART_FILE_EXTENSION},
+    utils::arrow::adapt_batch,
+};
 
 use super::StagingError;
 
@@ -50,8 +53,9 @@ pub struct DiskWriter {
 impl DiskWriter {
     /// Try to create a file to stream arrows into
     pub fn try_new(path: impl Into<PathBuf>, schema: &Schema) -> Result<Self, StagingError> {
-        let path = path.into();
-        let file = OpenOptions::new().create(true).append(true).open(&path)?;
+        let mut path = path.into();
+        path.set_extension(PART_FILE_EXTENSION);
+        let file = OpenOptions::new().write(true).create(true).open(&path)?;
         let inner = StreamWriter::try_new_buffered(file, schema)?;
 
         Ok(Self { inner, path })

--- a/src/parseable/staging/writer.rs
+++ b/src/parseable/staging/writer.rs
@@ -69,9 +69,11 @@ impl DiskWriter {
     pub fn write(&mut self, rb: &RecordBatch) -> Result<(), StagingError> {
         self.inner.write(rb).map_err(StagingError::Arrow)
     }
+}
 
+impl Drop for DiskWriter {
     /// Write the continuation bytes and mark the file as done, rename to `.data.arrows`
-    pub fn finish(&mut self) {
+    fn drop(&mut self) {
         if let Err(err) = self.inner.finish() {
             error!("Couldn't finish arrow file {:?}, error = {err}", self.path);
             return;
@@ -82,12 +84,6 @@ impl DiskWriter {
         if let Err(err) = std::fs::rename(&self.path, &arrow_path) {
             error!("Couldn't rename file {:?}, error = {err}", self.path);
         }
-    }
-}
-
-impl Drop for DiskWriter {
-    fn drop(&mut self) {
-        self.finish();
     }
 }
 

--- a/src/parseable/staging/writer.rs
+++ b/src/parseable/staging/writer.rs
@@ -55,7 +55,11 @@ impl DiskWriter {
     pub fn try_new(path: impl Into<PathBuf>, schema: &Schema) -> Result<Self, StagingError> {
         let mut path = path.into();
         path.set_extension(PART_FILE_EXTENSION);
-        let file = OpenOptions::new().write(true).create(true).open(&path)?;
+        let file = OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .create(true)
+            .open(&path)?;
         let inner = StreamWriter::try_new_buffered(file, schema)?;
 
         Ok(Self { inner, path })

--- a/src/parseable/staging/writer.rs
+++ b/src/parseable/staging/writer.rs
@@ -46,8 +46,8 @@ pub struct Writer {
 }
 
 pub struct DiskWriter {
-    pub inner: StreamWriter<BufWriter<File>>,
-    pub path: PathBuf,
+    inner: StreamWriter<BufWriter<File>>,
+    path: PathBuf,
 }
 
 impl DiskWriter {

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -28,7 +28,6 @@ use std::{
 };
 
 use arrow_array::RecordBatch;
-use arrow_ipc::writer::StreamWriter;
 use arrow_schema::{Field, Fields, Schema};
 use chrono::{NaiveDateTime, Timelike};
 use derive_more::{Deref, DerefMut};
@@ -59,7 +58,7 @@ use crate::{
 use super::{
     staging::{
         reader::{MergedRecordReader, MergedReverseRecordReader},
-        writer::Writer,
+        writer::{DiskWriter, Writer},
         StagingError,
     },
     LogStream, ARROW_FILE_EXTENSION,
@@ -133,12 +132,7 @@ impl Stream {
                     );
                     std::fs::create_dir_all(&self.data_path)?;
 
-                    let file = OpenOptions::new()
-                        .create(true)
-                        .append(true)
-                        .open(&file_path)?;
-
-                    let mut writer = StreamWriter::try_new(file, &record.schema())
+                    let mut writer = DiskWriter::new(file_path, &record.schema())
                         .expect("File and RecordBatch both are checked");
 
                     writer.write(record)?;

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -358,18 +358,11 @@ impl Stream {
     }
 
     pub fn flush(&self) {
-        let mut disk_writers = {
-            let mut writer = self.writer.lock().unwrap();
-            // Flush memory
-            writer.mem.clear();
-            // Take schema -> disk writer mapping
-            std::mem::take(&mut writer.disk)
-        };
-
-        // Flush disk
-        for writer in disk_writers.values_mut() {
-            _ = writer.finish();
-        }
+        let mut writer = self.writer.lock().unwrap();
+        // Flush memory
+        writer.mem.clear();
+        // Drop schema -> disk writer mapping, triggers flush to disk
+        writer.disk.drain();
     }
 
     fn parquet_writer_props(

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -124,7 +124,7 @@ impl Stream {
         if self.options.mode != Mode::Query || stream_type == StreamType::Internal {
             let filename =
                 self.filename_by_partition(schema_key, parsed_timestamp, custom_partition_values);
-            match guard.disk.get_mut(schema_key) {
+            match guard.disk.get_mut(&filename) {
                 Some(writer) => {
                     writer.write(record)?;
                 }
@@ -136,12 +136,12 @@ impl Stream {
                         parsed_timestamp.and_local_timezone(Utc).unwrap(),
                         OBJECT_STORE_DATA_GRANULARITY,
                     );
-                    let file_path = self.data_path.join(filename);
+                    let file_path = self.data_path.join(&filename);
                     let mut writer = DiskWriter::try_new(file_path, &record.schema(), range)
                         .expect("File and RecordBatch both are checked");
 
                     writer.write(record)?;
-                    guard.disk.insert(schema_key.to_owned(), writer);
+                    guard.disk.insert(filename, writer);
                 }
             };
         }

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -132,7 +132,7 @@ impl Stream {
                     );
                     std::fs::create_dir_all(&self.data_path)?;
 
-                    let mut writer = DiskWriter::new(file_path, &record.schema())
+                    let mut writer = DiskWriter::try_new(file_path, &record.schema())
                         .expect("File and RecordBatch both are checked");
 
                     writer.write(record)?;

--- a/src/utils/time.rs
+++ b/src/utils/time.rs
@@ -280,6 +280,11 @@ impl TimeRange {
 
         Self { start, end }
     }
+
+    /// Returns true if the provided timestamp is within the timerange
+    pub fn contains(&self, time: DateTime<Utc>) -> bool {
+        self.start <= time && self.end > time
+    }
 }
 
 /// Represents a minute value (0-59) and provides methods for converting it to a slot range.


### PR DESCRIPTION
Fixes https://github.com/parseablehq/parseable/issues/1240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new disk writing mechanism for enhanced on-disk data storage.
  - Added a new file extension constant for incomplete arrow files.
  - Enhanced `TimeRange` functionality with methods for generating granular time ranges and checking timestamp containment.

- **Refactor**
  - Streamlined the flushing process for disk writes, improving performance and reducing complexity.
  - Updated method names and signatures for clarity and consistency.
  - Updated test cases to reflect changes in the writing strategy and file naming conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->