### PR TITLE
index storage path in env

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -427,6 +427,17 @@ impl Options {
         &self.local_staging_path
     }
 
+    /// Path to index directory, ensures that it exists or returns the PathBuf
+    pub fn index_dir(&self) -> Option<&PathBuf> {
+        if let Some(path) = &self.index_storage_path {
+            fs::create_dir_all(path)
+                .expect("Should be able to create index directory if it doesn't exist");
+            Some(path)
+        } else {
+            None
+        }
+    }
+
     /// TODO: refactor and document
     pub fn get_url(&self, mode: Mode) -> Url {
         let (endpoint, env_var) = match mode {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -225,6 +225,7 @@ pub struct Options {
     )]
     pub hot_tier_storage_path: Option<PathBuf>,
 
+    //TODO: remove this when smart cache is implemented
     #[arg(
         long = "index-storage-path",
         env = "P_INDEX_DIR",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -226,6 +226,14 @@ pub struct Options {
     pub hot_tier_storage_path: Option<PathBuf>,
 
     #[arg(
+        long = "index-storage-path",
+        env = "P_INDEX_DIR",
+        value_parser = validation::canonicalize_path,
+        help = "Local path on this indexer used for indexing"
+    )]
+    pub index_storage_path: Option<PathBuf>,
+
+    #[arg(
         long,
         env = "P_MAX_DISK_USAGE_PERCENT",
         default_value = "80.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a command-line option (accessible via a flag or an environment variable) that allows users to specify a local path for indexing.
  - Added functionality to ensure the specified indexing path exists before use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->