### PR TITLE
update batch size in session config

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -271,6 +271,14 @@ pub struct Options {
     pub row_group_size: usize,
 
     #[arg(
+        long,
+        env = "P_EXECUTION_BATCH_SIZE",
+        default_value = "20000",
+        help = "batch size for query execution"
+    )]
+    pub execution_batch_size: usize,
+
+    #[arg(
         long = "compression-algo",
         env = "P_PARQUET_COMPRESSION_ALGO",
         default_value = "lz4_raw",

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -111,7 +111,7 @@ impl Query {
         let mut config = SessionConfig::default()
             .with_parquet_pruning(true)
             .with_prefer_existing_sort(true)
-            .with_batch_size(1000000);
+            .with_batch_size(20000);
 
         // Pushdown filters allows DF to push the filters as far down in the plan as possible
         // and thus, reducing the number of rows decoded

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -111,7 +111,9 @@ impl Query {
         let mut config = SessionConfig::default()
             .with_parquet_pruning(true)
             .with_prefer_existing_sort(true)
-            .with_batch_size(20000);
+            //batch size has been made configurable via environment variable
+            //default value is 20000
+            .with_batch_size(PARSEABLE.options.execution_batch_size);
 
         // Pushdown filters allows DF to push the filters as far down in the plan as possible
         // and thus, reducing the number of rows decoded


### PR DESCRIPTION
current: 1000000
update to 20000

this helps in query performance as larger batch size consumes more memory and slows down performance

with this change, parseable's clickbench numbers are [182,75,75]



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a configurable batch size for query execution, allowing users to set it via environment variables or command-line arguments.
  - Default batch size is now set to `20000`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->