### PR TITLE
fix: delete date stats

### DIFF
--- a/src/handlers/http/logstream.rs
+++ b/src/handlers/http/logstream.rs
@@ -57,9 +57,9 @@ pub async fn delete(stream_name: Path<String>) -> Result<impl Responder, StreamE
     objectstore.delete_stream(&stream_name).await?;
     // Delete from staging
     let stream_dir = PARSEABLE.get_or_create_stream(&stream_name);
-    if fs::remove_dir_all(&stream_dir.data_path).is_err() {
+    if let Err(err) = fs::remove_dir_all(&stream_dir.data_path) {
         warn!(
-            "failed to delete local data for stream {}. Clean {} manually",
+            "failed to delete local data for stream {} with error {err}. Clean {} manually",
             stream_name,
             stream_dir.data_path.to_string_lossy()
         )

--- a/src/handlers/http/modal/query/querier_logstream.rs
+++ b/src/handlers/http/modal/query/querier_logstream.rs
@@ -68,9 +68,9 @@ pub async fn delete(stream_name: Path<String>) -> Result<impl Responder, StreamE
     // Delete from storage
     objectstore.delete_stream(&stream_name).await?;
     let stream_dir = PARSEABLE.get_or_create_stream(&stream_name);
-    if fs::remove_dir_all(&stream_dir.data_path).is_err() {
+    if let Err(err) = fs::remove_dir_all(&stream_dir.data_path) {
         warn!(
-            "failed to delete local data for stream {}. Clean {} manually",
+            "failed to delete local data for stream {} with error {err}. Clean {} manually",
             stream_name,
             stream_dir.data_path.to_string_lossy()
         )


### PR DESCRIPTION
Stats were not getting deleted during stream deletion

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error messages when deleting local stream data, now providing detailed error information if deletion fails.
- **Refactor**
	- Enhanced metric removal logic to match and delete metrics based on label presence rather than positional prefix.
	- Added safer error handling during metric label removal to prevent error propagation and log warnings instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->