### PR TITLE
Updates for list filters API

### DIFF
--- a/src/handlers/http/users/filters.rs
+++ b/src/handlers/http/users/filters.rs
@@ -31,13 +31,59 @@ use actix_web::{
 use bytes::Bytes;
 use chrono::Utc;
 use http::StatusCode;
+use once_cell::sync::Lazy;
+use regex::Regex;
 use serde_json::Error as SerdeError;
+
+#[derive(Debug, Default)]
+struct FilterQueryParams {
+    stream: Option<String>,
+    user_id: Option<String>,
+    type_param: Option<String>,
+}
+
+static FILTER_QUERY_PARAMS_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?:^|&)(stream|user_id|type)=([^&]*)").unwrap());
 
 pub async fn list(req: HttpRequest) -> Result<impl Responder, FiltersError> {
     let key =
         extract_session_key_from_req(&req).map_err(|e| FiltersError::Custom(e.to_string()))?;
-    let filters = FILTERS.list_filters(&key).await;
-    Ok((web::Json(filters), StatusCode::OK))
+    let mut filters = FILTERS.list_filters(&key).await;
+
+    let query_string = req.query_string();
+    if query_string.is_empty() {
+        Ok((web::Json(filters), StatusCode::OK))
+    } else {
+        let mut params = FilterQueryParams::default();
+
+        let re = FILTER_QUERY_PARAMS_RE.clone();
+
+        for cap in re.captures_iter(query_string) {
+            let key = cap.get(1).unwrap().as_str();
+            let value = cap.get(2).unwrap().as_str().to_string();
+
+            match key {
+                "stream" => params.stream = Some(value),
+                "user_id" => params.user_id = Some(value),
+                "type" => params.type_param = Some(value),
+                _ => {} // This shouldn't happen with our regex
+            }
+        }
+
+        if params.stream.is_some() {
+            filters.retain(|f| f.stream_name.eq(params.stream.as_ref().unwrap()));
+        }
+
+        if params.user_id.is_some() {
+            filters.retain(|f| f.user_id == Some(params.user_id.clone().unwrap()));
+        }
+
+        if params.type_param.is_some() {
+            filters.retain(|f| f.query.filter_type == params.type_param.clone().unwrap());
+        }
+
+        Ok((web::Json(filters), StatusCode::OK))
+    }
 }
 
 pub async fn get(


### PR DESCRIPTION
Adds query params `stream`, `user_id`, and `type` to the endpoint

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the filtering mechanism for user queries to support more precise retrieval based on provided query parameters such as stream, user ID, and type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->