### PR TITLE
reject event if fields count exceed 250

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -371,12 +371,12 @@ pub struct Options {
 
     #[arg(
         long,
-        env = "P_OTEL_ATTRIBUTES_ALLOWED_LIMIT",
-        default_value = "200",
-        value_parser = validation::validate_otel_attributes_allowed_limit,
-        help = "allowed limit for otel attributes"
+        env = "P_DATASET_FIELDS_ALLOWED_LIMIT",
+        default_value = "250",
+        value_parser = validation::validate_dataset_fields_allowed_limit,
+        help = "allowed limit for fields count in a dataset"
     )]
-    pub otel_attributes_allowed_limit: usize,
+    pub dataset_fields_allowed_limit: usize,
 }
 
 #[derive(Parser, Debug)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,6 +35,7 @@ use crate::{
 pub const DEFAULT_USERNAME: &str = "admin";
 pub const DEFAULT_PASSWORD: &str = "admin";
 
+pub const DATASET_FIELD_COUNT_LIMIT: usize = 250;
 #[derive(Parser)]
 #[command(
     name = "parseable",
@@ -371,10 +372,10 @@ pub struct Options {
 
     #[arg(
         long,
-        env = "P_DATASET_FIELDS_ALLOWED_LIMIT",
-        default_value = "250",
+        env = "P_DATASET_FIELD_COUNT_LIMIT",
+        default_value_t = DATASET_FIELD_COUNT_LIMIT,
         value_parser = validation::validate_dataset_fields_allowed_limit,
-        help = "allowed limit for fields count in a dataset"
+        help = "total number of fields recommended in a dataset"
     )]
     pub dataset_fields_allowed_limit: usize,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -373,6 +373,7 @@ pub struct Options {
         long,
         env = "P_OTEL_ATTRIBUTES_ALLOWED_LIMIT",
         default_value = "200",
+        value_parser = validation::validate_otel_attributes_allowed_limit,
         help = "allowed limit for otel attributes"
     )]
     pub otel_attributes_allowed_limit: usize,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -368,6 +368,14 @@ pub struct Options {
 
     #[arg(long, env = "P_MS_CLARITY_TAG", help = "Tag for MS Clarity")]
     pub ms_clarity_tag: Option<String>,
+
+    #[arg(
+        long,
+        env = "P_OTEL_ATTRIBUTES_ALLOWED_LIMIT",
+        default_value = "200",
+        help = "allowed limit for otel attributes"
+    )]
+    pub otel_attributes_allowed_limit: usize,
 }
 
 #[derive(Parser, Debug)]

--- a/src/handlers/http/ingest.rs
+++ b/src/handlers/http/ingest.rs
@@ -498,7 +498,7 @@ impl actix_web::ResponseError for PostError {
             PostError::MissingTimePartition(_) => StatusCode::BAD_REQUEST,
             PostError::KnownFormat(_) => StatusCode::BAD_REQUEST,
             PostError::IncorrectLogFormat(_) => StatusCode::BAD_REQUEST,
-            PostError::OtelError(_) => StatusCode::EXPECTATION_FAILED,
+            PostError::OtelError(_) => StatusCode::BAD_REQUEST,
         }
     }
 

--- a/src/handlers/http/ingest.rs
+++ b/src/handlers/http/ingest.rs
@@ -35,6 +35,7 @@ use crate::metadata::SchemaVersion;
 use crate::option::Mode;
 use crate::otel::logs::OTEL_LOG_KNOWN_FIELD_LIST;
 use crate::otel::metrics::OTEL_METRICS_KNOWN_FIELD_LIST;
+use crate::otel::otel_utils::OtelError;
 use crate::otel::traces::OTEL_TRACES_KNOWN_FIELD_LIST;
 use crate::parseable::{StreamNotFound, PARSEABLE};
 use crate::storage::{ObjectStorageError, StreamType};
@@ -467,6 +468,8 @@ pub enum PostError {
     KnownFormat(#[from] known_schema::Error),
     #[error("Ingestion is not allowed to stream {0} as it is already associated with a different OTEL format")]
     IncorrectLogFormat(String),
+    #[error("OtelError: {0}")]
+    OtelError(#[from] OtelError),
 }
 
 impl actix_web::ResponseError for PostError {
@@ -495,6 +498,7 @@ impl actix_web::ResponseError for PostError {
             PostError::MissingTimePartition(_) => StatusCode::BAD_REQUEST,
             PostError::KnownFormat(_) => StatusCode::BAD_REQUEST,
             PostError::IncorrectLogFormat(_) => StatusCode::BAD_REQUEST,
+            PostError::OtelError(_) => StatusCode::EXPECTATION_FAILED,
         }
     }
 

--- a/src/handlers/http/ingest.rs
+++ b/src/handlers/http/ingest.rs
@@ -467,7 +467,7 @@ pub enum PostError {
     KnownFormat(#[from] known_schema::Error),
     #[error("Ingestion is not allowed to stream {0} as it is already associated with a different OTEL format")]
     IncorrectLogFormat(String),
-    #[error("Ingestion failed for dataset {0} as fields count {1} exceeds the limit {2}, Parseable recommends creating a new dataset.")]
+    #[error("Ingestion has been stoppped for dataset {0} as fields count {1} exceeds the allowed limit of {2}, Please create a new dataset.")]
     FieldsLimitExceeded(String, usize, usize),
 }
 

--- a/src/handlers/http/ingest.rs
+++ b/src/handlers/http/ingest.rs
@@ -468,7 +468,7 @@ pub enum PostError {
     #[error("Ingestion is not allowed to stream {0} as it is already associated with a different OTEL format")]
     IncorrectLogFormat(String),
     #[error("Failed to ingest events in dataset {0}. Total number of fields {1} exceeds the permissible limit of {2}. We recommend creating a new dataset beyond {2} for better query performance.")]
-    FieldsLimitExceeded(String, usize, usize),
+    FieldsCountLimitExceeded(String, usize, usize),
 }
 
 impl actix_web::ResponseError for PostError {
@@ -497,7 +497,7 @@ impl actix_web::ResponseError for PostError {
             PostError::MissingTimePartition(_) => StatusCode::BAD_REQUEST,
             PostError::KnownFormat(_) => StatusCode::BAD_REQUEST,
             PostError::IncorrectLogFormat(_) => StatusCode::BAD_REQUEST,
-            PostError::FieldsLimitExceeded(_, _, _) => StatusCode::BAD_REQUEST,
+            PostError::FieldsCountLimitExceeded(_, _, _) => StatusCode::BAD_REQUEST,
         }
     }
 

--- a/src/handlers/http/ingest.rs
+++ b/src/handlers/http/ingest.rs
@@ -467,7 +467,7 @@ pub enum PostError {
     KnownFormat(#[from] known_schema::Error),
     #[error("Ingestion is not allowed to stream {0} as it is already associated with a different OTEL format")]
     IncorrectLogFormat(String),
-    #[error("Ingestion has been stoppped for dataset {0} as fields count {1} exceeds the allowed limit of {2}, Please create a new dataset.")]
+    #[error("Failed to ingest events in dataset {0}. Total number of fields {1} exceeds the permissible limit of {2}. We recommend creating a new dataset beyond {2} for better query performance.")]
     FieldsLimitExceeded(String, usize, usize),
 }
 

--- a/src/handlers/http/modal/utils/ingest_utils.rs
+++ b/src/handlers/http/modal/utils/ingest_utils.rs
@@ -220,7 +220,7 @@ fn verify_dataset_fields_count(stream_name: &str) -> Result<(), PostError> {
         tracing::warn!(
             "Total fields in dataset {0} has reached the warning threshold of {1}. Ingestion will not be possible after reaching {2} fields. We recommend creating a new dataset.",
             stream_name,
-            dataset_fields_warn_threshold,
+            dataset_fields_warn_threshold as usize,
             PARSEABLE.options.dataset_fields_allowed_limit
             );
     }

--- a/src/handlers/http/modal/utils/ingest_utils.rs
+++ b/src/handlers/http/modal/utils/ingest_utils.rs
@@ -65,21 +65,24 @@ pub async fn flatten_and_push_logs(
         LogSource::OtelLogs => {
             //custom flattening required for otel logs
             let logs: LogsData = serde_json::from_value(json)?;
-            for record in flatten_otel_logs(&logs) {
+            let records = flatten_otel_logs(&logs)?;
+            for record in records {
                 push_logs(stream_name, record, log_source, p_custom_fields).await?;
             }
         }
         LogSource::OtelTraces => {
             //custom flattening required for otel traces
             let traces: TracesData = serde_json::from_value(json)?;
-            for record in flatten_otel_traces(&traces) {
+            let records = flatten_otel_traces(&traces)?;
+            for record in records {
                 push_logs(stream_name, record, log_source, p_custom_fields).await?;
             }
         }
         LogSource::OtelMetrics => {
             //custom flattening required for otel metrics
             let metrics: MetricsData = serde_json::from_value(json)?;
-            for record in flatten_otel_metrics(metrics) {
+            let records = flatten_otel_metrics(metrics)?;
+            for record in records {
                 push_logs(stream_name, record, log_source, p_custom_fields).await?;
             }
         }

--- a/src/handlers/http/modal/utils/ingest_utils.rs
+++ b/src/handlers/http/modal/utils/ingest_utils.rs
@@ -218,8 +218,9 @@ fn verify_dataset_fields_count(stream_name: &str) -> Result<(), PostError> {
     // Check if the fields count exceeds the warn threshold
     if fields_count > dataset_fields_warn_threshold as usize {
         tracing::warn!(
-            "Total fields in dataset {0} has reached the warning threshold of {1}. Ingestion will not be possible after reaching {2} fields. We recommend creating a new dataset.",
+            "Dataset {0} has {1} fields, which exceeds the warning threshold of {2}. Ingestion will not be possible after reaching {3} fields. We recommend creating a new dataset.",
             stream_name,
+            fields_count,
             dataset_fields_warn_threshold as usize,
             PARSEABLE.options.dataset_fields_allowed_limit
             );

--- a/src/handlers/http/modal/utils/ingest_utils.rs
+++ b/src/handlers/http/modal/utils/ingest_utils.rs
@@ -221,7 +221,7 @@ fn verify_dataset_fields_count(stream_name: &str) -> Result<(), PostError> {
     if fields_count > dataset_fields_warn_threshold as usize {
         tracing::warn!(
             "Fields count {0} for dataset {1} has exceeded the warning threshold of {2} fields, Parseable recommends creating a new dataset.",
-            dataset_fields_warn_threshold,
+            fields_count,
             stream_name,
             dataset_fields_warn_threshold);
     }

--- a/src/option.rs
+++ b/src/option.rs
@@ -95,6 +95,9 @@ pub mod validation {
 
     use super::{Compression, Mode};
 
+    // Maximum allowed otel attributes per event
+    const OTEL_ATTRIBUTES_ALLOWED_LIMIT: usize = 200;
+
     pub fn file_path(s: &str) -> Result<PathBuf, String> {
         if s.is_empty() {
             return Err("empty path".to_owned());
@@ -176,16 +179,16 @@ pub mod validation {
 
     pub fn validate_otel_attributes_allowed_limit(s: &str) -> Result<usize, String> {
         if let Ok(size) = s.parse::<usize>() {
-            if (1..=200).contains(&size) {
+            if (1..=OTEL_ATTRIBUTES_ALLOWED_LIMIT).contains(&size) {
                 Ok(size)
             } else {
                 Err(format!(
-                    "Invalid value for size. It should be between 1 and {}",
-                    200
+                    "Invalid value for P_OTEL_ATTRIBUTES_ALLOWED_LIMIT. It should be between 1 and {}",
+                    OTEL_ATTRIBUTES_ALLOWED_LIMIT
                 ))
             }
         } else {
-            Err("Invalid value for size. It should be given as integer value".to_string())
+            Err("Invalid value for P_OTEL_ATTRIBUTES_ALLOWED_LIMIT. It should be given as integer value".to_string())
         }
     }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -91,12 +91,10 @@ pub mod validation {
         path::{Path, PathBuf},
     };
 
+    use crate::handlers::http::modal::utils::ingest_utils::DATASET_FIELDS_ALLOWED_LIMIT;
     use path_clean::PathClean;
 
     use super::{Compression, Mode};
-
-    // Maximum allowed count for fields in a dataset
-    const DATASET_FIELDS_ALLOWED_LIMIT: usize = 250;
 
     pub fn file_path(s: &str) -> Result<PathBuf, String> {
         if s.is_empty() {

--- a/src/option.rs
+++ b/src/option.rs
@@ -91,7 +91,7 @@ pub mod validation {
         path::{Path, PathBuf},
     };
 
-    use crate::handlers::http::modal::utils::ingest_utils::DATASET_FIELDS_ALLOWED_LIMIT;
+    use crate::cli::DATASET_FIELD_COUNT_LIMIT;
     use path_clean::PathClean;
 
     use super::{Compression, Mode};
@@ -177,16 +177,16 @@ pub mod validation {
 
     pub fn validate_dataset_fields_allowed_limit(s: &str) -> Result<usize, String> {
         if let Ok(size) = s.parse::<usize>() {
-            if (1..=DATASET_FIELDS_ALLOWED_LIMIT).contains(&size) {
+            if (1..=DATASET_FIELD_COUNT_LIMIT).contains(&size) {
                 Ok(size)
             } else {
                 Err(format!(
-                    "Invalid value for P_DATASET_FIELDS_ALLOWED_LIMIT. It should be between 1 and {}",
-                    DATASET_FIELDS_ALLOWED_LIMIT
+                    "Invalid value for P_DATASET_FIELD_COUNT_LIMIT. It should be between 1 and {}",
+                    DATASET_FIELD_COUNT_LIMIT
                 ))
             }
         } else {
-            Err("Invalid value for P_DATASET_FIELDS_ALLOWED_LIMIT. It should be given as integer value".to_string())
+            Err("Invalid value for P_DATASET_FIELD_COUNT_LIMIT. It should be given as integer value".to_string())
         }
     }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -173,4 +173,19 @@ pub mod validation {
             Err("Invalid value for max disk usage. It should be given as 90.0 for 90%".to_string())
         }
     }
+
+    pub fn validate_otel_attributes_allowed_limit(s: &str) -> Result<usize, String> {
+        if let Ok(size) = s.parse::<usize>() {
+            if (1..=200).contains(&size) {
+                Ok(size)
+            } else {
+                Err(format!(
+                    "Invalid value for size. It should be between 1 and {}",
+                    200
+                ))
+            }
+        } else {
+            Err("Invalid value for size. It should be given as integer value".to_string())
+        }
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -95,8 +95,8 @@ pub mod validation {
 
     use super::{Compression, Mode};
 
-    // Maximum allowed otel attributes per event
-    const OTEL_ATTRIBUTES_ALLOWED_LIMIT: usize = 200;
+    // Maximum allowed count for fields in a dataset
+    const DATASET_FIELDS_ALLOWED_LIMIT: usize = 250;
 
     pub fn file_path(s: &str) -> Result<PathBuf, String> {
         if s.is_empty() {
@@ -177,18 +177,18 @@ pub mod validation {
         }
     }
 
-    pub fn validate_otel_attributes_allowed_limit(s: &str) -> Result<usize, String> {
+    pub fn validate_dataset_fields_allowed_limit(s: &str) -> Result<usize, String> {
         if let Ok(size) = s.parse::<usize>() {
-            if (1..=OTEL_ATTRIBUTES_ALLOWED_LIMIT).contains(&size) {
+            if (1..=DATASET_FIELDS_ALLOWED_LIMIT).contains(&size) {
                 Ok(size)
             } else {
                 Err(format!(
-                    "Invalid value for P_OTEL_ATTRIBUTES_ALLOWED_LIMIT. It should be between 1 and {}",
-                    OTEL_ATTRIBUTES_ALLOWED_LIMIT
+                    "Invalid value for P_DATASET_FIELDS_ALLOWED_LIMIT. It should be between 1 and {}",
+                    DATASET_FIELDS_ALLOWED_LIMIT
                 ))
             }
         } else {
-            Err("Invalid value for P_OTEL_ATTRIBUTES_ALLOWED_LIMIT. It should be given as integer value".to_string())
+            Err("Invalid value for P_DATASET_FIELDS_ALLOWED_LIMIT. It should be given as integer value".to_string())
         }
     }
 }

--- a/src/otel/logs.rs
+++ b/src/otel/logs.rs
@@ -16,6 +16,14 @@
  *
  */
 
+use std::collections::HashSet;
+
+use crate::parseable::PARSEABLE;
+
+use super::otel_utils::collect_json_from_values;
+use super::otel_utils::convert_epoch_nano_to_timestamp;
+use super::otel_utils::insert_attributes;
+use super::otel_utils::OtelError;
 use opentelemetry_proto::tonic::logs::v1::LogRecord;
 use opentelemetry_proto::tonic::logs::v1::LogsData;
 use opentelemetry_proto::tonic::logs::v1::ScopeLogs;
@@ -23,19 +31,23 @@ use opentelemetry_proto::tonic::logs::v1::SeverityNumber;
 use serde_json::Map;
 use serde_json::Value;
 
-use super::otel_utils::add_other_attributes_if_not_empty;
-use super::otel_utils::collect_json_from_values;
-use super::otel_utils::convert_epoch_nano_to_timestamp;
-use super::otel_utils::insert_attributes;
-use super::otel_utils::merge_attributes_in_json;
-
-pub const OTEL_LOG_KNOWN_FIELD_LIST: [&str; 6] = [
+pub const OTEL_LOG_KNOWN_FIELD_LIST: [&str; 16] = [
+    "scope_name",
+    "scope_version",
+    "scope_log_schema_url",
+    "scope_dropped_attributes_count",
+    "resource_dropped_attributes_count",
+    "resource_schema_url",
     "time_unix_nano",
+    "observed_time_unix_nano",
     "severity_number",
     "severity_text",
     "body",
+    "flags",
+    "log_record_dropped_attributes_count",
     "span_id",
     "trace_id",
+    "event_name",
 ];
 /// otel log event has severity number
 /// there is a mapping of severity number to severity text provided in proto
@@ -60,7 +72,6 @@ fn flatten_severity(severity_number: i32) -> Map<String, Value> {
 /// this function is called recursively for each log record object in the otel logs
 pub fn flatten_log_record(log_record: &LogRecord) -> Map<String, Value> {
     let mut log_record_json: Map<String, Value> = Map::new();
-    let mut other_attributes = Map::new();
     log_record_json.insert(
         "time_unix_nano".to_string(),
         Value::String(convert_epoch_nano_to_timestamp(
@@ -83,11 +94,7 @@ pub fn flatten_log_record(log_record: &LogRecord) -> Map<String, Value> {
             log_record_json.insert(key.to_owned(), body_json[key].to_owned());
         }
     }
-    insert_attributes(
-        &mut log_record_json,
-        &log_record.attributes,
-        &mut other_attributes,
-    );
+    insert_attributes(&mut log_record_json, &log_record.attributes);
     log_record_json.insert(
         "log_record_dropped_attributes_count".to_string(),
         Value::Number(log_record.dropped_attributes_count.into()),
@@ -106,9 +113,6 @@ pub fn flatten_log_record(log_record: &LogRecord) -> Map<String, Value> {
         Value::String(hex::encode(&log_record.trace_id)),
     );
 
-    // Add the `other_attributes` to the log record json
-    add_other_attributes_if_not_empty(&mut log_record_json, &other_attributes);
-
     log_record_json
 }
 
@@ -117,18 +121,13 @@ pub fn flatten_log_record(log_record: &LogRecord) -> Map<String, Value> {
 fn flatten_scope_log(scope_log: &ScopeLogs) -> Vec<Map<String, Value>> {
     let mut vec_scope_log_json = Vec::new();
     let mut scope_log_json = Map::new();
-    let mut other_attributes = Map::new();
     if let Some(scope) = &scope_log.scope {
         scope_log_json.insert("scope_name".to_string(), Value::String(scope.name.clone()));
         scope_log_json.insert(
             "scope_version".to_string(),
             Value::String(scope.version.clone()),
         );
-        insert_attributes(
-            &mut scope_log_json,
-            &scope.attributes,
-            &mut other_attributes,
-        );
+        insert_attributes(&mut scope_log_json, &scope.attributes);
         scope_log_json.insert(
             "scope_dropped_attributes_count".to_string(),
             Value::Number(scope.dropped_attributes_count.into()),
@@ -146,26 +145,19 @@ fn flatten_scope_log(scope_log: &ScopeLogs) -> Vec<Map<String, Value>> {
         vec_scope_log_json.push(combined_json);
     }
 
-    // Add the `other_attributes` to the scope log json
-    merge_attributes_in_json(other_attributes, &mut vec_scope_log_json);
-
     vec_scope_log_json
 }
 
 /// this function performs the custom flattening of the otel logs
 /// and returns a `Vec` of `Value::Object` of the flattened json
-pub fn flatten_otel_logs(message: &LogsData) -> Vec<Value> {
+pub fn flatten_otel_logs(message: &LogsData) -> Result<Vec<Value>, OtelError> {
     let mut vec_otel_json = Vec::new();
+    let known_fields: HashSet<&str> = OTEL_LOG_KNOWN_FIELD_LIST.iter().cloned().collect();
 
     for record in &message.resource_logs {
         let mut resource_log_json = Map::new();
-        let mut other_attributes = Map::new();
         if let Some(resource) = &record.resource {
-            insert_attributes(
-                &mut resource_log_json,
-                &resource.attributes,
-                &mut other_attributes,
-            );
+            insert_attributes(&mut resource_log_json, &resource.attributes);
             resource_log_json.insert(
                 "resource_dropped_attributes_count".to_string(),
                 Value::Number(resource.dropped_attributes_count.into()),
@@ -176,6 +168,7 @@ pub fn flatten_otel_logs(message: &LogsData) -> Vec<Value> {
         for scope_log in &record.scope_logs {
             vec_resource_logs_json.extend(flatten_scope_log(scope_log));
         }
+
         resource_log_json.insert(
             "schema_url".to_string(),
             Value::String(record.schema_url.clone()),
@@ -183,12 +176,27 @@ pub fn flatten_otel_logs(message: &LogsData) -> Vec<Value> {
 
         for resource_logs_json in &mut vec_resource_logs_json {
             resource_logs_json.extend(resource_log_json.clone());
+
+            let attribute_count = resource_logs_json
+                .keys()
+                .filter(|key| !known_fields.contains(key.as_str()))
+                .count();
+            // Check if the number of attributes exceeds the allowed limit
+            if attribute_count > PARSEABLE.options.otel_attributes_allowed_limit {
+                tracing::error!(
+                    "OTEL logs ingestion failed because the number of attributes ({}) exceeded the threshold of {}",
+                    attribute_count,
+                    PARSEABLE.options.otel_attributes_allowed_limit
+                );
+                return Err(OtelError::AttributeCountExceeded(
+                    attribute_count,
+                    PARSEABLE.options.otel_attributes_allowed_limit,
+                ));
+            }
+
+            vec_otel_json.push(Value::Object(resource_logs_json.clone()));
         }
-
-        // Add the `other_attributes` to the resource log json
-        merge_attributes_in_json(other_attributes, &mut vec_resource_logs_json);
-
-        vec_otel_json.extend(vec_resource_logs_json);
     }
-    vec_otel_json.into_iter().map(Value::Object).collect()
+
+    Ok(vec_otel_json)
 }

--- a/src/otel/logs.rs
+++ b/src/otel/logs.rs
@@ -37,7 +37,7 @@ pub const OTEL_LOG_KNOWN_FIELD_LIST: [&str; 16] = [
     "scope_log_schema_url",
     "scope_dropped_attributes_count",
     "resource_dropped_attributes_count",
-    "resource_schema_url",
+    "schema_url",
     "time_unix_nano",
     "observed_time_unix_nano",
     "severity_number",
@@ -178,8 +178,8 @@ pub fn flatten_otel_logs(message: &LogsData) -> Result<Vec<Value>, OtelError> {
             resource_logs_json.extend(resource_log_json.clone());
 
             let attribute_count = resource_logs_json
-                .keys()
-                .filter(|key| !known_fields.contains(key.as_str()))
+                .iter()
+                .filter(|(key, _)| !known_fields.contains(key.as_str()))
                 .count();
             // Check if the number of attributes exceeds the allowed limit
             if attribute_count > PARSEABLE.options.otel_attributes_allowed_limit {

--- a/src/otel/metrics.rs
+++ b/src/otel/metrics.rs
@@ -32,7 +32,7 @@ use super::otel_utils::{
     convert_epoch_nano_to_timestamp, insert_attributes, insert_number_if_some,
 };
 
-pub const OTEL_METRICS_KNOWN_FIELD_LIST: [&str; 35] = [
+pub const OTEL_METRICS_KNOWN_FIELD_LIST: [&str; 34] = [
     "metric_name",
     "metric_description",
     "metric_unit",
@@ -63,11 +63,10 @@ pub const OTEL_METRICS_KNOWN_FIELD_LIST: [&str; 35] = [
     "metric_type",
     "scope_name",
     "scope_version",
-    "scope_metrics_schema_url",
+    "scope_schema_url",
     "scope_dropped_attributes_count",
     "resource_dropped_attributes_count",
     "resource_schema_url",
-    "resource_metrics_schema_url",
 ];
 
 /// otel metrics event has json array for exemplar
@@ -544,7 +543,7 @@ pub fn flatten_otel_metrics(message: MetricsData) -> Result<Vec<Value>, OtelErro
             }
 
             scope_metrics_json.insert(
-                "scope_metrics_schema_url".to_string(),
+                "scope_schema_url".to_string(),
                 Value::String(scope_metric.schema_url.clone()),
             );
 
@@ -556,7 +555,7 @@ pub fn flatten_otel_metrics(message: MetricsData) -> Result<Vec<Value>, OtelErro
         }
 
         resource_metrics_json.insert(
-            "resource_metrics_schema_url".to_string(),
+            "resource_schema_url".to_string(),
             Value::String(record.schema_url.clone()),
         );
 
@@ -566,8 +565,8 @@ pub fn flatten_otel_metrics(message: MetricsData) -> Result<Vec<Value>, OtelErro
             }
 
             let attribute_count = resource_metric_json
-                .keys()
-                .filter(|key| !known_fields.contains(key.as_str()))
+                .iter()
+                .filter(|(key, _)| !known_fields.contains(key.as_str()))
                 .count();
 
             // Check if the number of attributes exceeds the allowed limit

--- a/src/otel/otel_utils.rs
+++ b/src/otel/otel_utils.rs
@@ -20,7 +20,6 @@ use chrono::DateTime;
 use opentelemetry_proto::tonic::common::v1::{
     any_value::Value as OtelValue, AnyValue, ArrayValue, KeyValue, KeyValueList,
 };
-use serde::Serialize;
 use serde_json::{Map, Value};
 
 // Value can be one of types - String, Bool, Int, Double, ArrayValue, AnyValue, KeyValueList, Byte
@@ -193,10 +192,4 @@ pub fn insert_attributes(map: &mut Map<String, Value>, attributes: &[KeyValue]) 
 pub fn convert_epoch_nano_to_timestamp(epoch_ns: i64) -> String {
     let dt = DateTime::from_timestamp_nanos(epoch_ns).naive_utc();
     dt.format("%Y-%m-%dT%H:%M:%S%.6fZ").to_string()
-}
-
-#[derive(Debug, thiserror::Error, Serialize)]
-pub enum OtelError {
-    #[error("Ingestion failed because the attributes count {0} exceeded the threshold of {1}")]
-    AttributeCountExceeded(usize, usize),
 }

--- a/src/otel/otel_utils.rs
+++ b/src/otel/otel_utils.rs
@@ -20,6 +20,7 @@ use chrono::DateTime;
 use opentelemetry_proto::tonic::common::v1::{
     any_value::Value as OtelValue, AnyValue, ArrayValue, KeyValue, KeyValueList,
 };
+use serde::Serialize;
 use serde_json::{Map, Value};
 
 // Value can be one of types - String, Bool, Int, Double, ArrayValue, AnyValue, KeyValueList, Byte
@@ -149,7 +150,7 @@ pub fn value_to_string(value: serde_json::Value) -> String {
     }
 }
 
-pub fn flatten_attributes(attributes: &Vec<KeyValue>) -> Map<String, Value> {
+pub fn flatten_attributes(attributes: &[KeyValue]) -> Map<String, Value> {
     let mut attributes_json: Map<String, Value> = Map::new();
     for attribute in attributes {
         let key = &attribute.key;
@@ -182,7 +183,7 @@ pub fn insert_bool_if_some(map: &mut Map<String, Value>, key: &str, option: &Opt
     }
 }
 
-pub fn insert_attributes(map: &mut Map<String, Value>, attributes: &Vec<KeyValue>) {
+pub fn insert_attributes(map: &mut Map<String, Value>, attributes: &[KeyValue]) {
     let attributes_json = flatten_attributes(attributes);
     for (key, value) in attributes_json {
         map.insert(key, value);
@@ -194,7 +195,7 @@ pub fn convert_epoch_nano_to_timestamp(epoch_ns: i64) -> String {
     dt.format("%Y-%m-%dT%H:%M:%S%.6fZ").to_string()
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, Serialize)]
 pub enum OtelError {
     #[error("Ingestion failed because the attributes count {0} exceeded the threshold of {1}")]
     AttributeCountExceeded(usize, usize),

--- a/src/otel/traces.rs
+++ b/src/otel/traces.rs
@@ -32,7 +32,7 @@ use crate::parseable::PARSEABLE;
 use super::otel_utils::convert_epoch_nano_to_timestamp;
 use super::otel_utils::insert_attributes;
 
-pub const OTEL_TRACES_KNOWN_FIELD_LIST: [&str; 31] = [
+pub const OTEL_TRACES_KNOWN_FIELD_LIST: [&str; 30] = [
     "scope_name",
     "scope_version",
     "scope_schema_url",
@@ -43,7 +43,6 @@ pub const OTEL_TRACES_KNOWN_FIELD_LIST: [&str; 31] = [
     "span_span_id",
     "span_name",
     "span_parent_span_id",
-    "flags",
     "name",
     "span_kind",
     "span_kind_description",
@@ -96,7 +95,7 @@ fn flatten_scope_span(scope_span: &ScopeSpans) -> Vec<Map<String, Value>> {
 
     for span_json in &mut vec_scope_span_json {
         span_json.insert(
-            "schema_url".to_string(),
+            "scope_schema_url".to_string(),
             Value::String(scope_span.schema_url.clone()),
         );
     }
@@ -127,7 +126,7 @@ pub fn flatten_otel_traces(message: &TracesData) -> Result<Vec<Value>, OtelError
         }
 
         resource_span_json.insert(
-            "schema_url".to_string(),
+            "resource_schema_url".to_string(),
             Value::String(record.schema_url.clone()),
         );
 
@@ -137,8 +136,8 @@ pub fn flatten_otel_traces(message: &TracesData) -> Result<Vec<Value>, OtelError
             }
 
             let attribute_count = resource_spans_json
-                .keys()
-                .filter(|key| !known_fields.contains(key.as_str()))
+                .iter()
+                .filter(|(key, _)| !known_fields.contains(key.as_str()))
                 .count();
 
             // Check if the number of attributes exceeds the allowed limit

--- a/src/otel/traces.rs
+++ b/src/otel/traces.rs
@@ -15,9 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-
-use std::collections::HashSet;
-
 use opentelemetry_proto::tonic::trace::v1::span::Event;
 use opentelemetry_proto::tonic::trace::v1::span::Link;
 use opentelemetry_proto::tonic::trace::v1::ScopeSpans;
@@ -25,9 +22,6 @@ use opentelemetry_proto::tonic::trace::v1::Span;
 use opentelemetry_proto::tonic::trace::v1::Status;
 use opentelemetry_proto::tonic::trace::v1::TracesData;
 use serde_json::{Map, Value};
-
-use crate::otel::otel_utils::OtelError;
-use crate::parseable::PARSEABLE;
 
 use super::otel_utils::convert_epoch_nano_to_timestamp;
 use super::otel_utils::insert_attributes;
@@ -105,9 +99,8 @@ fn flatten_scope_span(scope_span: &ScopeSpans) -> Vec<Map<String, Value>> {
 
 /// this function performs the custom flattening of the otel traces event
 /// and returns a `Vec` of `Value::Object` of the flattened json
-pub fn flatten_otel_traces(message: &TracesData) -> Result<Vec<Value>, OtelError> {
+pub fn flatten_otel_traces(message: &TracesData) -> Vec<Value> {
     let mut vec_otel_json = Vec::new();
-    let known_fields: HashSet<&str> = OTEL_TRACES_KNOWN_FIELD_LIST.iter().cloned().collect();
 
     for record in &message.resource_spans {
         let mut resource_span_json = Map::new();
@@ -135,29 +128,11 @@ pub fn flatten_otel_traces(message: &TracesData) -> Result<Vec<Value>, OtelError
                 resource_spans_json.insert(key.clone(), value.clone());
             }
 
-            let attribute_count = resource_spans_json
-                .iter()
-                .filter(|(key, _)| !known_fields.contains(key.as_str()))
-                .count();
-
-            // Check if the number of attributes exceeds the allowed limit
-            if attribute_count > PARSEABLE.options.otel_attributes_allowed_limit {
-                tracing::error!(
-                    "OTEL traces ingestion failed because the number of attributes ({}) exceeded the threshold of {}",
-                    attribute_count,
-                    PARSEABLE.options.otel_attributes_allowed_limit
-                );
-                return Err(OtelError::AttributeCountExceeded(
-                    attribute_count,
-                    PARSEABLE.options.otel_attributes_allowed_limit,
-                ));
-            }
-
             vec_otel_json.push(Value::Object(resource_spans_json.clone()));
         }
     }
 
-    Ok(vec_otel_json)
+    vec_otel_json
 }
 
 /// otel traces has json array of events


### PR DESCRIPTION
keep all attributes as individual columns in the ingested event 
add check for fields count in any dataset
reject event if fields count exceeds `P_DATASET_FIELDS_ALLOWED_LIMIT`
default value is set to 250
Fixes: #1310



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a configurable limit for allowed dataset fields via command-line flag and environment variable.
  - Introduced error handling for datasets exceeding the allowed field count, returning clear error responses.
  - Added warnings when dataset field count approaches the configured limit to encourage dataset creation.

- **Refactor**
  - Simplified OpenTelemetry (OTel) log, trace, and metric attribute handling by removing intermediate attribute maps and merging steps.
  - Expanded lists of known OTel fields for logs, metrics, and traces, improving attribute classification.
  - Streamlined attribute insertion by consolidating attribute maps into a single flat structure.

- **Bug Fixes**
  - Improved error propagation and HTTP response codes for ingestion errors related to field limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->