### PR TITLE
add time field names to the list

### DIFF
--- a/src/event/format/mod.rs
+++ b/src/event/format/mod.rs
@@ -40,7 +40,7 @@ use super::{Event, DEFAULT_TIMESTAMP_KEY};
 
 pub mod json;
 
-static TIME_FIELD_NAME_PARTS: [&str; 13] = [
+static TIME_FIELD_NAME_PARTS: [&str; 11] = [
     "time",
     "date",
     "timestamp",
@@ -50,8 +50,6 @@ static TIME_FIELD_NAME_PARTS: [&str; 13] = [
     "collected",
     "start",
     "end",
-    "event",
-    "log",
     "ts",
     "dt",
 ];

--- a/src/event/format/mod.rs
+++ b/src/event/format/mod.rs
@@ -40,7 +40,21 @@ use super::{Event, DEFAULT_TIMESTAMP_KEY};
 
 pub mod json;
 
-static TIME_FIELD_NAME_PARTS: [&str; 2] = ["time", "date"];
+static TIME_FIELD_NAME_PARTS: [&str; 13] = [
+    "time",
+    "date",
+    "timestamp",
+    "created",
+    "received",
+    "ingested",
+    "collected",
+    "start",
+    "end",
+    "event",
+    "log",
+    "ts",
+    "dt",
+];
 type EventSchema = Vec<Arc<Field>>;
 
 /// Source of the logs, used to perform special processing for certain sources


### PR DESCRIPTION
add below field names to the list
```
"time","date","timestamp","created","received","ingested",
"collected","start","end","event","log","ts", "dt"
```

this list help catch most standard timestamp field names commonly used across various systems

help transform the data type to TimeStamp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded support for a wider range of time-related field names, which enhances the system's ability to detect and process various timestamp formats in event data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->