### PR TITLE
fix: datasets API edgecase where stream is not hottiered

### DIFF
--- a/src/prism/logstream/mod.rs
+++ b/src/prism/logstream/mod.rs
@@ -24,7 +24,7 @@ use chrono::Utc;
 use http::StatusCode;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use tracing::{debug, warn};
+use tracing::{debug, error, warn};
 
 use crate::{
     handlers::http::{
@@ -45,6 +45,7 @@ use crate::{
         arrow::record_batches_to_json,
         time::{TimeParseError, TimeRange},
     },
+    validator::error::HotTierValidationError,
     LOCK_EXPECT,
 };
 
@@ -273,10 +274,13 @@ impl PrismDatasetRequest {
             } = get_prism_logstream_info(stream).await?;
 
             let hottier = match HotTierManager::global() {
-                Some(hot_tier_manager) => {
-                    let stats = hot_tier_manager.get_hot_tier(stream).await?;
-                    Some(stats)
-                }
+                Some(manager) => match manager.get_hot_tier(stream).await {
+                    Ok(stats) => Some(stats),
+                    Err(HotTierError::HotTierValidationError(
+                        HotTierValidationError::NotFound(_),
+                    )) => None,
+                    Err(err) => return Err(err.into()),
+                },
                 _ => None,
             };
             let records = CountsRequest {


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

Handles the circumstance where hottier is not configured at the stream level, but hottier is enabled at instance level

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
