### PR TITLE
add schema to dataset api response

### DIFF
--- a/src/prism/logstream/mod.rs
+++ b/src/prism/logstream/mod.rs
@@ -204,6 +204,8 @@ pub struct PrismDatasetResponse {
     stream: String,
     /// Basic information about the stream
     info: StreamInfo,
+    /// Schema of the stream
+    schema: Arc<Schema>,
     /// Statistics for the queried timeframe
     stats: QueriedStats,
     /// Retention policy details
@@ -268,9 +270,9 @@ impl PrismDatasetRequest {
 
             let PrismLogstreamInfo {
                 info,
+                schema,
                 stats,
                 retention,
-                ..
             } = get_prism_logstream_info(stream).await?;
 
             let hottier = match HotTierManager::global() {
@@ -304,6 +306,7 @@ impl PrismDatasetRequest {
             responses.push(PrismDatasetResponse {
                 stream: stream.clone(),
                 info,
+                schema,
                 stats,
                 retention,
                 hottier,


### PR DESCRIPTION
updated response json -
```
[
    {
        "stream": "app",
        "info": {
            "created-at": "2025-03-21T06:27:50.128215731+00:00",
            "first-event-at": "2025-03-21T02:27:53.010-04:00",
            "stream_type": "UserDefined",
            "log_source": [
                {
                    "log_source_format": "Json",
                    "fields": []
                }
            ]
        },
        "schema": {
            "fields": [
                {
                    "name": "app_meta",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "device_id",
                    "data_type": "Float64",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "host",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "level",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "location",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "message",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "meta-source",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "meta-test",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "os",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "p_src_ip",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "p_timestamp",
                    "data_type": {
                        "Timestamp": [
                            "Millisecond",
                            null
                        ]
                    },
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "p_user_agent",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "process_id",
                    "data_type": "Float64",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "request_body",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "response_time",
                    "data_type": "Float64",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "runtime",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "session_id",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "source_time",
                    "data_type": {
                        "Timestamp": [
                            "Millisecond",
                            null
                        ]
                    },
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "status_code",
                    "data_type": "Float64",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "timezone",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "user_agent",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "user_id",
                    "data_type": "Float64",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "uuid",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "version",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                }
            ],
            "metadata": {}
        },
        "stats": {
            "stream": "app",
            "time": "2025-03-21T08:38:05.421778192Z",
            "ingestion": {
                "count": 40000,
                "size": 15034316,
                "format": "json",
                "lifetime_count": 40000,
                "lifetime_size": 15034316,
                "deleted_count": 0,
                "deleted_size": 0
            },
            "storage": {
                "size": 2921062,
                "format": "parquet",
                "lifetime_size": 2921062,
                "deleted_size": 0
            }
        },
        "retention": [],
        "hottier": null,
        "counts": {
            "fields": [
                "start_time",
                "end_time",
                "count"
            ],
            "records": [
                {
                    "start_time": "2025-03-21T07:38:05.421784903+00:00",
                    "end_time": "2025-03-21T07:44:05.421784903+00:00",
                    "count": 0
                },
                {
                    "start_time": "2025-03-21T07:44:05.421784903+00:00",
                    "end_time": "2025-03-21T07:50:05.421784903+00:00",
                    "count": 0
                },
                {
                    "start_time": "2025-03-21T07:50:05.421784903+00:00",
                    "end_time": "2025-03-21T07:56:05.421784903+00:00",
                    "count": 0
                },
                {
                    "start_time": "2025-03-21T07:56:05.421784903+00:00",
                    "end_time": "2025-03-21T08:02:05.421784903+00:00",
                    "count": 0
                },
                {
                    "start_time": "2025-03-21T08:02:05.421784903+00:00",
                    "end_time": "2025-03-21T08:08:05.421784903+00:00",
                    "count": 0
                },
                {
                    "start_time": "2025-03-21T08:08:05.421784903+00:00",
                    "end_time": "2025-03-21T08:14:05.421784903+00:00",
                    "count": 0
                },
                {
                    "start_time": "2025-03-21T08:14:05.421784903+00:00",
                    "end_time": "2025-03-21T08:20:05.421784903+00:00",
                    "count": 0
                },
                {
                    "start_time": "2025-03-21T08:20:05.421784903+00:00",
                    "end_time": "2025-03-21T08:26:05.421784903+00:00",
                    "count": 0
                },
                {
                    "start_time": "2025-03-21T08:26:05.421784903+00:00",
                    "end_time": "2025-03-21T08:32:05.421784903+00:00",
                    "count": 0
                },
                {
                    "start_time": "2025-03-21T08:32:05.421784903+00:00",
                    "end_time": "2025-03-21T08:38:05.421784903+00:00",
                    "count": 0
                }
            ]
        },
        "distinct_sources": {
            "ips": null,
            "user_agents": null
        }
    },
    {
        "stream": "test10",
        "info": {
            "created-at": "2025-03-21T07:50:29.407600602+00:00",
            "first-event-at": "2025-03-21T03:50:29.410-04:00",
            "stream_type": "UserDefined",
            "log_source": [
                {
                    "log_source_format": "Json",
                    "fields": []
                }
            ]
        },
        "schema": {
            "fields": [
                {
                    "name": "app_meta",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "device_id",
                    "data_type": "Float64",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "host",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "level",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "location",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "message",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "os",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "p_timestamp",
                    "data_type": {
                        "Timestamp": [
                            "Millisecond",
                            null
                        ]
                    },
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "process_id",
                    "data_type": "Float64",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "request_body",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "response_time",
                    "data_type": "Float64",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "runtime",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "session_id",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "source_time",
                    "data_type": {
                        "Timestamp": [
                            "Millisecond",
                            null
                        ]
                    },
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "status_code",
                    "data_type": "Float64",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "timezone",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "user_agent",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "user_id",
                    "data_type": "Float64",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "uuid",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                },
                {
                    "name": "version",
                    "data_type": "Utf8",
                    "nullable": true,
                    "dict_id": 0,
                    "dict_is_ordered": false,
                    "metadata": {}
                }
            ],
            "metadata": {}
        },
        "stats": {
            "stream": "test10",
            "time": "2025-03-21T08:38:05.424866128Z",
            "ingestion": {
                "count": 1043100,
                "size": 402467342,
                "format": "json",
                "lifetime_count": 1043100,
                "lifetime_size": 402467342,
                "deleted_count": 0,
                "deleted_size": 0
            },
            "storage": {
                "size": 133742440,
                "format": "parquet",
                "lifetime_size": 133742440,
                "deleted_size": 0
            }
        },
        "retention": [],
        "hottier": null,
        "counts": {
            "fields": [
                "start_time",
                "end_time",
                "count"
            ],
            "records": [
                {
                    "start_time": "2025-03-21T07:38:05.424869774+00:00",
                    "end_time": "2025-03-21T07:44:05.424869774+00:00",
                    "count": 0
                },
                {
                    "start_time": "2025-03-21T07:44:05.424869774+00:00",
                    "end_time": "2025-03-21T07:50:05.424869774+00:00",
                    "count": 0
                },
                {
                    "start_time": "2025-03-21T07:50:05.424869774+00:00",
                    "end_time": "2025-03-21T07:56:05.424869774+00:00",
                    "count": 1042950
                },
                {
                    "start_time": "2025-03-21T07:56:05.424869774+00:00",
                    "end_time": "2025-03-21T08:02:05.424869774+00:00",
                    "count": 0
                },
                {
                    "start_time": "2025-03-21T08:02:05.424869774+00:00",
                    "end_time": "2025-03-21T08:08:05.424869774+00:00",
                    "count": 0
                },
                {
                    "start_time": "2025-03-21T08:08:05.424869774+00:00",
                    "end_time": "2025-03-21T08:14:05.424869774+00:00",
                    "count": 0
                },
                {
                    "start_time": "2025-03-21T08:14:05.424869774+00:00",
                    "end_time": "2025-03-21T08:20:05.424869774+00:00",
                    "count": 0
                },
                {
                    "start_time": "2025-03-21T08:20:05.424869774+00:00",
                    "end_time": "2025-03-21T08:26:05.424869774+00:00",
                    "count": 0
                },
                {
                    "start_time": "2025-03-21T08:26:05.424869774+00:00",
                    "end_time": "2025-03-21T08:32:05.424869774+00:00",
                    "count": 0
                },
                {
                    "start_time": "2025-03-21T08:32:05.424869774+00:00",
                    "end_time": "2025-03-21T08:38:05.424869774+00:00",
                    "count": 0
                }
            ]
        },
        "distinct_sources": {
            "ips": null,
            "user_agents": null
        }
    }
]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced dataset responses to include detailed schema information, allowing for a richer representation of queried streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->