### PR TITLE
fix: prism home api

### DIFF
--- a/src/alerts/mod.rs
+++ b/src/alerts/mod.rs
@@ -886,6 +886,7 @@ pub struct AlertsInfo {
     low: u64,
     medium: u64,
     high: u64,
+    critical: u64,
 }
 
 // TODO: add RBAC
@@ -898,6 +899,7 @@ pub async fn get_alerts_info() -> Result<AlertsInfo, AlertError> {
     let mut low = 0;
     let mut medium = 0;
     let mut high = 0;
+    let mut critical = 0;
 
     for (_, alert) in alerts.iter() {
         total += 1;
@@ -911,7 +913,7 @@ pub async fn get_alerts_info() -> Result<AlertsInfo, AlertError> {
             Severity::Low => low += 1,
             Severity::Medium => medium += 1,
             Severity::High => high += 1,
-            _ => {}
+            Severity::Critical => critical += 1,
         }
     }
 
@@ -923,5 +925,6 @@ pub async fn get_alerts_info() -> Result<AlertsInfo, AlertError> {
         low,
         medium,
         high,
+        critical,
     })
 }

--- a/src/prism/home/mod.rs
+++ b/src/prism/home/mod.rs
@@ -149,7 +149,7 @@ pub async fn generate_home_response(key: &SessionKey) -> Result<HomeResponse, Pr
     let alerts_info = get_alerts_info().await?;
 
     // generate dates for date-wise stats
-    let dates = (0..7)
+    let mut dates = (0..7)
         .map(|i| {
             Utc::now()
                 .checked_sub_signed(chrono::Duration::days(i))
@@ -158,6 +158,7 @@ pub async fn generate_home_response(key: &SessionKey) -> Result<HomeResponse, Pr
         })
         .map(|date| date.format("%Y-%m-%d").to_string())
         .collect_vec();
+    dates.reverse();
 
     let mut stream_details = Vec::new();
 


### PR DESCRIPTION
1. add critical severity alert count to alerts info
2. date level stats in sorted order




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The alert system now tracks and displays the count of high-severity alerts.
  - The home section now presents dates in reverse order, ensuring the most recent dates appear first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->