### PR TITLE
add `timeTaken` to query response

### DIFF
--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -67,6 +67,7 @@ pub struct Query {
 }
 
 pub async fn query(req: HttpRequest, query_request: Query) -> Result<HttpResponse, QueryError> {
+    let start = Instant::now();
     let session_state = QUERY_SESSION.state();
     let raw_logical_plan = match session_state
         .create_logical_plan(&query_request.query)
@@ -132,12 +133,13 @@ pub async fn query(req: HttpRequest, query_request: Query) -> Result<HttpRespons
     }
 
     let (records, fields) = execute(query, &table_name).await?;
-
+    let total_time = format!("{:?}", start.elapsed());
     let response = QueryResponse {
         records,
         fields,
         fill_null: query_request.send_null,
         with_fields: query_request.fields,
+        total_time,
     }
     .to_http()?;
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -23,6 +23,8 @@ use itertools::Itertools;
 use serde_json::{json, Value};
 use tracing::info;
 
+pub const TIME_ELAPSED_HEADER: &str = "p-time-elapsed";
+
 pub struct QueryResponse {
     pub records: Vec<RecordBatch>,
     pub fields: Vec<String>,
@@ -51,15 +53,13 @@ impl QueryResponse {
             json!({
                 "fields": self.fields,
                 "records": values,
-                "totalTime": self.total_time
             })
         } else {
-            json!({
-                "records": values,
-                "totalTime": self.total_time
-            })
+            Value::Array(values)
         };
 
-        Ok(HttpResponse::Ok().json(response))
+        Ok(HttpResponse::Ok()
+            .insert_header((TIME_ELAPSED_HEADER, self.total_time.as_str()))
+            .json(response))
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -28,6 +28,7 @@ pub struct QueryResponse {
     pub fields: Vec<String>,
     pub fill_null: bool,
     pub with_fields: bool,
+    pub total_time: String,
 }
 
 impl QueryResponse {
@@ -49,10 +50,14 @@ impl QueryResponse {
         let response = if self.with_fields {
             json!({
                 "fields": self.fields,
-                "records": values
+                "records": values,
+                "totalTime": self.total_time
             })
         } else {
-            Value::Array(values)
+            json!({
+                "records": values,
+                "totalTime": self.total_time
+            })
         };
 
         Ok(HttpResponse::Ok().json(response))


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Query responses now include execution time details, providing users with insight into the duration of query operations without altering current behavior.
  - HTTP response headers now feature a new timing header for enhanced performance tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->