### PR TITLE
Update to coverage

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -33,6 +33,34 @@ jobs:
             pkg-config \
             build-essential
         if: runner.os == 'Linux'
+        
+      - name: Find and fix librdkafka CMakeLists.txt
+        run: |
+          # Download the package first so it's in the registry
+          cargo fetch
+          
+          # Find the rdkafka-sys package directory
+          RDKAFKA_SYS_DIR=$(find ~/.cargo/registry/src -name "rdkafka-sys-*" -type d | head -n 1)
+          echo "Found rdkafka-sys at: $RDKAFKA_SYS_DIR"
+          
+          # Find the librdkafka CMakeLists.txt file
+          CMAKE_FILE="$RDKAFKA_SYS_DIR/librdkafka/CMakeLists.txt"
+          
+          if [ -f "$CMAKE_FILE" ]; then
+            echo "Found CMakeLists.txt at: $CMAKE_FILE"
+            
+            # Make a backup of the original file
+            cp "$CMAKE_FILE" "$CMAKE_FILE.bak"
+            
+            # Replace the minimum required version
+            sed -i 's/cmake_minimum_required(VERSION 3.2)/cmake_minimum_required(VERSION 3.5)/' "$CMAKE_FILE"
+            
+            echo "Modified CMakeLists.txt - before and after comparison:"
+            diff "$CMAKE_FILE.bak" "$CMAKE_FILE" || true
+          else
+            echo "Could not find librdkafka CMakeLists.txt file!"
+            exit 1
+          fi
 
       - name: Check with clippy
         env:


### PR DESCRIPTION
Github action fails because the runner's minimum supported version for CMAKE is 3.5 whereas the minimum version mentioned in `librdkafka` is 3.2 This PR introduces a (hopefully temporary) change which fetches the crates and modifies the `CMakeLists.txt` of `librdkafka` before installation

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the CI workflow with an automated step that updates dependency configuration settings to meet current requirements. The new process identifies configuration mismatches earlier through improved error reporting, leading to a more robust and reliable build process. This update helps ensure a smoother and more efficient development workflow by catching potential issues sooner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->