### PR TITLE
fix: home api

### DIFF
--- a/src/prism/home/mod.rs
+++ b/src/prism/home/mod.rs
@@ -204,7 +204,10 @@ pub async fn generate_home_response(key: &SessionKey) -> Result<HomeResponse, Pr
         }
         stream_wise_stream_json.insert(stream.clone(), stream_jsons.clone());
 
-        let log_source = &stream_jsons[0].clone().log_source;
+        let log_source = PARSEABLE
+            .get_stream(&stream)
+            .map_err(|e| PrismHomeError::Anyhow(e.into()))?
+            .get_log_source();
 
         // if log_source_format is otel-metrics, set DataSetType to metrics
         //if log_source_format is otel-traces, set DataSetType to traces


### PR DESCRIPTION
get log_source from memory map
instead of checking stream.json from storage
as there may be stream.json of an ingestor which is offline and has never migrated to a newer version


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the home experience by refining the data retrieval process.
  - Updated the error handling approach to manage unexpected issues more gracefully, resulting in improved system stability and a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->