### PR TITLE
fix: file pruning with notEq operator

### DIFF
--- a/src/query/stream_schema_provider.rs
+++ b/src/query/stream_schema_provider.rs
@@ -979,7 +979,6 @@ fn satisfy_constraints(value: CastRes, op: Operator, stats: &TypedStatistics) ->
     fn matches<T: std::cmp::PartialOrd>(value: T, min: T, max: T, op: Operator) -> Option<bool> {
         let val = match op {
             Operator::Eq | Operator::IsNotDistinctFrom => value >= min && value <= max,
-            Operator::NotEq => value < min && value > max,
             Operator::Lt => value > min,
             Operator::LtEq => value >= min,
             Operator::Gt => value < max,


### PR DESCRIPTION
current: all files get pruned in query for notEq operator because of incorrect condition match

fix: with notEq, we cannot determine if the file can be pruned hence, removed the check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved filtering behavior by refining how inequality conditions are evaluated, ensuring more consistent results when applying non-equality constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->