### PR TITLE
chore: rm`replace_columns`, unused code

### DIFF
--- a/src/event/format/mod.rs
+++ b/src/event/format/mod.rs
@@ -183,8 +183,7 @@ pub trait EventFormat: Sized {
         rb = replace_columns(
             rb.schema(),
             &rb,
-            &[0],
-            &[Arc::new(get_timestamp_array(p_timestamp, rb.num_rows()))],
+            &[(0, Arc::new(get_timestamp_array(p_timestamp, rb.num_rows())))],
         );
 
         Ok((rb, is_first))

--- a/src/utils/arrow/mod.rs
+++ b/src/utils/arrow/mod.rs
@@ -61,8 +61,7 @@ use serde_json::{Map, Value};
 ///
 /// * `schema` - The schema of the record batch.
 /// * `batch` - The record batch to modify.
-/// * `indexes` - The indexes of the columns to replace.
-/// * `arrays` - The new arrays to replace the columns with.
+/// * `indexed_arrays` - A list of indexes and arrays to replace the columns indexed with.
 ///
 /// # Returns
 ///
@@ -70,12 +69,11 @@ use serde_json::{Map, Value};
 pub fn replace_columns(
     schema: Arc<Schema>,
     batch: &RecordBatch,
-    indexes: &[usize],
-    arrays: &[Arc<dyn Array + 'static>],
+    indexed_arrays: &[(usize, Arc<dyn Array + 'static>)],
 ) -> RecordBatch {
     let mut batch_arrays = batch.columns().iter().map(Arc::clone).collect_vec();
-    for (&index, arr) in indexes.iter().zip(arrays.iter()) {
-        batch_arrays[index] = Arc::clone(arr);
+    for (index, arr) in indexed_arrays {
+        batch_arrays[*index] = Arc::clone(arr);
     }
     RecordBatch::try_new(schema, batch_arrays).unwrap()
 }
@@ -180,7 +178,7 @@ mod tests {
 
         let arr: Arc<dyn Array + 'static> = Arc::new(Int32Array::from_value(0, 3));
 
-        let new_rb = replace_columns(schema_ref.clone(), &rb, &[2], &[arr]);
+        let new_rb = replace_columns(schema_ref.clone(), &rb, &[(2, arr)]);
 
         assert_eq!(new_rb.schema(), schema_ref);
         assert_eq!(new_rb.num_columns(), 3);


### PR DESCRIPTION
https://github.com/parseablehq/parseable/pull/1218#discussion_r1976356303

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
	- Removed the `replace_columns` function and associated logic for column replacement in record batches.
- **Bug Fixes**
	- Addressed potential compilation errors by removing uninitialized variable references in the `into_recordbatch` method.
- **Chores**
	- Cleaned up unused import statements and deleted commented-out example functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->