### PR TITLE
update user auth for list filters

### DIFF
--- a/src/alerts/mod.rs
+++ b/src/alerts/mod.rs
@@ -17,7 +17,6 @@
  */
 
 use actix_web::http::header::ContentType;
-use alerts_utils::user_auth_for_query;
 use async_trait::async_trait;
 use chrono::Utc;
 use derive_more::derive::FromStr;
@@ -43,6 +42,7 @@ use crate::rbac::map::SessionKey;
 use crate::storage;
 use crate::storage::ObjectStorageError;
 use crate::sync::alert_runtime;
+use crate::utils::user_auth_for_query;
 
 use self::target::Target;
 

--- a/src/correlation.rs
+++ b/src/correlation.rs
@@ -40,7 +40,7 @@ use crate::{
     rbac::{map::SessionKey, Users},
     storage::ObjectStorageError,
     users::filters::FilterQuery,
-    utils::{get_hash, user_auth_for_query},
+    utils::{get_hash, user_auth_for_datasets},
 };
 
 pub static CORRELATIONS: Lazy<Correlations> = Lazy::new(Correlations::default);
@@ -87,7 +87,7 @@ impl Correlations {
                 .iter()
                 .map(|t| t.table_name.clone())
                 .collect_vec();
-            if user_auth_for_query(&permissions, tables).is_ok() {
+            if user_auth_for_datasets(&permissions, tables).is_ok() {
                 user_correlations.push(correlation.clone());
             }
         }
@@ -281,7 +281,7 @@ impl CorrelationConfig {
             .map(|t| t.table_name.clone())
             .collect_vec();
 
-        user_auth_for_query(&permissions, tables)?;
+        user_auth_for_datasets(&permissions, tables)?;
 
         // to validate table config, we need to check whether the mentioned fields
         // are present in the table or not

--- a/src/handlers/airplane.rs
+++ b/src/handlers/airplane.rs
@@ -44,7 +44,7 @@ use crate::utils::arrow::flight::{
     send_to_ingester,
 };
 use crate::utils::time::TimeRange;
-use crate::utils::user_auth_for_query;
+use crate::utils::user_auth_for_datasets;
 use arrow_flight::{
     flight_service_server::FlightService, Action, ActionType, Criteria, Empty, FlightData,
     FlightDescriptor, FlightInfo, HandshakeRequest, HandshakeResponse, PutResult, SchemaAsIpc,
@@ -211,7 +211,7 @@ impl FlightService for AirServiceImpl {
 
         let permissions = Users.get_permissions(&key);
 
-        user_auth_for_query(&permissions, &streams).map_err(|_| {
+        user_auth_for_datasets(&permissions, &streams).map_err(|_| {
             Status::permission_denied("User Does not have permission to access this")
         })?;
         let time = Instant::now();

--- a/src/handlers/http/alerts.rs
+++ b/src/handlers/http/alerts.rs
@@ -22,7 +22,7 @@ use crate::{
     parseable::PARSEABLE,
     storage::object_storage::alert_json_path,
     // sync::schedule_alert_task,
-    utils::actix::extract_session_key_from_req,
+    utils::{actix::extract_session_key_from_req, user_auth_for_query},
 };
 use actix_web::{
     web::{self, Json, Path},
@@ -31,9 +31,7 @@ use actix_web::{
 use bytes::Bytes;
 use ulid::Ulid;
 
-use crate::alerts::{
-    alerts_utils::user_auth_for_query, AlertConfig, AlertError, AlertRequest, AlertState, ALERTS,
-};
+use crate::alerts::{AlertConfig, AlertError, AlertRequest, AlertState, ALERTS};
 
 // GET /alerts
 /// User needs at least a read access to the stream(s) that is being referenced in an alert

--- a/src/handlers/http/correlation.rs
+++ b/src/handlers/http/correlation.rs
@@ -23,7 +23,7 @@ use itertools::Itertools;
 
 use crate::rbac::Users;
 use crate::utils::actix::extract_session_key_from_req;
-use crate::utils::{get_hash, get_user_from_request, user_auth_for_query};
+use crate::utils::{get_hash, get_user_from_request, user_auth_for_datasets};
 
 use crate::correlation::{CorrelationConfig, CorrelationError, CORRELATIONS};
 
@@ -54,7 +54,7 @@ pub async fn get(
         .map(|t| t.table_name.clone())
         .collect_vec();
 
-    user_auth_for_query(&permissions, tables)?;
+    user_auth_for_datasets(&permissions, tables)?;
 
     Ok(web::Json(correlation))
 }

--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -49,7 +49,7 @@ use crate::storage::object_storage::commit_schema_to_storage;
 use crate::storage::ObjectStorageError;
 use crate::utils::actix::extract_session_key_from_req;
 use crate::utils::time::{TimeParseError, TimeRange};
-use crate::utils::user_auth_for_query;
+use crate::utils::user_auth_for_datasets;
 
 /// Query Request through http endpoint.
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -99,7 +99,7 @@ pub async fn query(req: HttpRequest, query_request: Query) -> Result<HttpRespons
         .first_table_name()
         .ok_or_else(|| QueryError::MalformedQuery("No table name found in query"))?;
 
-    user_auth_for_query(&permissions, &tables)?;
+    user_auth_for_datasets(&permissions, &tables)?;
 
     let time = Instant::now();
     // Intercept `count(*)`` queries and use the counts API
@@ -162,7 +162,7 @@ pub async fn get_counts(
     let permissions = Users.get_permissions(&creds);
 
     // does user have access to table?
-    user_auth_for_query(&permissions, &[counts_request.stream.clone()])?;
+    user_auth_for_datasets(&permissions, &[counts_request.stream.clone()])?;
 
     let records = counts_request.get_bin_density().await?;
 

--- a/src/users/dashboards.rs
+++ b/src/users/dashboards.rs
@@ -22,8 +22,11 @@ use serde_json::Value;
 use tokio::sync::RwLock;
 
 use crate::{
-    alerts::alerts_utils::user_auth_for_query, migration::to_bytes, parseable::PARSEABLE,
-    rbac::map::SessionKey, storage::object_storage::dashboard_path, utils::get_hash,
+    migration::to_bytes,
+    parseable::PARSEABLE,
+    rbac::map::SessionKey,
+    storage::object_storage::dashboard_path,
+    utils::{get_hash, user_auth_for_query},
 };
 
 use super::TimeFilter;

--- a/src/users/filters.rs
+++ b/src/users/filters.rs
@@ -185,6 +185,10 @@ impl Filters {
                 continue;
             };
             let filter_type = &f.query.filter_type;
+
+            // if filter type is one of SQL or filter
+            // then check if the user has access to the dataset based on the query string
+            // if filter type is search then check if the user has access to the dataset based on the dataset name
             if *filter_type == FilterType::SQL || *filter_type == FilterType::Filter {
                 if (user_auth_for_query(key, query).await).is_ok() {
                     filters.push(f.clone())


### PR DESCRIPTION
current: server checks if user is authorized to a dataset based on query string 
this logic does not work for saved searches because there is no query string 
as searches have key:value pair syntax

update: server fetches the filter_type
if filter_type is sql or filter,
server checks if user is authorized to a dataset based on query string if filter_type is search,
server checks if user is authorized to a dataset based on the dataset_name



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced filter functionality now categorizes filters into distinct types (e.g., SQL, Search) for clearer processing.
  - Improved asynchronous query handling provides a more responsive experience.

- **Bug Fixes**
  - Addressed inconsistencies in user authorization logic by shifting from query-specific checks to dataset-level permissions.

- **Refactor**
  - Updated user authorization mechanisms across features to enforce streamlined, dataset-level permissions.
  - Reorganized and consolidated internal dependencies for greater system clarity and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->