### PR TITLE
add sql to denied names

### DIFF
--- a/src/validator.rs
+++ b/src/validator.rs
@@ -25,7 +25,7 @@ use crate::utils::human_size::bytes_to_human_size;
 
 // Add more sql keywords here in lower case
 const DENIED_NAMES: &[&str] = &[
-    "select", "from", "where", "group", "by", "order", "limit", "offset", "join", "and",
+    "select", "from", "where", "group", "by", "order", "limit", "offset", "join", "and", "sql",
 ];
 
 const ALLOWED_SPECIAL_CHARS: &[char] = &['-', '_'];


### PR DESCRIPTION
add `sql` to the list of denied names
restrict user to create stream name from this list


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced stream naming validation to disallow reserved SQL keywords, now including "sql", ensuring clearer naming consistency across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->