### PR TITLE
feat: add querier json

### DIFF
--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -77,8 +77,8 @@ pub struct Report {
     inactive_ingestors: u64,
     active_indexers: u64,
     inactive_indexers: u64,
-    active_queries: u64,
-    inactive_queries: u64,
+    active_queriers: u64,
+    inactive_queriers: u64,
     stream_count: usize,
     total_events_count: u64,
     total_json_bytes: u64,
@@ -113,8 +113,8 @@ impl Report {
         let ingestor_metrics = fetch_ingestors_metrics().await?;
         let mut active_indexers = 0;
         let mut inactive_indexers = 0;
-        let mut active_queries = 0;
-        let mut inactive_queries = 0;
+        let mut active_queriers = 0;
+        let mut inactive_queriers = 0;
 
         // check liveness of indexers
         // get the count of active and inactive indexers
@@ -132,9 +132,9 @@ impl Report {
         let query_infos: Vec<NodeMetadata> = cluster::get_node_info(NodeType::Querier).await?;
         for query in query_infos {
             if check_liveness(&query.domain_name).await {
-                active_queries += 1;
+                active_queriers += 1;
             } else {
-                inactive_queries += 1;
+                inactive_queriers += 1;
             }
         }
         Ok(Self {
@@ -154,8 +154,8 @@ impl Report {
             inactive_ingestors: ingestor_metrics.1,
             active_indexers,
             inactive_indexers,
-            active_queries,
-            inactive_queries,
+            active_queriers,
+            inactive_queriers,
             stream_count: ingestor_metrics.2,
             total_events_count: ingestor_metrics.3,
             total_json_bytes: ingestor_metrics.4,

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -36,6 +36,7 @@ use crate::{
         http::{
             base_path_without_preceding_slash,
             cluster::{self, utils::check_liveness},
+            modal::NodeMetadata,
         },
         STREAM_NAME_HEADER_KEY,
     },
@@ -228,7 +229,7 @@ async fn fetch_ingestors_metrics(
         // send analytics for ingest servers
 
         // ingestor infos should be valid here, if not some thing is wrong
-        let ingestor_infos = cluster::get_ingestor_info().await.unwrap();
+        let ingestor_infos: Vec<NodeMetadata> = cluster::get_node_info("ingestor").await.unwrap();
 
         for im in ingestor_infos {
             if !check_liveness(&im.domain_name).await {

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -287,10 +287,14 @@ async fn fetch_ingestors_metrics(
                 .send()
                 .await
                 .expect("should respond");
-
-            let data = serde_json::from_slice::<NodeMetrics>(&resp.bytes().await?)?;
-            vec.push(data);
-            active_ingestors += 1;
+            // check if the response is valid
+            if let Ok(data) = serde_json::from_slice::<NodeMetrics>(&resp.bytes().await?) {
+                active_ingestors += 1;
+                vec.push(data);
+            } else {
+                offline_ingestors += 1;
+                continue;
+            }
         }
 
         node_metrics.accumulate(&mut vec);

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -28,7 +28,10 @@ use tracing::{error, info};
 
 use crate::{
     event::DEFAULT_TIMESTAMP_KEY,
-    handlers::{self, http::base_path_without_preceding_slash},
+    handlers::{
+        self,
+        http::{base_path_without_preceding_slash, modal::NodeMetadata},
+    },
     metrics::{EVENTS_INGESTED_DATE, EVENTS_INGESTED_SIZE_DATE, EVENTS_STORAGE_SIZE_DATE},
     option::Mode,
     parseable::PARSEABLE,
@@ -406,8 +409,8 @@ pub async fn get_first_event(
             }
         }
         Mode::Query => {
-            let ingestor_metadata =
-                handlers::http::cluster::get_ingestor_info()
+            let ingestor_metadata: Vec<NodeMetadata> =
+                handlers::http::cluster::get_node_info("ingestor")
                     .await
                     .map_err(|err| {
                         error!("Fatal: failed to get ingestor info: {:?}", err);

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -343,10 +343,10 @@ pub async fn remove_manifest_from_snapshot(
             Ok(get_first_event(storage.clone(), stream_name, Vec::new()).await?)
         }
         Mode::Query => Ok(get_first_event(storage, stream_name, dates).await?),
-        Mode::Index => Err(ObjectStorageError::UnhandledError(Box::new(
+        Mode::Index | Mode::Prism => Err(ObjectStorageError::UnhandledError(Box::new(
             std::io::Error::new(
                 std::io::ErrorKind::Unsupported,
-                "Can't remove manifest from within Index server",
+                "Can't remove manifest from within Index or Prism server",
             ),
         ))),
     }
@@ -359,7 +359,7 @@ pub async fn get_first_event(
 ) -> Result<Option<String>, ObjectStorageError> {
     let mut first_event_at: String = String::default();
     match PARSEABLE.options.mode {
-        Mode::Index => unimplemented!(),
+        Mode::Index | Mode::Prism => unimplemented!(),
         Mode::All | Mode::Ingest => {
             // get current snapshot
             let stream_first_event = PARSEABLE.get_stream(stream_name)?.get_first_event();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -447,6 +447,8 @@ impl Options {
         }
     }
 
+    /// get the address of the server
+    /// based on the mode
     pub fn get_url(&self, mode: Mode) -> Url {
         let endpoint = match mode {
             Mode::Ingest => self.get_endpoint(&self.ingestor_endpoint, "P_INGESTOR_ENDPOINT"),
@@ -458,6 +460,8 @@ impl Options {
         self.parse_endpoint(&endpoint)
     }
 
+    /// get the endpoint for the server
+    /// if env var is empty, use the address, else use the env var
     fn get_endpoint(&self, endpoint: &str, env_var: &str) -> String {
         if endpoint.is_empty() {
             self.address.to_string()
@@ -472,6 +476,9 @@ impl Options {
         }
     }
 
+    /// parse the endpoint to get the address and port
+    /// if the address is an env var, resolve it
+    /// if the port is an env var, resolve it
     fn parse_endpoint(&self, endpoint: &str) -> Url {
         let addr_parts: Vec<&str> = endpoint.split(':').collect();
 
@@ -488,6 +495,9 @@ impl Options {
         self.build_url(&format!("{}:{}", hostname, port))
     }
 
+    /// resolve the env var
+    /// if the env var is not set, panic
+    /// if the env var is set, return the value
     fn resolve_env_var(&self, value: &str) -> String {
         if let Some(env_var) = value.strip_prefix('$') {
             let resolved_value = env::var(env_var).unwrap_or_else(|_| {
@@ -510,6 +520,7 @@ impl Options {
         }
     }
 
+    /// build the url from the address
     fn build_url(&self, address: &str) -> Url {
         format!("{}://{}", self.get_scheme(), address)
             .parse::<Url>()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -447,107 +447,77 @@ impl Options {
         }
     }
 
-    /// TODO: refactor and document
     pub fn get_url(&self, mode: Mode) -> Url {
-        let (endpoint, env_var) = match mode {
-            Mode::Ingest => {
-                if self.ingestor_endpoint.is_empty() {
-                    return format!(
-                        "{}://{}",
-                        self.get_scheme(),
-                        self.address
-                    )
-                    .parse::<Url>() // if the value was improperly set, this will panic before hand
-                    .unwrap_or_else(|err| {
-                        panic!("{err}, failed to parse `{}` as Url. Please set the environment variable `P_ADDR` to `<ip address>:<port>` without the scheme (e.g., 192.168.1.1:8000). Please refer to the documentation: https://logg.ing/env for more details.", self.address)
-                    });
-                }
-                (&self.ingestor_endpoint, "P_INGESTOR_ENDPOINT")
-            }
-            Mode::Index => {
-                if self.indexer_endpoint.is_empty() {
-                    return format!(
-                        "{}://{}",
-                        self.get_scheme(),
-                        self.address
-                    )
-                    .parse::<Url>() // if the value was improperly set, this will panic before hand
-                    .unwrap_or_else(|err| {
-                        panic!("{err}, failed to parse `{}` as Url. Please set the environment variable `P_ADDR` to `<ip address>:<port>` without the scheme (e.g., 192.168.1.1:8000). Please refer to the documentation: https://logg.ing/env for more details.", self.address)
-                    });
-                }
-                (&self.indexer_endpoint, "P_INDEXER_ENDPOINT")
-            }
-            Mode::Query => {
-                if self.querier_endpoint.is_empty() {
-                    return format!(
-                        "{}://{}",
-                        self.get_scheme(),
-                        self.address
-                    )
-                    .parse::<Url>() // if the value was improperly set, this will panic before hand
-                    .unwrap_or_else(|err| {
-                        panic!("{err}, failed to parse `{}` as Url. Please set the environment variable `P_ADDR` to `<ip address>:<port>` without the scheme (e.g., 192.168.1.1:8000). Please refer to the documentation: https://logg.ing/env for more details.", self.address)
-                    });
-                }
-                (&self.querier_endpoint, "P_QUERIER_ENDPOINT")
-            }
-            _ => {
-                return format!(
-                    "{}://{}",
-                    self.get_scheme(),
-                    self.address
-                )
-                .parse::<Url>() // if the value was improperly set, this will panic before hand
-                .unwrap_or_else(|err| {
-                    panic!("{err}, failed to parse `{}` as Url. Please set the environment variable `P_ADDR` to `<ip address>:<port>` without the scheme (e.g., 192.168.1.1:8000). Please refer to the documentation: https://logg.ing/env for more details.", self.address)
-                });
-            }
+        let endpoint = match mode {
+            Mode::Ingest => self.get_endpoint(&self.ingestor_endpoint, "P_INGESTOR_ENDPOINT"),
+            Mode::Index => self.get_endpoint(&self.indexer_endpoint, "P_INDEXER_ENDPOINT"),
+            Mode::Query => self.get_endpoint(&self.querier_endpoint, "P_QUERIER_ENDPOINT"),
+            _ => return self.build_url(&self.address),
         };
 
-        if endpoint.starts_with("http") {
-            panic!("Invalid value `{}`, please set the environement variable `{env_var}` to `<ip address / DNS>:<port>` without the scheme (e.g., 192.168.1.1:8000 or example.com:8000). Please refer to the documentation: https://logg.ing/env for more details.", endpoint);
-        }
+        self.parse_endpoint(&endpoint)
+    }
 
-        let addr_from_env = endpoint.split(':').collect::<Vec<&str>>();
-
-        if addr_from_env.len() != 2 {
-            panic!("Invalid value `{}`, please set the environement variable `{env_var}` to `<ip address / DNS>:<port>` without the scheme (e.g., 192.168.1.1:8000 or example.com:8000). Please refer to the documentation: https://logg.ing/env for more details.", endpoint);
-        }
-
-        let mut hostname = addr_from_env[0].to_string();
-        let mut port = addr_from_env[1].to_string();
-
-        // if the env var value fits the pattern $VAR_NAME:$VAR_NAME
-        // fetch the value from the specified env vars
-        if hostname.starts_with('$') {
-            let var_hostname = hostname[1..].to_string();
-            hostname = env::var(&var_hostname).unwrap_or_default();
-
-            if hostname.is_empty() {
-                panic!("The environement variable `{}` is not set, please set as <ip address / DNS> without the scheme (e.g., 192.168.1.1 or example.com). Please refer to the documentation: https://logg.ing/env for more details.", var_hostname);
-            }
-            if hostname.starts_with("http") {
-                panic!("Invalid value `{}`, please set the environement variable `{}` to `<ip address / DNS>` without the scheme (e.g., 192.168.1.1 or example.com). Please refer to the documentation: https://logg.ing/env for more details.", hostname, var_hostname);
-            } else {
-                hostname = format!("{}://{}", self.get_scheme(), hostname);
-            }
-        }
-
-        if port.starts_with('$') {
-            let var_port = port[1..].to_string();
-            port = env::var(&var_port).unwrap_or_default();
-
-            if port.is_empty() {
+    fn get_endpoint(&self, endpoint: &str, env_var: &str) -> String {
+        if endpoint.is_empty() {
+            self.address.to_string()
+        } else {
+            if endpoint.starts_with("http") {
                 panic!(
-                    "Port is not set in the environement variable `{}`. Please refer to the documentation: https://logg.ing/env for more details.",
-                    var_port
+                    "Invalid value `{}`, please set the environment variable `{}` to `<ip address / DNS>:<port>` without the scheme (e.g., 192.168.1.1:8000 or example.com:8000). Please refer to the documentation: https://logg.ing/env for more details.",
+                    endpoint, env_var
                 );
             }
+            endpoint.to_string()
+        }
+    }
+
+    fn parse_endpoint(&self, endpoint: &str) -> Url {
+        let addr_parts: Vec<&str> = endpoint.split(':').collect();
+
+        if addr_parts.len() != 2 {
+            panic!(
+                "Invalid value `{}`, please set the environment variable to `<ip address / DNS>:<port>` without the scheme (e.g., 192.168.1.1:8000 or example.com:8000). Please refer to the documentation: https://logg.ing/env for more details.",
+                endpoint
+            );
         }
 
-        format!("{}://{}:{}", self.get_scheme(), hostname, port)
+        let hostname = self.resolve_env_var(addr_parts[0]);
+        let port = self.resolve_env_var(addr_parts[1]);
+
+        self.build_url(&format!("{}:{}", hostname, port))
+    }
+
+    fn resolve_env_var(&self, value: &str) -> String {
+        if let Some(env_var) = value.strip_prefix('$') {
+            let resolved_value = env::var(env_var).unwrap_or_else(|_| {
+                panic!(
+                    "The environment variable `{}` is not set. Please set it to a valid value. Refer to the documentation: https://logg.ing/env for more details.",
+                    env_var
+                );
+            });
+
+            if resolved_value.starts_with("http") {
+                panic!(
+                    "Invalid value `{}`, please set the environment variable `{}` to `<ip address / DNS>` without the scheme (e.g., 192.168.1.1 or example.com). Please refer to the documentation: https://logg.ing/env for more details.",
+                    resolved_value, env_var
+                );
+            }
+
+            resolved_value
+        } else {
+            value.to_string()
+        }
+    }
+
+    fn build_url(&self, address: &str) -> Url {
+        format!("{}://{}", self.get_scheme(), address)
             .parse::<Url>()
-            .expect("Valid URL")
+            .unwrap_or_else(|err| {
+                panic!(
+                    "{err}, failed to parse `{}` as Url. Please set the environment variable `P_ADDR` to `<ip address>:<port>` without the scheme (e.g., 192.168.1.1:8000). Please refer to the documentation: https://logg.ing/env for more details.",
+                    address
+                );
+            })
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -492,7 +492,17 @@ impl Options {
                 }
                 (&self.querier_endpoint, "P_QUERIER_ENDPOINT")
             }
-            _ => panic!("Invalid mode"),
+            _ => {
+                return format!(
+                    "{}://{}",
+                    self.get_scheme(),
+                    self.address
+                )
+                .parse::<Url>() // if the value was improperly set, this will panic before hand
+                .unwrap_or_else(|err| {
+                    panic!("{err}, failed to parse `{}` as Url. Please set the environment variable `P_ADDR` to `<ip address>:<port>` without the scheme (e.g., 192.168.1.1:8000). Please refer to the documentation: https://logg.ing/env for more details.", self.address)
+                });
+            }
         };
 
         if endpoint.starts_with("http") {

--- a/src/handlers/airplane.rs
+++ b/src/handlers/airplane.rs
@@ -33,7 +33,8 @@ use futures_util::{Future, TryFutureExt};
 use tonic::transport::{Identity, Server, ServerTlsConfig};
 use tonic_web::GrpcWebLayer;
 
-use crate::handlers::http::cluster::get_ingestor_info;
+use crate::handlers::http::cluster::get_node_info;
+use crate::handlers::http::modal::NodeMetadata;
 use crate::handlers::http::query::{into_query, update_schema_when_distributed};
 use crate::handlers::livetail::cross_origin_config;
 use crate::metrics::QUERY_EXECUTE_TIME;
@@ -179,7 +180,7 @@ impl FlightService for AirServiceImpl {
             })
             .to_string();
 
-            let ingester_metadatas = get_ingestor_info()
+            let ingester_metadatas: Vec<NodeMetadata> = get_node_info("ingestor")
                 .await
                 .map_err(|err| Status::failed_precondition(err.to_string()))?;
             let mut minute_result: Vec<RecordBatch> = vec![];

--- a/src/handlers/airplane.rs
+++ b/src/handlers/airplane.rs
@@ -34,7 +34,7 @@ use tonic::transport::{Identity, Server, ServerTlsConfig};
 use tonic_web::GrpcWebLayer;
 
 use crate::handlers::http::cluster::get_node_info;
-use crate::handlers::http::modal::NodeMetadata;
+use crate::handlers::http::modal::{NodeMetadata, NodeType};
 use crate::handlers::http::query::{into_query, update_schema_when_distributed};
 use crate::handlers::livetail::cross_origin_config;
 use crate::metrics::QUERY_EXECUTE_TIME;
@@ -180,7 +180,7 @@ impl FlightService for AirServiceImpl {
             })
             .to_string();
 
-            let ingester_metadatas: Vec<NodeMetadata> = get_node_info("ingestor")
+            let ingester_metadatas: Vec<NodeMetadata> = get_node_info(NodeType::Ingestor)
                 .await
                 .map_err(|err| Status::failed_precondition(err.to_string()))?;
             let mut minute_result: Vec<RecordBatch> = vec![];

--- a/src/handlers/http/about.rs
+++ b/src/handlers/http/about.rs
@@ -63,7 +63,8 @@ pub async fn about() -> Json<Value> {
     let commit = current_release.commit_hash;
     let deployment_id = meta.deployment_id.to_string();
     let mode = PARSEABLE.get_server_mode_string();
-    let staging = if PARSEABLE.options.mode == Mode::Query {
+    let staging = if PARSEABLE.options.mode == Mode::Query || PARSEABLE.options.mode == Mode::Prism
+    {
         "".to_string()
     } else {
         PARSEABLE.options.staging_dir().display().to_string()

--- a/src/handlers/http/about.rs
+++ b/src/handlers/http/about.rs
@@ -21,7 +21,6 @@ use serde_json::{json, Value};
 
 use crate::{
     about::{self, get_latest_release},
-    option::Mode,
     parseable::PARSEABLE,
     storage::StorageMetadata,
 };
@@ -63,12 +62,7 @@ pub async fn about() -> Json<Value> {
     let commit = current_release.commit_hash;
     let deployment_id = meta.deployment_id.to_string();
     let mode = PARSEABLE.get_server_mode_string();
-    let staging = if PARSEABLE.options.mode == Mode::Query || PARSEABLE.options.mode == Mode::Prism
-    {
-        "".to_string()
-    } else {
-        PARSEABLE.options.staging_dir().display().to_string()
-    };
+    let staging = PARSEABLE.options.staging_dir().display().to_string();
     let grpc_port = PARSEABLE.options.grpc_port;
 
     let store_endpoint = PARSEABLE.storage.get_endpoint();

--- a/src/handlers/http/cluster/mod.rs
+++ b/src/handlers/http/cluster/mod.rs
@@ -37,7 +37,9 @@ use serde_json::error::Error as SerdeError;
 use serde_json::{to_vec, Value as JsonValue};
 use tracing::{error, info, warn};
 use url::Url;
-use utils::{check_liveness, to_url_string, IngestionStats, QueriedStats, StorageStats};
+use utils::{
+    check_liveness, to_url_string, ClusterInfo, IngestionStats, QueriedStats, StorageStats,
+};
 
 use crate::handlers::http::ingest::ingest_internal_stream;
 use crate::metrics::prom_utils::Metrics;
@@ -540,8 +542,13 @@ pub async fn send_retention_cleanup_request(
 }
 
 pub async fn get_cluster_info() -> Result<impl Responder, StreamError> {
-    let self_info = utils::ClusterInfo::new(
-        &PARSEABLE.options.address,
+    let self_info = ClusterInfo::new(
+        format!(
+            "{}://{}",
+            PARSEABLE.options.get_scheme(),
+            PARSEABLE.options.address
+        )
+        .as_str(),
         true,
         PARSEABLE
             .options

--- a/src/handlers/http/cluster/mod.rs
+++ b/src/handlers/http/cluster/mod.rs
@@ -736,7 +736,15 @@ pub async fn get_node_info<T: Metadata + DeserializeOwned>(
         )
         .await?
         .iter()
-        .filter_map(|x| serde_json::from_slice::<T>(x).ok())
+        .filter_map(|x| {
+            match serde_json::from_slice::<T>(x) {
+                Ok(val) => Some(val),
+                Err(e) => {
+                    error!("Failed to parse node metadata: {:?}", e);
+                    None
+                }
+            }
+        })
         .collect();
 
     Ok(metadata)

--- a/src/handlers/http/cluster/utils.rs
+++ b/src/handlers/http/cluster/utils.rs
@@ -16,7 +16,10 @@
  *
  */
 
-use crate::{handlers::http::base_path_without_preceding_slash, HTTP_CLIENT};
+use crate::{
+    handlers::http::{base_path_without_preceding_slash, modal::NodeType},
+    HTTP_CLIENT,
+};
 use actix_web::http::header;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -55,7 +58,7 @@ pub struct ClusterInfo {
     storage_path: String,
     error: Option<String>,  // error message if the ingestor is not reachable
     status: Option<String>, // status message if the ingestor is reachable
-    node_type: String,
+    node_type: NodeType,
 }
 
 impl ClusterInfo {
@@ -66,7 +69,7 @@ impl ClusterInfo {
         storage_path: String,
         error: Option<String>,
         status: Option<String>,
-        node_type: &str,
+        node_type: &NodeType,
     ) -> Self {
         Self {
             domain_name: domain_name.to_string(),
@@ -75,7 +78,7 @@ impl ClusterInfo {
             storage_path,
             error,
             status,
-            node_type: node_type.to_string(),
+            node_type: node_type.clone(),
         }
     }
 }

--- a/src/handlers/http/logstream.rs
+++ b/src/handlers/http/logstream.rs
@@ -47,7 +47,7 @@ use tracing::warn;
 pub async fn delete(stream_name: Path<String>) -> Result<impl Responder, StreamError> {
     let stream_name = stream_name.into_inner();
     // Error out if stream doesn't exist in memory, or in the case of query node, in storage as well
-    if PARSEABLE.check_or_load_stream(&stream_name).await {
+    if !PARSEABLE.check_or_load_stream(&stream_name).await {
         return Err(StreamNotFound(stream_name).into());
     }
 
@@ -124,7 +124,7 @@ pub async fn get_schema(stream_name: Path<String>) -> Result<impl Responder, Str
     let stream_name = stream_name.into_inner();
 
     // Ensure parseable is aware of stream in distributed mode
-    if PARSEABLE.check_or_load_stream(&stream_name).await {
+    if !PARSEABLE.check_or_load_stream(&stream_name).await {
         return Err(StreamNotFound(stream_name.clone()).into());
     }
 
@@ -160,7 +160,7 @@ pub async fn get_retention(stream_name: Path<String>) -> Result<impl Responder, 
     // For query mode, if the stream not found in memory map,
     //check if it exists in the storage
     //create stream and schema from storage
-    if PARSEABLE.check_or_load_stream(&stream_name).await {
+    if !PARSEABLE.check_or_load_stream(&stream_name).await {
         return Err(StreamNotFound(stream_name.clone()).into());
     }
 
@@ -180,7 +180,7 @@ pub async fn put_retention(
     // For query mode, if the stream not found in memory map,
     //check if it exists in the storage
     //create stream and schema from storage
-    if PARSEABLE.check_or_load_stream(&stream_name).await {
+    if !PARSEABLE.check_or_load_stream(&stream_name).await {
         return Err(StreamNotFound(stream_name).into());
     }
 
@@ -231,7 +231,7 @@ pub async fn get_stats(
     // For query mode, if the stream not found in memory map,
     //check if it exists in the storage
     //create stream and schema from storage
-    if PARSEABLE.check_or_load_stream(&stream_name).await {
+    if !PARSEABLE.check_or_load_stream(&stream_name).await {
         return Err(StreamNotFound(stream_name.clone()).into());
     }
 
@@ -289,7 +289,7 @@ pub async fn get_stream_info(stream_name: Path<String>) -> Result<impl Responder
     // For query mode, if the stream not found in memory map,
     //check if it exists in the storage
     //create stream and schema from storage
-    if PARSEABLE.check_or_load_stream(&stream_name).await {
+    if !PARSEABLE.check_or_load_stream(&stream_name).await {
         return Err(StreamNotFound(stream_name.clone()).into());
     }
 
@@ -349,7 +349,7 @@ pub async fn put_stream_hot_tier(
     // For query mode, if the stream not found in memory map,
     //check if it exists in the storage
     //create stream and schema from storage
-    if PARSEABLE.check_or_load_stream(&stream_name).await {
+    if !PARSEABLE.check_or_load_stream(&stream_name).await {
         return Err(StreamNotFound(stream_name).into());
     }
 
@@ -396,7 +396,7 @@ pub async fn get_stream_hot_tier(stream_name: Path<String>) -> Result<impl Respo
     // For query mode, if the stream not found in memory map,
     //check if it exists in the storage
     //create stream and schema from storage
-    if PARSEABLE.check_or_load_stream(&stream_name).await {
+    if !PARSEABLE.check_or_load_stream(&stream_name).await {
         return Err(StreamNotFound(stream_name.clone()).into());
     }
 
@@ -416,7 +416,7 @@ pub async fn delete_stream_hot_tier(
     // For query mode, if the stream not found in memory map,
     //check if it exists in the storage
     //create stream and schema from storage
-    if PARSEABLE.check_or_load_stream(&stream_name).await {
+    if !PARSEABLE.check_or_load_stream(&stream_name).await {
         return Err(StreamNotFound(stream_name).into());
     }
 

--- a/src/handlers/http/middleware.rs
+++ b/src/handlers/http/middleware.rs
@@ -358,7 +358,7 @@ where
                 })
             }
 
-            Mode::Index => {
+            Mode::Index | Mode::Prism => {
                 let fut = self.service.call(req);
 
                 Box::pin(async move {

--- a/src/handlers/http/mod.rs
+++ b/src/handlers/http/mod.rs
@@ -22,7 +22,7 @@ use arrow_schema::Schema;
 use cluster::get_node_info;
 use http::StatusCode;
 use itertools::Itertools;
-use modal::NodeMetadata;
+use modal::{NodeMetadata, NodeType};
 use serde_json::Value;
 
 use crate::{parseable::PARSEABLE, storage::STREAM_ROOT_DIRECTORY, HTTP_CLIENT};
@@ -110,7 +110,7 @@ pub async fn fetch_schema(stream_name: &str) -> anyhow::Result<arrow_schema::Sch
 pub async fn send_query_request_to_ingestor(query: &Query) -> anyhow::Result<Vec<Value>> {
     // send the query request to the ingestor
     let mut res = vec![];
-    let ima: Vec<NodeMetadata> = get_node_info("ingestor").await?;
+    let ima: Vec<NodeMetadata> = get_node_info(NodeType::Ingestor).await?;
 
     for im in ima.iter() {
         let uri = format!(

--- a/src/handlers/http/mod.rs
+++ b/src/handlers/http/mod.rs
@@ -19,13 +19,15 @@
 use actix_cors::Cors;
 use actix_web::Responder;
 use arrow_schema::Schema;
+use cluster::get_node_info;
 use http::StatusCode;
 use itertools::Itertools;
+use modal::NodeMetadata;
 use serde_json::Value;
 
 use crate::{parseable::PARSEABLE, storage::STREAM_ROOT_DIRECTORY, HTTP_CLIENT};
 
-use self::{cluster::get_ingestor_info, query::Query};
+use self::query::Query;
 
 pub mod about;
 pub mod alerts;
@@ -108,7 +110,7 @@ pub async fn fetch_schema(stream_name: &str) -> anyhow::Result<arrow_schema::Sch
 pub async fn send_query_request_to_ingestor(query: &Query) -> anyhow::Result<Vec<Value>> {
     // send the query request to the ingestor
     let mut res = vec![];
-    let ima = get_ingestor_info().await?;
+    let ima: Vec<NodeMetadata> = get_node_info("ingestor").await?;
 
     for im in ima.iter() {
         let uri = format!(

--- a/src/handlers/http/modal/ingest/ingestor_logstream.rs
+++ b/src/handlers/http/modal/ingest/ingestor_logstream.rs
@@ -72,7 +72,7 @@ pub async fn delete(stream_name: Path<String>) -> Result<impl Responder, StreamE
     }
 
     // Delete from staging
-    let stream_dir = PARSEABLE.get_or_create_stream(&stream_name);
+    let stream_dir = PARSEABLE.get_stream(&stream_name)?;
     if fs::remove_dir_all(&stream_dir.data_path).is_err() {
         warn!(
             "failed to delete local data for stream {}. Clean {} manually",

--- a/src/handlers/http/modal/ingest/ingestor_logstream.rs
+++ b/src/handlers/http/modal/ingest/ingestor_logstream.rs
@@ -16,6 +16,8 @@
  *
  */
 
+use std::fs;
+
 use actix_web::{
     web::{Json, Path},
     HttpRequest, Responder,
@@ -67,6 +69,16 @@ pub async fn delete(stream_name: Path<String>) -> Result<impl Responder, StreamE
             .unwrap_or(false)
     {
         return Err(StreamNotFound(stream_name.clone()).into());
+    }
+
+    // Delete from staging
+    let stream_dir = PARSEABLE.get_or_create_stream(&stream_name);
+    if fs::remove_dir_all(&stream_dir.data_path).is_err() {
+        warn!(
+            "failed to delete local data for stream {}. Clean {} manually",
+            stream_name,
+            stream_dir.data_path.to_string_lossy()
+        )
     }
 
     // Delete from memory

--- a/src/handlers/http/modal/ingest_server.rs
+++ b/src/handlers/http/modal/ingest_server.rs
@@ -16,6 +16,7 @@
  *
  */
 
+use std::sync::Arc;
 use std::thread;
 
 use actix_web::web;
@@ -54,7 +55,7 @@ use super::{
 };
 
 pub const INGESTOR_EXPECT: &str = "Ingestor Metadata should be set in ingestor mode";
-pub static INGESTOR_META: OnceCell<IngestorMetadata> = OnceCell::const_new();
+pub static INGESTOR_META: OnceCell<Arc<IngestorMetadata>> = OnceCell::const_new();
 pub struct IngestServer;
 
 #[async_trait]

--- a/src/handlers/http/modal/mod.rs
+++ b/src/handlers/http/modal/mod.rs
@@ -340,7 +340,7 @@ impl NodeMetadata {
                 meta.token = token;
             }
 
-            meta.node_type = node_type.clone();
+            meta.node_type.clone_from(&node_type);
             meta.put_on_disk(staging_path)
                 .expect("Couldn't write to disk");
 
@@ -436,7 +436,7 @@ impl NodeMetadata {
         };
 
         let mut resource = Self::from_bytes(&bytes, PARSEABLE.options.flight_port)?;
-        resource.node_type = self.node_type.clone();
+        resource.node_type.clone_from(&self.node_type);
         let bytes = Bytes::from(serde_json::to_vec(&resource)?);
 
         resource.put_on_disk(PARSEABLE.options.staging_dir())?;

--- a/src/handlers/http/modal/mod.rs
+++ b/src/handlers/http/modal/mod.rs
@@ -230,11 +230,7 @@ impl NodeType {
 
 impl fmt::Display for NodeType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            NodeType::Ingestor => write!(f, "ingestor"),
-            NodeType::Indexer => write!(f, "indexer"),
-            NodeType::Querier => write!(f, "querier"),
-        }
+        write!(f, "{}", self.as_str())
     }
 }
 

--- a/src/handlers/http/modal/mod.rs
+++ b/src/handlers/http/modal/mod.rs
@@ -199,6 +199,7 @@ pub async fn load_on_init() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// NodeType represents the type of node in the cluster
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum NodeType {
@@ -531,7 +532,7 @@ impl Metadata for NodeMetadata {
     }
 }
 
-// Type aliases for backward compatibility
+// Aliases for different node types
 pub type IngestorMetadata = NodeMetadata;
 pub type IndexerMetadata = NodeMetadata;
 pub type QuerierMetadata = NodeMetadata;

--- a/src/handlers/http/modal/mod.rs
+++ b/src/handlers/http/modal/mod.rs
@@ -200,14 +200,14 @@ pub async fn load_on_init() -> anyhow::Result<()> {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, Default)]
+#[serde(rename_all = "lowercase")]
 pub enum NodeType {
     #[default]
-    #[serde(rename = "ingestor")]
     Ingestor,
-    #[serde(rename = "indexer")]
     Indexer,
-    #[serde(rename = "querier")]
     Querier,
+    Prism,
+    All,
 }
 
 impl NodeType {
@@ -216,6 +216,8 @@ impl NodeType {
             NodeType::Ingestor => "ingestor",
             NodeType::Indexer => "indexer",
             NodeType::Querier => "querier",
+            NodeType::Prism => "prism",
+            NodeType::All => "all",
         }
     }
 
@@ -224,6 +226,8 @@ impl NodeType {
             NodeType::Ingestor => Mode::Ingest,
             NodeType::Indexer => Mode::Index,
             NodeType::Querier => Mode::Query,
+            NodeType::Prism => Mode::Prism,
+            NodeType::All => Mode::All,
         }
     }
 }
@@ -532,89 +536,6 @@ pub type IngestorMetadata = NodeMetadata;
 pub type IndexerMetadata = NodeMetadata;
 pub type QuerierMetadata = NodeMetadata;
 
-// Helper functions for creating specific node types
-pub fn create_ingestor_metadata(
-    port: String,
-    domain_name: String,
-    bucket_name: String,
-    username: &str,
-    password: &str,
-    ingestor_id: String,
-    flight_port: String,
-) -> NodeMetadata {
-    NodeMetadata::new(
-        port,
-        domain_name,
-        bucket_name,
-        username,
-        password,
-        ingestor_id,
-        flight_port,
-        NodeType::Ingestor,
-    )
-}
-
-pub fn load_ingestor_metadata(
-    options: &Options,
-    storage: &dyn ObjectStorageProvider,
-) -> Arc<NodeMetadata> {
-    NodeMetadata::load(options, storage, NodeType::Ingestor)
-}
-
-pub fn create_indexer_metadata(
-    port: String,
-    domain_name: String,
-    bucket_name: String,
-    username: &str,
-    password: &str,
-    indexer_id: String,
-    flight_port: String,
-) -> NodeMetadata {
-    NodeMetadata::new(
-        port,
-        domain_name,
-        bucket_name,
-        username,
-        password,
-        indexer_id,
-        flight_port,
-        NodeType::Indexer,
-    )
-}
-
-pub fn load_indexer_metadata(
-    options: &Options,
-    storage: &dyn ObjectStorageProvider,
-) -> Arc<NodeMetadata> {
-    NodeMetadata::load(options, storage, NodeType::Indexer)
-}
-
-pub fn create_querier_metadata(
-    port: String,
-    domain_name: String,
-    bucket_name: String,
-    username: &str,
-    password: &str,
-    querier_id: String,
-    flight_port: String,
-) -> NodeMetadata {
-    NodeMetadata::new(
-        port,
-        domain_name,
-        bucket_name,
-        username,
-        password,
-        querier_id,
-        flight_port,
-        NodeType::Querier,
-    )
-}
-pub fn load_querier_metadata(
-    options: &Options,
-    storage: &dyn ObjectStorageProvider,
-) -> Arc<NodeMetadata> {
-    NodeMetadata::load(options, storage, NodeType::Querier)
-}
 #[cfg(test)]
 mod test {
     use actix_web::body::MessageBody;

--- a/src/handlers/http/modal/mod.rs
+++ b/src/handlers/http/modal/mod.rs
@@ -277,7 +277,7 @@ impl NodeMetadata {
         }
     }
 
-    pub async fn load_node_metadata(node_type: NodeType) -> anyhow::Result<Self> {
+    pub async fn load_node_metadata(node_type: NodeType) -> anyhow::Result<Arc<Self>> {
         let staging_path = PARSEABLE.options.staging_dir();
         let node_type_str = node_type.as_str();
 
@@ -310,7 +310,7 @@ impl NodeMetadata {
         mut meta: Self,
         staging_path: &Path,
         node_type: NodeType,
-    ) -> anyhow::Result<Self> {
+    ) -> anyhow::Result<Arc<Self>> {
         Self::update_metadata(&mut meta, &PARSEABLE.options, node_type);
         meta.put_on_disk(staging_path)
             .expect("Couldn't write updated metadata to disk");
@@ -320,11 +320,11 @@ impl NodeMetadata {
         let store = PARSEABLE.storage.get_object_store();
         store.put_object(&path, resource).await?;
 
-        Ok(meta)
+        Ok(Arc::new(meta))
     }
 
     /// Store new metadata
-    async fn store_new_metadata(meta: Self, staging_path: &Path) -> anyhow::Result<Self> {
+    async fn store_new_metadata(meta: Self, staging_path: &Path) -> anyhow::Result<Arc<Self>> {
         meta.put_on_disk(staging_path)
             .expect("Couldn't write new metadata to disk");
 
@@ -333,7 +333,7 @@ impl NodeMetadata {
         let store = PARSEABLE.storage.get_object_store();
         store.put_object(&path, resource).await?;
 
-        Ok(meta)
+        Ok(Arc::new(meta))
     }
 
     async fn load_from_storage(node_type: String) -> Vec<NodeMetadata> {

--- a/src/handlers/http/modal/mod.rs
+++ b/src/handlers/http/modal/mod.rs
@@ -535,6 +535,7 @@ impl Metadata for NodeMetadata {
 pub type IngestorMetadata = NodeMetadata;
 pub type IndexerMetadata = NodeMetadata;
 pub type QuerierMetadata = NodeMetadata;
+pub type PrismMetadata = NodeMetadata;
 
 #[cfg(test)]
 mod test {

--- a/src/handlers/http/modal/mod.rs
+++ b/src/handlers/http/modal/mod.rs
@@ -333,7 +333,7 @@ impl NodeMetadata {
     fn is_valid_metadata_file(path: &Path, node_type_str: &str) -> bool {
         path.file_name()
             .and_then(|s| s.to_str())
-            .map_or(false, |s| s.contains(node_type_str))
+            .is_some_and(|s| s.contains(node_type_str))
     }
 
     /// Update metadata fields if they differ from the current configuration

--- a/src/handlers/http/modal/query/querier_logstream.rs
+++ b/src/handlers/http/modal/query/querier_logstream.rs
@@ -41,6 +41,7 @@ use crate::{
             utils::{merge_quried_stats, IngestionStats, QueriedStats, StorageStats},
         },
         logstream::{error::StreamError, get_stats_date},
+        modal::NodeMetadata,
     },
     hottier::HotTierManager,
     parseable::{StreamNotFound, PARSEABLE},
@@ -81,10 +82,11 @@ pub async fn delete(stream_name: Path<String>) -> Result<impl Responder, StreamE
         }
     }
 
-    let ingestor_metadata = cluster::get_ingestor_info().await.map_err(|err| {
-        error!("Fatal: failed to get ingestor info: {:?}", err);
-        err
-    })?;
+    let ingestor_metadata: Vec<NodeMetadata> =
+        cluster::get_node_info("ingestor").await.map_err(|err| {
+            error!("Fatal: failed to get ingestor info: {:?}", err);
+            err
+        })?;
 
     for ingestor in ingestor_metadata {
         let url = format!(

--- a/src/handlers/http/modal/query/querier_logstream.rs
+++ b/src/handlers/http/modal/query/querier_logstream.rs
@@ -41,7 +41,7 @@ use crate::{
             utils::{merge_quried_stats, IngestionStats, QueriedStats, StorageStats},
         },
         logstream::{error::StreamError, get_stats_date},
-        modal::NodeMetadata,
+        modal::{NodeMetadata, NodeType},
     },
     hottier::HotTierManager,
     parseable::{StreamNotFound, PARSEABLE},
@@ -82,8 +82,9 @@ pub async fn delete(stream_name: Path<String>) -> Result<impl Responder, StreamE
         }
     }
 
-    let ingestor_metadata: Vec<NodeMetadata> =
-        cluster::get_node_info("ingestor").await.map_err(|err| {
+    let ingestor_metadata: Vec<NodeMetadata> = cluster::get_node_info(NodeType::Ingestor)
+        .await
+        .map_err(|err| {
             error!("Fatal: failed to get ingestor info: {:?}", err);
             err
         })?;

--- a/src/handlers/http/modal/query_server.rs
+++ b/src/handlers/http/modal/query_server.rs
@@ -130,9 +130,6 @@ impl ParseableServer for QueryServer {
 
         tokio::spawn(airplane::server());
 
-        // write the querier metadata to storage
-        PARSEABLE.store_metadata(Mode::Query).await?;
-
         let result = self
             .start(shutdown_rx, prometheus.clone(), PARSEABLE.options.openid())
             .await?;

--- a/src/handlers/http/modal/query_server.rs
+++ b/src/handlers/http/modal/query_server.rs
@@ -25,6 +25,7 @@ use crate::handlers::http::{base_path, prism_base_path};
 use crate::handlers::http::{logstream, MAX_EVENT_PAYLOAD_SIZE};
 use crate::handlers::http::{rbac, role};
 use crate::hottier::HotTierManager;
+use crate::option::Mode;
 use crate::rbac::role::Action;
 use crate::{analytics, migration, storage, sync};
 use actix_web::web::{resource, ServiceConfig};
@@ -128,6 +129,9 @@ impl ParseableServer for QueryServer {
         thread::spawn(|| sync::handler(cancel_rx));
 
         tokio::spawn(airplane::server());
+
+        // write the querier metadata to storage
+        PARSEABLE.store_metadata(Mode::Query).await?;
 
         let result = self
             .start(shutdown_rx, prometheus.clone(), PARSEABLE.options.openid())

--- a/src/handlers/http/modal/query_server.rs
+++ b/src/handlers/http/modal/query_server.rs
@@ -16,6 +16,7 @@
  *
  */
 
+use std::sync::Arc;
 use std::thread;
 
 use crate::handlers::airplane;
@@ -42,7 +43,7 @@ use super::query::{querier_ingest, querier_logstream, querier_rbac, querier_role
 use super::{load_on_init, NodeType, OpenIdClient, ParseableServer, QuerierMetadata};
 
 pub struct QueryServer;
-pub static QUERIER_META: OnceCell<QuerierMetadata> = OnceCell::const_new();
+pub static QUERIER_META: OnceCell<Arc<QuerierMetadata>> = OnceCell::const_new();
 #[async_trait]
 impl ParseableServer for QueryServer {
     // configure the api routes

--- a/src/handlers/http/modal/query_server.rs
+++ b/src/handlers/http/modal/query_server.rs
@@ -25,7 +25,6 @@ use crate::handlers::http::{base_path, prism_base_path};
 use crate::handlers::http::{logstream, MAX_EVENT_PAYLOAD_SIZE};
 use crate::handlers::http::{rbac, role};
 use crate::hottier::HotTierManager;
-use crate::option::Mode;
 use crate::rbac::role::Action;
 use crate::{analytics, migration, storage, sync};
 use actix_web::web::{resource, ServiceConfig};

--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -329,6 +329,8 @@ Description: {0}"#
     SerdeJsonError(#[from] serde_json::Error),
     #[error("CustomError: {0}")]
     CustomError(String),
+    #[error("No available queriers found")]
+    NoAvailableQuerier,
 }
 
 impl actix_web::ResponseError for QueryError {

--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -327,6 +327,8 @@ Description: {0}"#
     StreamNotFound(#[from] StreamNotFound),
     #[error("SerdeJsonError: {0}")]
     SerdeJsonError(#[from] serde_json::Error),
+    #[error("CustomError: {0}")]
+    CustomError(String),
 }
 
 impl actix_web::ResponseError for QueryError {

--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -172,6 +172,9 @@ pub async fn get_counts(
 }
 
 pub async fn update_schema_when_distributed(tables: &Vec<String>) -> Result<(), EventError> {
+    // if the mode is query or prism, we need to update the schema in memory
+    // no need to commit schema to storage
+    // as the schema is read from memory everytime
     if PARSEABLE.options.mode == Mode::Query || PARSEABLE.options.mode == Mode::Prism {
         for table in tables {
             if let Ok(new_schema) = fetch_schema(table).await {

--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -325,6 +325,8 @@ Description: {0}"#
     Anyhow(#[from] anyhow::Error),
     #[error("Error: {0}")]
     StreamNotFound(#[from] StreamNotFound),
+    #[error("SerdeJsonError: {0}")]
+    SerdeJsonError(#[from] serde_json::Error),
 }
 
 impl actix_web::ResponseError for QueryError {

--- a/src/logstream/mod.rs
+++ b/src/logstream/mod.rs
@@ -27,7 +27,7 @@ use crate::{handlers::http::{logstream::error::StreamError, query::update_schema
 
 pub async fn get_stream_schema_helper(stream_name: &str) -> Result<Arc<Schema>, StreamError> {
     // Ensure parseable is aware of stream in distributed mode
-    if PARSEABLE.check_or_load_stream(&stream_name).await {
+    if !PARSEABLE.check_or_load_stream(&stream_name).await {
         return Err(StreamNotFound(stream_name.to_owned()).into());
     }
 
@@ -48,7 +48,7 @@ pub async fn get_stream_info_helper(stream_name: &str) -> Result<StreamInfo, Str
     // For query mode, if the stream not found in memory map,
     //check if it exists in the storage
     //create stream and schema from storage
-    if PARSEABLE.check_or_load_stream(&stream_name).await {
+    if !PARSEABLE.check_or_load_stream(&stream_name).await {
         return Err(StreamNotFound(stream_name.to_owned()).into());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,10 @@ async fn main() -> anyhow::Result<()> {
             println!("Indexing is an enterprise feature. Check out https://www.parseable.com/pricing to know more!");
             exit(0)
         }
+        Mode::Prism => {
+            println!("Prism is an enterprise feature. Check out https://www.parseable.com/pricing to know more!");
+            exit(0)
+        }
         Mode::All => Box::new(Server),
     };
 

--- a/src/option.rs
+++ b/src/option.rs
@@ -23,6 +23,7 @@ pub enum Mode {
     Query,
     Ingest,
     Index,
+    Prism,
     #[default]
     All,
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -129,6 +129,7 @@ pub mod validation {
         match s {
             "query" => Ok(Mode::Query),
             "ingest" => Ok(Mode::Ingest),
+            "prism" => Ok(Mode::Prism),
             "all" => Ok(Mode::All),
             "index" => Ok(Mode::Index),
             _ => Err("Invalid MODE provided".to_string()),

--- a/src/option.rs
+++ b/src/option.rs
@@ -18,6 +18,8 @@
 use parquet::basic::{BrotliLevel, GzipLevel, ZstdLevel};
 use serde::{Deserialize, Serialize};
 
+use crate::handlers::http::modal::NodeType;
+
 #[derive(Debug, Default, Eq, PartialEq, Clone, Copy, Serialize, Deserialize)]
 pub enum Mode {
     Query,
@@ -40,6 +42,16 @@ impl Mode {
         }
 
         Ok(())
+    }
+
+    pub fn to_node_type(&self) -> NodeType {
+        match self {
+            Mode::Ingest => NodeType::Ingestor,
+            Mode::Index => NodeType::Indexer,
+            Mode::Query => NodeType::Querier,
+            Mode::Prism => NodeType::Prism,
+            Mode::All => NodeType::All,
+        }
     }
 }
 

--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -47,7 +47,10 @@ use crate::{
             cluster::{sync_streams_with_ingestors, INTERNAL_STREAM_NAME},
             ingest::PostError,
             logstream::error::{CreateStreamError, StreamError},
-            modal::{utils::logstream_utils::PutStreamHeaders, IndexerMetadata, IngestorMetadata},
+            modal::{
+                utils::logstream_utils::PutStreamHeaders, IndexerMetadata, IngestorMetadata,
+                NodeType,
+            },
         },
         STREAM_TYPE_KEY,
     },
@@ -143,11 +146,19 @@ impl Parseable {
         storage: Arc<dyn ObjectStorageProvider>,
     ) -> Self {
         let ingestor_metadata = match &options.mode {
-            Mode::Ingest => Some(IngestorMetadata::load(&options, storage.as_ref())),
+            Mode::Ingest => Some(IngestorMetadata::load(
+                &options,
+                storage.as_ref(),
+                NodeType::Ingestor,
+            )),
             _ => None,
         };
         let indexer_metadata = match &options.mode {
-            Mode::Index => Some(IndexerMetadata::load(&options, storage.as_ref())),
+            Mode::Index => Some(IndexerMetadata::load(
+                &options,
+                storage.as_ref(),
+                NodeType::Indexer,
+            )),
             _ => None,
         };
         Parseable {
@@ -184,7 +195,7 @@ impl Parseable {
             LogStreamMetadata::default(),
             self.ingestor_metadata
                 .as_ref()
-                .map(|meta| meta.get_ingestor_id()),
+                .map(|meta| meta.get_node_id()),
         )
     }
 
@@ -388,7 +399,7 @@ impl Parseable {
             metadata,
             self.ingestor_metadata
                 .as_ref()
-                .map(|meta| meta.get_ingestor_id()),
+                .map(|meta| meta.get_node_id()),
         );
 
         Ok(true)
@@ -693,7 +704,7 @@ impl Parseable {
                     metadata,
                     self.ingestor_metadata
                         .as_ref()
-                        .map(|meta| meta.get_ingestor_id()),
+                        .map(|meta| meta.get_node_id()),
                 );
             }
             Err(err) => {

--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -558,8 +558,11 @@ impl Parseable {
 
         let stream_in_memory_dont_update =
             self.streams.contains(stream_name) && !update_stream_flag;
-        let stream_in_storage_only_for_query_node = !self.streams.contains(stream_name)     // check if stream in storage only if not in memory
-            && (self.options.mode == Mode::Query  || self.options.mode == Mode::Prism)                                                // and running in query mode
+        // check if stream in storage only if not in memory
+        // for Parseable OSS, create_update_stream is called only from query node
+        // for Parseable Enterprise, create_update_stream is called from prism node
+        let stream_in_storage_only_for_query_node = !self.streams.contains(stream_name)
+            && (self.options.mode == Mode::Query || self.options.mode == Mode::Prism)
             && self
                 .create_stream_and_schema_from_storage(stream_name)
                 .await?;

--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -212,13 +212,14 @@ impl Parseable {
 
     /// Checks for the stream in memory, or loads it from storage when in distributed mode
     pub async fn check_or_load_stream(&self, stream_name: &str) -> bool {
-        !self.streams.contains(stream_name)
-            && (self.options.mode != Mode::Query
-                || self.options.mode != Mode::Prism
-                || !self
-                    .create_stream_and_schema_from_storage(stream_name)
-                    .await
-                    .unwrap_or_default())
+        if self.streams.contains(stream_name) {
+            return true;
+        }
+        (self.options.mode == Mode::Query || self.options.mode == Mode::Prism)
+            && self
+                .create_stream_and_schema_from_storage(stream_name)
+                .await
+                .unwrap_or_default()
     }
 
     // validate the storage, if the proper path for staging directory is provided

--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -200,6 +200,7 @@ impl Parseable {
             Mode::Ingest => self.ingestor_metadata.as_ref(),
             Mode::Index => self.indexer_metadata.as_ref(),
             Mode::Query => self.querier_metadata.as_ref(),
+            Mode::Prism => self.prism_metadata.as_ref(),
             _ => return None,
         };
 

--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -620,11 +620,9 @@ impl Parseable {
                     SchemaVersion::V1, // New stream
                     log_source,
                 );
-                let ingestor_id = if let Some(ingestor_metadata) = INGESTOR_META.get() {
-                    Some(ingestor_metadata.get_node_id())
-                } else {
-                    None
-                };
+                let ingestor_id = INGESTOR_META
+                    .get()
+                    .map(|ingestor_metadata| ingestor_metadata.get_node_id());
 
                 // Gets write privileges only for creating the stream when it doesn't already exist.
                 self.streams.get_or_create(

--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -211,6 +211,8 @@ impl Parseable {
     }
 
     /// Checks for the stream in memory, or loads it from storage when in distributed mode
+    /// return true if stream exists in memory or loaded from storage
+    /// return false if stream doesn't exist in memory and not loaded from storage
     pub async fn check_or_load_stream(&self, stream_name: &str) -> bool {
         if self.streams.contains(stream_name) {
             return true;

--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -282,6 +282,7 @@ impl Parseable {
             Mode::Query => "Distributed (Query)",
             Mode::Ingest => "Distributed (Ingest)",
             Mode::Index => "Distributed (Index)",
+            Mode::Prism => "Distributed (Prism)",
             Mode::All => "Standalone",
         }
     }

--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -214,6 +214,7 @@ impl Parseable {
     pub async fn check_or_load_stream(&self, stream_name: &str) -> bool {
         !self.streams.contains(stream_name)
             && (self.options.mode != Mode::Query
+                || self.options.mode != Mode::Prism
                 || !self
                     .create_stream_and_schema_from_storage(stream_name)
                     .await
@@ -521,7 +522,7 @@ impl Parseable {
         let stream_in_memory_dont_update =
             self.streams.contains(stream_name) && !update_stream_flag;
         let stream_in_storage_only_for_query_node = !self.streams.contains(stream_name)     // check if stream in storage only if not in memory
-            && self.options.mode == Mode::Query                                                   // and running in query mode
+            && (self.options.mode == Mode::Query  || self.options.mode == Mode::Prism)                                                // and running in query mode
             && self
                 .create_stream_and_schema_from_storage(stream_name)
                 .await?;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -467,7 +467,7 @@ pub async fn get_manifest_list(
     let mut merged_snapshot: Snapshot = Snapshot::default();
 
     // get a list of manifests
-    if PARSEABLE.options.mode == Mode::Query {
+    if PARSEABLE.options.mode == Mode::Query || PARSEABLE.options.mode == Mode::Prism {
         let path = RelativePathBuf::from_iter([stream_name, STREAM_ROOT_DIRECTORY]);
         let obs = glob_storage
             .get_objects(

--- a/src/query/stream_schema_provider.rs
+++ b/src/query/stream_schema_provider.rs
@@ -503,7 +503,7 @@ impl TableProvider for StandardTableProvider {
             .await?;
         };
         let mut merged_snapshot = Snapshot::default();
-        if PARSEABLE.options.mode == Mode::Query {
+        if PARSEABLE.options.mode == Mode::Query || PARSEABLE.options.mode == Mode::Prism {
             let path = RelativePathBuf::from_iter([&self.stream, STREAM_ROOT_DIRECTORY]);
             let obs = glob_storage
                 .get_objects(

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -41,7 +41,7 @@ mod metrics_layer;
 pub mod object_storage;
 pub mod retention;
 mod s3;
-mod store_metadata;
+pub mod store_metadata;
 
 use self::retention::Retention;
 pub use azure_blob::AzureBlobConfig;

--- a/src/storage/object_storage.rs
+++ b/src/storage/object_storage.rs
@@ -48,6 +48,7 @@ use crate::correlation::{CorrelationConfig, CorrelationError};
 use crate::event::format::LogSource;
 use crate::event::format::LogSourceEntry;
 use crate::handlers::http::modal::ingest_server::INGESTOR_EXPECT;
+use crate::handlers::http::modal::ingest_server::INGESTOR_META;
 use crate::handlers::http::users::CORRELATION_DIR;
 use crate::handlers::http::users::{DASHBOARDS_DIR, FILTER_DIR, USERS_ROOT_DIR};
 use crate::metrics::storage::StorageMetrics;
@@ -896,10 +897,9 @@ pub fn to_bytes(any: &(impl ?Sized + serde::Serialize)) -> Bytes {
 
 pub fn schema_path(stream_name: &str) -> RelativePathBuf {
     if PARSEABLE.options.mode == Mode::Ingest {
-        let id = PARSEABLE
-            .ingestor_metadata
-            .as_ref()
-            .expect(INGESTOR_EXPECT)
+        let id = INGESTOR_META
+            .get()
+            .unwrap_or_else(|| panic!("{}", INGESTOR_EXPECT))
             .get_node_id();
         let file_name = format!(".ingestor.{id}{SCHEMA_FILE_NAME}");
 
@@ -912,10 +912,9 @@ pub fn schema_path(stream_name: &str) -> RelativePathBuf {
 #[inline(always)]
 pub fn stream_json_path(stream_name: &str) -> RelativePathBuf {
     if PARSEABLE.options.mode == Mode::Ingest {
-        let id = PARSEABLE
-            .ingestor_metadata
-            .as_ref()
-            .expect(INGESTOR_EXPECT)
+        let id = INGESTOR_META
+            .get()
+            .unwrap_or_else(|| panic!("{}", INGESTOR_EXPECT))
             .get_node_id();
         let file_name = format!(".ingestor.{id}{STREAM_METADATA_FILE_NAME}",);
         RelativePathBuf::from_iter([stream_name, STREAM_ROOT_DIRECTORY, &file_name])
@@ -962,10 +961,9 @@ pub fn alert_json_path(alert_id: Ulid) -> RelativePathBuf {
 pub fn manifest_path(prefix: &str) -> RelativePathBuf {
     match &PARSEABLE.options.mode {
         Mode::Ingest => {
-            let id = PARSEABLE
-                .ingestor_metadata
-                .as_ref()
-                .expect(INGESTOR_EXPECT)
+            let id = INGESTOR_META
+                .get()
+                .unwrap_or_else(|| panic!("{}", INGESTOR_EXPECT))
                 .get_node_id();
             let manifest_file_name = format!("ingestor.{id}.{MANIFEST_FILE}");
             RelativePathBuf::from_iter([prefix, &manifest_file_name])

--- a/src/storage/object_storage.rs
+++ b/src/storage/object_storage.rs
@@ -895,40 +895,36 @@ pub fn to_bytes(any: &(impl ?Sized + serde::Serialize)) -> Bytes {
 }
 
 pub fn schema_path(stream_name: &str) -> RelativePathBuf {
-    match &PARSEABLE.options.mode {
-        Mode::Ingest => {
-            let id = PARSEABLE
-                .ingestor_metadata
-                .as_ref()
-                .expect(INGESTOR_EXPECT)
-                .get_node_id();
-            let file_name = format!(".ingestor.{id}{SCHEMA_FILE_NAME}");
+    if PARSEABLE.options.mode == Mode::Ingest {
+        let id = PARSEABLE
+            .ingestor_metadata
+            .as_ref()
+            .expect(INGESTOR_EXPECT)
+            .get_node_id();
+        let file_name = format!(".ingestor.{id}{SCHEMA_FILE_NAME}");
 
-            RelativePathBuf::from_iter([stream_name, STREAM_ROOT_DIRECTORY, &file_name])
-        }
-        Mode::All | Mode::Query | Mode::Index => {
-            RelativePathBuf::from_iter([stream_name, STREAM_ROOT_DIRECTORY, SCHEMA_FILE_NAME])
-        }
+        RelativePathBuf::from_iter([stream_name, STREAM_ROOT_DIRECTORY, &file_name])
+    } else {
+        RelativePathBuf::from_iter([stream_name, STREAM_ROOT_DIRECTORY, SCHEMA_FILE_NAME])
     }
 }
 
 #[inline(always)]
 pub fn stream_json_path(stream_name: &str) -> RelativePathBuf {
-    match &PARSEABLE.options.mode {
-        Mode::Ingest => {
-            let id = PARSEABLE
-                .ingestor_metadata
-                .as_ref()
-                .expect(INGESTOR_EXPECT)
-                .get_node_id();
-            let file_name = format!(".ingestor.{id}{STREAM_METADATA_FILE_NAME}",);
-            RelativePathBuf::from_iter([stream_name, STREAM_ROOT_DIRECTORY, &file_name])
-        }
-        Mode::Query | Mode::All | Mode::Index => RelativePathBuf::from_iter([
+    if PARSEABLE.options.mode == Mode::Ingest {
+        let id = PARSEABLE
+            .ingestor_metadata
+            .as_ref()
+            .expect(INGESTOR_EXPECT)
+            .get_node_id();
+        let file_name = format!(".ingestor.{id}{STREAM_METADATA_FILE_NAME}",);
+        RelativePathBuf::from_iter([stream_name, STREAM_ROOT_DIRECTORY, &file_name])
+    } else {
+        RelativePathBuf::from_iter([
             stream_name,
             STREAM_ROOT_DIRECTORY,
             STREAM_METADATA_FILE_NAME,
-        ]),
+        ])
     }
 }
 

--- a/src/storage/object_storage.rs
+++ b/src/storage/object_storage.rs
@@ -901,7 +901,7 @@ pub fn schema_path(stream_name: &str) -> RelativePathBuf {
                 .ingestor_metadata
                 .as_ref()
                 .expect(INGESTOR_EXPECT)
-                .get_ingestor_id();
+                .get_node_id();
             let file_name = format!(".ingestor.{id}{SCHEMA_FILE_NAME}");
 
             RelativePathBuf::from_iter([stream_name, STREAM_ROOT_DIRECTORY, &file_name])
@@ -920,7 +920,7 @@ pub fn stream_json_path(stream_name: &str) -> RelativePathBuf {
                 .ingestor_metadata
                 .as_ref()
                 .expect(INGESTOR_EXPECT)
-                .get_ingestor_id();
+                .get_node_id();
             let file_name = format!(".ingestor.{id}{STREAM_METADATA_FILE_NAME}",);
             RelativePathBuf::from_iter([stream_name, STREAM_ROOT_DIRECTORY, &file_name])
         }
@@ -970,7 +970,7 @@ pub fn manifest_path(prefix: &str) -> RelativePathBuf {
                 .ingestor_metadata
                 .as_ref()
                 .expect(INGESTOR_EXPECT)
-                .get_ingestor_id();
+                .get_node_id();
             let manifest_file_name = format!("ingestor.{id}.{MANIFEST_FILE}");
             RelativePathBuf::from_iter([prefix, &manifest_file_name])
         }

--- a/src/storage/store_metadata.rs
+++ b/src/storage/store_metadata.rs
@@ -159,7 +159,7 @@ pub async fn resolve_parseable_metadata(
                         metadata.server_mode = PARSEABLE.options.mode;
                         metadata.staging = PARSEABLE.options.staging_dir().to_path_buf();
                       },
-                    Mode::Index => {
+                    Mode::Index | Mode::Prism => {
                         // if index server is started fetch the metadata from remote
                         // update the server mode for local metadata
                         metadata.server_mode = PARSEABLE.options.mode;

--- a/src/storage/store_metadata.rs
+++ b/src/storage/store_metadata.rs
@@ -129,9 +129,13 @@ pub async fn resolve_parseable_metadata(
             Err("Could not start the server because staging directory indicates stale data from previous deployment, please choose an empty staging directory and restart the server")
         }
         EnvChange::NewStaging(mut metadata) => {
+
+            if metadata.server_mode==Mode::Prism {
+                Err("Starting Parseable OSS is not permitted when Parseable Enterprise is enabled. Please restart the server with different storage")
+            }
             // if server is started in ingest mode,we need to make sure that query mode has been started
             // i.e the metadata is updated to reflect the server mode = Query
-            if metadata.server_mode== Mode::All && PARSEABLE.options.mode == Mode::Ingest {
+            else if metadata.server_mode== Mode::All && PARSEABLE.options.mode == Mode::Ingest {
                 Err("Starting Ingest Mode is not allowed, Since Query Server has not been started yet")
             } else {
                 create_dir_all(PARSEABLE.options.staging_dir())?;

--- a/src/storage/store_metadata.rs
+++ b/src/storage/store_metadata.rs
@@ -202,7 +202,7 @@ pub async fn resolve_parseable_metadata(
     Ok(metadata)
 }
 
-fn determine_environment(
+pub fn determine_environment(
     staging_metadata: Option<StorageMetadata>,
     remote_metadata: Option<StorageMetadata>,
 ) -> EnvChange {

--- a/src/storage/store_metadata.rs
+++ b/src/storage/store_metadata.rs
@@ -130,12 +130,9 @@ pub async fn resolve_parseable_metadata(
         }
         EnvChange::NewStaging(mut metadata) => {
 
-            if metadata.server_mode==Mode::Prism {
-                Err("Starting Parseable OSS is not permitted when Parseable Enterprise is enabled. Please restart the server with different storage")
-            }
             // if server is started in ingest mode,we need to make sure that query mode has been started
             // i.e the metadata is updated to reflect the server mode = Query
-            else if metadata.server_mode== Mode::All && PARSEABLE.options.mode == Mode::Ingest {
+            if metadata.server_mode== Mode::All && PARSEABLE.options.mode == Mode::Ingest {
                 Err("Starting Ingest Mode is not allowed, Since Query Server has not been started yet")
             } else {
                 create_dir_all(PARSEABLE.options.staging_dir())?;

--- a/src/storage/store_metadata.rs
+++ b/src/storage/store_metadata.rs
@@ -148,7 +148,7 @@ pub async fn resolve_parseable_metadata(
                             })?;
                             overwrite_remote = true;
                     },
-                    Mode::Query => {
+                    Mode::Query | Mode::Prism => {
                         overwrite_remote = true;
                         metadata.server_mode = PARSEABLE.options.mode;
                         metadata.staging = PARSEABLE.options.staging_dir().to_path_buf();
@@ -159,7 +159,7 @@ pub async fn resolve_parseable_metadata(
                         metadata.server_mode = PARSEABLE.options.mode;
                         metadata.staging = PARSEABLE.options.staging_dir().to_path_buf();
                       },
-                    Mode::Index | Mode::Prism => {
+                    Mode::Index => {
                         // if index server is started fetch the metadata from remote
                         // update the server mode for local metadata
                         metadata.server_mode = PARSEABLE.options.mode;
@@ -175,7 +175,7 @@ pub async fn resolve_parseable_metadata(
             // new metadata needs to be set
             // if mode is query or all then both staging and remote
             match PARSEABLE.options.mode {
-                Mode::All | Mode::Query => overwrite_remote = true,
+                Mode::All | Mode::Query | Mode::Prism => overwrite_remote = true,
                 _ => (),
             }
             // else only staging

--- a/src/utils/arrow/flight.rs
+++ b/src/utils/arrow/flight.rs
@@ -133,7 +133,8 @@ pub fn send_to_ingester(start: i64, end: i64) -> bool {
     );
     let time_filters =
         extract_primary_filter(&[Expr::BinaryExpr(ex1), Expr::BinaryExpr(ex2)], &None);
-    PARSEABLE.options.mode == Mode::Query && is_within_staging_window(&time_filters)
+    (PARSEABLE.options.mode == Mode::Query || PARSEABLE.options.mode == Mode::Prism)
+        && is_within_staging_window(&time_filters)
 }
 
 fn lit_timestamp_milli(time: i64) -> Expr {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -36,19 +36,10 @@ use chrono::{NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use datafusion::common::tree_node::TreeNode;
 use regex::Regex;
 use sha2::{Digest, Sha256};
-use tracing::debug;
 
-pub fn get_ingestor_id() -> String {
+pub fn get_node_id() -> String {
     let now = Utc::now().to_rfc3339();
     let id = get_hash(&now).to_string().split_at(15).0.to_string();
-    debug!("Ingestor ID: {id}");
-    id
-}
-
-pub fn get_indexer_id() -> String {
-    let now = Utc::now().to_rfc3339();
-    let id = get_hash(&now).to_string().split_at(15).0.to_string();
-    debug!("Indexer ID: {id}");
     id
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new enterprise mode ("Prism") with dedicated messaging and behavior.
  - Added a command-line option to configure the querier endpoint.
  - Added global singleton caching for ingestor and querier metadata on server initialization.

- **Enhancements**
  - Expanded metrics reporting to track active and inactive indexers and queriers.
  - Unified metadata handling across node types: ingestors, indexers, queriers, and prism nodes.
  - Improved error handling and stream management for consistent user experience.
  - Updated manifest and schema processing to support both "Query" and "Prism" modes.
  - Added new error types for enhanced query error reporting.
  - Refined control flow to consistently raise errors when streams are not found.
  - Centralized ingestor metadata access via a global singleton.
  - Improved server mode handling to ensure accurate metadata updates and environment determination.
  - Made metadata storage module publicly accessible for broader usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->