### PR TITLE
remove user auth for query in list filters

### DIFF
--- a/src/handlers/http/users/filters.rs
+++ b/src/handlers/http/users/filters.rs
@@ -21,7 +21,7 @@ use crate::{
     parseable::PARSEABLE,
     storage::{object_storage::filter_path, ObjectStorageError},
     users::filters::{Filter, CURRENT_FILTER_VERSION, FILTERS},
-    utils::{actix::extract_session_key_from_req, get_hash, get_user_from_request},
+    utils::{get_hash, get_user_from_request},
 };
 use actix_web::{
     http::header::ContentType,
@@ -33,10 +33,8 @@ use chrono::Utc;
 use http::StatusCode;
 use serde_json::Error as SerdeError;
 
-pub async fn list(req: HttpRequest) -> Result<impl Responder, FiltersError> {
-    let key =
-        extract_session_key_from_req(&req).map_err(|e| FiltersError::Custom(e.to_string()))?;
-    let filters = FILTERS.list_filters(&key).await;
+pub async fn list() -> Result<impl Responder, FiltersError> {
+    let filters = FILTERS.list_filters().await;
     Ok((web::Json(filters), StatusCode::OK))
 }
 

--- a/src/prism/home/mod.rs
+++ b/src/prism/home/mod.rs
@@ -104,7 +104,7 @@ pub async fn generate_home_response(key: &SessionKey) -> Result<HomeResponse, Pr
         get_alert_titles(key),
         get_correlation_titles(key),
         get_dashboard_titles(key),
-        get_filter_titles(key),
+        get_filter_titles(),
         get_alerts_info()
     );
 
@@ -258,9 +258,9 @@ async fn get_dashboard_titles(key: &SessionKey) -> Result<Vec<TitleAndId>, Prism
     Ok(dashboard_titles)
 }
 
-async fn get_filter_titles(key: &SessionKey) -> Result<Vec<TitleAndId>, PrismHomeError> {
+async fn get_filter_titles() -> Result<Vec<TitleAndId>, PrismHomeError> {
     let filter_titles = FILTERS
-        .list_filters(key)
+        .list_filters()
         .await
         .iter()
         .map(|filter| TitleAndId {

--- a/src/users/filters.rs
+++ b/src/users/filters.rs
@@ -23,8 +23,8 @@ use tokio::sync::RwLock;
 
 use super::TimeFilter;
 use crate::{
-    alerts::alerts_utils::user_auth_for_query, migration::to_bytes, parseable::PARSEABLE,
-    rbac::map::SessionKey, storage::object_storage::filter_path, utils::get_hash,
+    migration::to_bytes, parseable::PARSEABLE, storage::object_storage::filter_path,
+    utils::get_hash,
 };
 
 pub static FILTERS: Lazy<Filters> = Lazy::new(Filters::default);
@@ -152,23 +152,8 @@ impl Filters {
             .cloned()
     }
 
-    pub async fn list_filters(&self, key: &SessionKey) -> Vec<Filter> {
-        let read = self.0.read().await;
-
-        let mut filters = Vec::new();
-
-        for f in read.iter() {
-            let query = if let Some(q) = &f.query.filter_query {
-                q
-            } else {
-                continue;
-            };
-
-            if (user_auth_for_query(key, query).await).is_ok() {
-                filters.push(f.clone())
-            }
-        }
-        filters
+    pub async fn list_filters(&self) -> Vec<Filter> {
+        self.0.read().await.iter().cloned().collect()
     }
 }
 


### PR DESCRIPTION
current: server validates if user is authorized
for the streams in the `filter_query` in the filters list

change: server lists all available saved filters

reason: in saved search, `filter_query` is not a valid sql string it is just a key-value pair
also, unauthorized user cannot view the saved filter as he is restricted in the prism UI
hence, removed the check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the process for retrieving and displaying filter options, ensuring a more consistent user experience.
  - Simplified filter data handling by removing redundant session checks, which helps reduce potential delays or errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->