### PR TITLE
fix: sql query to fetch distinct values in datasets API

### DIFF
--- a/src/prism/logstream/mod.rs
+++ b/src/prism/logstream/mod.rs
@@ -392,7 +392,7 @@ impl PrismDatasetRequest {
         field: &str,
     ) -> Result<Vec<String>, QueryError> {
         let query = Query {
-            query: format!("SELECT DISTINCT({field}) FROM {stream_name}"),
+            query: format!("SELECT DISTINCT({field}) FROM \"{stream_name}\""),
             start_time: "1h".to_owned(),
             end_time: "now".to_owned(),
             send_null: false,


### PR DESCRIPTION
add escape characters to the stream names in the query call query string -
`select DISTINCT(p_src_ip) from \"{stream-name}\"`
`\select DISTINCT(p_user_agent) from \"{stream-name}\"`

