### PR TITLE
fix: query for datasets api

### DIFF
--- a/src/prism/logstream/mod.rs
+++ b/src/prism/logstream/mod.rs
@@ -336,7 +336,7 @@ impl PrismDatasetRequest {
         field: &str,
     ) -> Result<Vec<String>, QueryError> {
         let query = Query {
-            query: format!("SELECT DISTINCT({field}) FOR {stream_name}"),
+            query: format!("SELECT DISTINCT({field}) FROM {stream_name}"),
             start_time: "1h".to_owned(),
             end_time: "now".to_owned(),
             send_null: false,


### PR DESCRIPTION
fix the queries -
 for distinct p_src_ip -
`select distinct(p_src_ip) from <stream-name>`

for distinct p_user_agent -
`select distinct(p_user_agent) from <stream-name>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected an issue with data retrieval queries to ensure they execute consistently and adhere to standard SQL conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->