### PR TITLE
revamp home api

### DIFF
--- a/src/handlers/http/modal/server.rs
+++ b/src/handlers/http/modal/server.rs
@@ -148,8 +148,10 @@ impl ParseableServer for Server {
 }
 
 impl Server {
-    pub fn get_prism_home() -> Resource {
-        web::resource("/home").route(web::get().to(http::prism_home::home_api))
+    pub fn get_prism_home() -> Scope {
+        web::scope("/home")
+            .service(web::resource("").route(web::get().to(http::prism_home::home_api)))
+            .service(web::resource("/search").route(web::get().to(http::prism_home::home_search)))
     }
 
     pub fn get_prism_logstream() -> Scope {

--- a/src/handlers/http/prism_home.rs
+++ b/src/handlers/http/prism_home.rs
@@ -19,7 +19,7 @@
 use actix_web::{web, HttpRequest, Responder};
 
 use crate::{
-    prism::home::{generate_home_response, PrismHomeError},
+    prism::home::{generate_home_response, generate_home_search_response, PrismHomeError},
     utils::actix::extract_session_key_from_req,
 };
 
@@ -34,6 +34,15 @@ pub async fn home_api(req: HttpRequest) -> Result<impl Responder, PrismHomeError
         .map_err(|err| PrismHomeError::Anyhow(anyhow::Error::msg(err.to_string())))?;
 
     let res = generate_home_response(&key).await?;
+
+    Ok(web::Json(res))
+}
+
+pub async fn home_search(req: HttpRequest) -> Result<impl Responder, PrismHomeError> {
+    let key = extract_session_key_from_req(&req)
+        .map_err(|err| PrismHomeError::Anyhow(anyhow::Error::msg(err.to_string())))?;
+
+    let res = generate_home_search_response(&key).await?;
 
     Ok(web::Json(res))
 }

--- a/src/prism/home/mod.rs
+++ b/src/prism/home/mod.rs
@@ -36,19 +36,11 @@ use crate::{
     },
     parseable::PARSEABLE,
     rbac::{map::SessionKey, role::Action, Users},
-    stats::Stats,
     storage::{ObjectStorageError, ObjectStoreFormat, STREAM_ROOT_DIRECTORY},
     users::{dashboards::DASHBOARDS, filters::FILTERS},
 };
 
 type StreamMetadataResponse = Result<(String, Vec<ObjectStoreFormat>, DataSetType), PrismHomeError>;
-
-#[derive(Debug, Serialize, Default)]
-struct StreamStats {
-    // stream_count: u32,
-    // log_source_count: u32,
-    stats_summary: Stats,
-}
 
 #[derive(Debug, Serialize, Default)]
 struct DatedStats {
@@ -146,14 +138,10 @@ pub async fn generate_home_response(key: &SessionKey) -> Result<HomeResponse, Pr
         futures::future::join_all(stats_futures).await;
 
     let mut stream_details = Vec::new();
-    let mut summary = StreamStats::default();
 
     for result in stats_results {
         match result {
             Ok(dated_stats) => {
-                summary.stats_summary.events += dated_stats.events;
-                summary.stats_summary.ingestion += dated_stats.ingestion_size;
-                summary.stats_summary.storage += dated_stats.storage_size;
                 stream_details.push(dated_stats);
             }
             Err(e) => {

--- a/src/prism/home/mod.rs
+++ b/src/prism/home/mod.rs
@@ -97,8 +97,7 @@ pub async fn generate_home_response(key: &SessionKey) -> Result<HomeResponse, Pr
         .map(|i| {
             Utc::now()
                 .checked_sub_signed(chrono::Duration::days(i))
-                .ok_or_else(|| anyhow::Error::msg("Date conversion failed"))
-                .unwrap()
+                .expect("Date conversion failed")
         })
         .map(|date| date.format("%Y-%m-%d").to_string())
         .collect_vec();
@@ -331,12 +330,7 @@ async fn get_dashboard_titles(key: &SessionKey) -> Result<Vec<TitleAndId>, Prism
         .iter()
         .map(|dashboard| TitleAndId {
             title: dashboard.name.clone(),
-            id: dashboard
-                .dashboard_id
-                .as_ref()
-                .ok_or_else(|| anyhow::Error::msg("Dashboard ID is null"))
-                .unwrap()
-                .clone(),
+            id: dashboard.dashboard_id.as_ref().unwrap().clone(),
         })
         .collect_vec();
 
@@ -350,12 +344,7 @@ async fn get_filter_titles(key: &SessionKey) -> Result<Vec<TitleAndId>, PrismHom
         .iter()
         .map(|filter| TitleAndId {
             title: filter.filter_name.clone(),
-            id: filter
-                .filter_id
-                .as_ref()
-                .ok_or_else(|| anyhow::Error::msg("Filter ID is null"))
-                .unwrap()
-                .clone(),
+            id: filter.filter_id.as_ref().unwrap().clone(),
         })
         .collect_vec();
 

--- a/src/rbac/role.rs
+++ b/src/rbac/role.rs
@@ -324,6 +324,7 @@ pub mod model {
                 Action::GetDashboard,
                 Action::CreateDashboard,
                 Action::DeleteDashboard,
+                Action::GetRetention,
                 Action::GetStreamInfo,
                 Action::GetUserRoles,
                 Action::GetAlert,


### PR DESCRIPTION
update the implementation of `/api/prism/v1/home`
remove titles of alerts, dashboards, correlations, filters from home api

updated response -
```
{
    "alerts_info": {
        "total": 0,
        "silenced": 0,
        "resolved": 0,
        "triggered": 0,
        "low": 0,
        "medium": 0,
        "high": 0,
        "critical": 0
    },
    "stats_details": [
        {
            "date": "2025-04-30",
            "events": 0,
            "ingestion_size": 0,
            "storage_size": 0
        },
        {
            "date": "2025-05-01",
            "events": 0,
            "ingestion_size": 0,
            "storage_size": 0
        },
        {
            "date": "2025-05-02",
            "events": 3866860,
            "ingestion_size": 5260602290,
            "storage_size": 736510108
        },
        {
            "date": "2025-05-03",
            "events": 0,
            "ingestion_size": 0,
            "storage_size": 0
        },
        {
            "date": "2025-05-04",
            "events": 0,
            "ingestion_size": 0,
            "storage_size": 0
        },
        {
            "date": "2025-05-05",
            "events": 0,
            "ingestion_size": 0,
            "storage_size": 0
        },
        {
            "date": "2025-05-06",
            "events": 2027400,
            "ingestion_size": 2757834546,
            "storage_size": 384782870
        }
    ],
    "datasets": [
        {
            "title": "test15",
            "dataset_type": "Logs"
        }
    ]
}
```

add another api to be called from prism
`/api/prism/v1/home/search`

server sends title and id of alerts, dashboards, correlations, filters

```
{
    "alerts": [],
    "correlations": [],
    "dashboards": [],
    "filters": [
        {
            "title": "body not null",
            "id": "e71d1affa4ad72136e03092a717a4b0e0c3fd6d643a09572ad65e1748a5c2df8"
        },
        {
            "title": "select *",
            "id": "6fe16f99b05566d7d4a598a7f0fa2604379d75164cdda5657c7fdbf61e54a555"
        }
    ]
}
```

update datasets api -
update readers priviledge - add `GetRetention` action remove distinct values from datasets api
prism to call the query apis directly for p_src_ip and p_user_agent



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `/home/search` endpoint, providing search-related metadata for alerts, correlations, dashboards, filters, and datasets.

- **Improvements**
  - Enhanced the `/home` endpoint to support multiple routes, allowing for more flexible data retrieval under the `/home` prefix.
  - The "Reader" role now includes permission to view retention settings.

- **Refactor**
  - Separated home page data from search metadata, resulting in clearer and more maintainable responses.

- **Bug Fixes**
  - Removed distinct source data (such as IPs and user agents) from dataset responses to streamline output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->