### PR TITLE
fix: dataloss due to contention at stream creation

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -74,7 +74,7 @@ pub enum SchemaVersion {
     V1,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct LogStreamMetadata {
     pub schema_version: SchemaVersion,
     pub schema: HashMap<String, Arc<Field>>,

--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -171,7 +171,7 @@ impl Parseable {
         }
 
         // Gets write privileges only for creating the stream when it doesn't already exist.
-        self.streams.create(
+        self.streams.get_or_create(
             self.options.clone(),
             stream_name.to_owned(),
             LogStreamMetadata::default(),
@@ -342,7 +342,7 @@ impl Parseable {
             schema_version,
             log_source,
         );
-        self.streams.create(
+        self.streams.get_or_create(
             self.options.clone(),
             stream_name.to_string(),
             metadata,
@@ -652,7 +652,7 @@ impl Parseable {
                     SchemaVersion::V1, // New stream
                     log_source,
                 );
-                self.streams.create(
+                self.streams.get_or_create(
                     self.options.clone(),
                     stream_name.to_string(),
                     metadata,

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -737,7 +737,7 @@ pub struct Streams(RwLock<HashMap<String, StreamRef>>);
 // 4. When first event is sent to stream (update the schema)
 // 5. When set alert API is called (update the alert)
 impl Streams {
-    /// Checks after getting an excluse lock whether the stream already exists, else creates it.
+    /// Checks after getting an exclusive lock whether the stream already exists, else creates it.
     /// NOTE: This is done to ensure we don't have contention among threads.
     pub fn get_or_create(
         &self,

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -737,7 +737,7 @@ pub struct Streams(RwLock<HashMap<String, StreamRef>>);
 // 4. When first event is sent to stream (update the schema)
 // 5. When set alert API is called (update the alert)
 impl Streams {
-    /// Checks after getting an excluse lock whether already stream exists, else creates it.
+    /// Checks after getting an excluse lock whether the stream already exists, else creates it.
     /// NOTE: This is done to ensure we don't have contention among threads.
     pub fn get_or_create(
         &self,


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

Ensure streams are not created in a contentious manner, which may lead to dataloss

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

### Testing Methodology

1. Create a new stream with `/api/vi/ingest` only
2. Use k6 at 25vus to ensure concurrent requests for stream creation
3. Observe logs to see how streams are not being created if they have already been created

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Stream handling has been improved to automatically detect and use existing streams or create new ones as needed. This streamlined approach enhances system reliability and efficiency during stream operations, resulting in a smoother and more robust user experience.
  
- **New Features**
  - Added the ability to clone `LogStreamMetadata` instances, allowing for easier management of stream metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->