### PR TITLE
feat: mask PII data if env is set

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -174,6 +174,14 @@ pub struct Options {
     )]
     pub send_analytics: bool,
 
+    #[arg(
+        long,
+        env = "P_MASK_PII",
+        default_value = "false",
+        help = "mask PII data when sending to Prism"
+    )]
+    pub mask_pii: bool,
+
     // TLS/Security
     #[arg(
         long,


### PR DESCRIPTION
New environment variable `P_MASK_PII` is added
if set to true, server masks the PII data as per below -

1. emails are masked like `test@example.com` -> `TXXX@XXX`
2. urls are sent as None
3. strings are masked as all `X`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a configuration option that allows users to enable or disable masking of personally identifiable data.
  - Enhanced privacy by automatically obscuring sensitive information such as email details and URLs when masking is active.

- **Tests**
  - Added comprehensive tests to ensure the new data masking functionality works as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->