### PR TITLE
restrict otel ingestion

### DIFF
--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -427,11 +427,6 @@ impl Parseable {
         log_source: Vec<LogSourceEntry>,
     ) -> Result<bool, PostError> {
         if self.streams.contains(stream_name) {
-            for stream_log_source in log_source {
-                self.add_update_log_source(stream_name, stream_log_source)
-                    .await?;
-            }
-
             return Ok(true);
         }
 
@@ -443,7 +438,7 @@ impl Parseable {
                 .create_stream_and_schema_from_storage(stream_name)
                 .await?
         {
-            return Ok(false);
+            return Ok(true);
         }
 
         self.create_stream(


### PR DESCRIPTION
log ingestion is not allowed
if stream is already associated with otel metrics or traces

metrics ingestion is not allowed
if stream is already associated with otel traces or any log formats

similarly, traces ingestion is not allowed
if stream is already associated with otel metrics or any log formats

otel logs can be ingested with other log formats


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced error handling for log ingestion, providing users with clearer notifications when unsupported log formats are detected.

- **Refactor**
  - Streamlined the logic for handling existing streams, ensuring more accurate confirmation of stream existence and improving overall ingestion efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->