### PR TITLE
feat: re-enable time-partitioning

### DIFF
--- a/src/event/format/json.rs
+++ b/src/event/format/json.rs
@@ -179,7 +179,7 @@ impl EventFormat for Event {
             origin_size,
             is_first_event,
             parsed_timestamp,
-            time_partition: None,
+            time_partitioned: time_partition.is_some(),
             custom_partition_values,
             stream_type,
         })

--- a/src/event/format/json.rs
+++ b/src/event/format/json.rs
@@ -179,7 +179,7 @@ impl EventFormat for Event {
             origin_size,
             is_first_event,
             parsed_timestamp,
-            time_partitioned: time_partition.is_some(),
+            is_time_partitioned: time_partition.is_some(),
             custom_partition_values,
             stream_type,
         })

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -47,7 +47,7 @@ pub struct Event {
     pub origin_size: u64,
     pub is_first_event: bool,
     pub parsed_timestamp: NaiveDateTime,
-    pub time_partitioned: bool,
+    pub is_time_partitioned: bool,
     pub custom_partition_values: HashMap<String, String>,
     pub stream_type: StreamType,
 }
@@ -56,7 +56,7 @@ pub struct Event {
 impl Event {
     pub fn process(self) -> Result<(), EventError> {
         let mut key = get_schema_key(&self.rb.schema().fields);
-        if self.time_partitioned {
+        if self.is_time_partitioned {
             // For time partitioned streams, concatenate timestamp to filename, ensuring we don't write to a finished arrows file
             let curr_timestamp = Utc::now().format("%Y%m%dT%H%M").to_string();
             key.push_str(&curr_timestamp);

--- a/src/handlers/http/ingest.rs
+++ b/src/handlers/http/ingest.rs
@@ -296,7 +296,7 @@ pub async fn push_logs_unchecked(
         origin_format: "json",
         origin_size: 0,
         parsed_timestamp: Utc::now().naive_utc(),
-        time_partition: None,
+        time_partitioned: false,
         is_first_event: true,                    // NOTE: Maybe should be false
         custom_partition_values: HashMap::new(), // should be an empty map for unchecked push
         stream_type: StreamType::UserDefined,

--- a/src/handlers/http/ingest.rs
+++ b/src/handlers/http/ingest.rs
@@ -296,7 +296,7 @@ pub async fn push_logs_unchecked(
         origin_format: "json",
         origin_size: 0,
         parsed_timestamp: Utc::now().naive_utc(),
-        time_partitioned: false,
+        is_time_partitioned: false,
         is_first_event: true,                    // NOTE: Maybe should be false
         custom_partition_values: HashMap::new(), // should be an empty map for unchecked push
         stream_type: StreamType::UserDefined,

--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -557,15 +557,21 @@ impl Parseable {
                 .await;
         }
 
-        if !time_partition.is_empty() || !time_partition_limit.is_empty() {
-            return Err(StreamError::Custom {
-                msg: "Creating stream with time partition is not supported anymore".to_string(),
-                status: StatusCode::BAD_REQUEST,
-            });
-        }
+        let time_partition_in_days = if !time_partition_limit.is_empty() {
+            Some(validate_time_partition_limit(&time_partition_limit)?)
+        } else {
+            None
+        };
 
         if let Some(custom_partition) = &custom_partition {
             validate_custom_partition(custom_partition)?;
+        }
+
+        if !time_partition.is_empty() && custom_partition.is_some() {
+            return Err(StreamError::Custom {
+                msg: "Cannot set both time partition and custom partition".to_string(),
+                status: StatusCode::BAD_REQUEST,
+            });
         }
 
         let schema = validate_static_schema(
@@ -579,7 +585,7 @@ impl Parseable {
         self.create_stream(
             stream_name.to_string(),
             &time_partition,
-            None,
+            time_partition_in_days,
             custom_partition.as_ref(),
             static_schema_flag,
             schema,

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -144,10 +144,8 @@ impl Stream {
                     // entry is not present thus we create it
                     std::fs::create_dir_all(&self.data_path)?;
 
-                    let range = TimeRange::granularity_range(
-                        parsed_timestamp.and_local_timezone(Utc).unwrap(),
-                        OBJECT_STORE_DATA_GRANULARITY,
-                    );
+                    let range =
+                        TimeRange::granularity_range(Utc::now(), OBJECT_STORE_DATA_GRANULARITY);
                     let file_path = self.data_path.join(&filename);
                     let mut writer = DiskWriter::try_new(file_path, &record.schema(), range)
                         .expect("File and RecordBatch both are checked");

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -144,6 +144,7 @@ impl Stream {
                     // entry is not present thus we create it
                     std::fs::create_dir_all(&self.data_path)?;
 
+                    // Use current time for partitioning to ensure consistent partition boundaries
                     let range =
                         TimeRange::granularity_range(Utc::now(), OBJECT_STORE_DATA_GRANULARITY);
                     let file_path = self.data_path.join(&filename);


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated event partitioning to use a clear true/false indicator for improved and consistent timestamp handling.
  - Enhanced validations during stream updates to prevent conflicts when selecting partitioning options.
- **Bug Fixes**
  - Corrected logic in event processing to ensure timestamps are based on the current time rather than outdated values.
  - Adjusted handling of time partitioning in event ingestion to reflect the new boolean structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->