### PR TITLE
fix: date level stats

### DIFF
--- a/src/handlers/http/cluster/mod.rs
+++ b/src/handlers/http/cluster/mod.rs
@@ -393,7 +393,7 @@ pub async fn sync_role_update_with_ingestors(
     .await
 }
 
-pub fn fetch_daily_stats_from_ingestors(
+pub fn fetch_daily_stats(
     date: &str,
     stream_meta_list: &[ObjectStoreFormat],
 ) -> Result<Stats, StreamError> {

--- a/src/handlers/http/logstream.rs
+++ b/src/handlers/http/logstream.rs
@@ -524,6 +524,8 @@ pub mod error {
         HotTierValidation(#[from] HotTierValidationError),
         #[error("{0}")]
         HotTierError(#[from] HotTierError),
+        #[error("Invalid query parameter: {0}")]
+        InvalidQueryParameter(String),
     }
 
     impl actix_web::ResponseError for StreamError {
@@ -559,6 +561,7 @@ pub mod error {
                 StreamError::HotTierNotEnabled(_) => StatusCode::FORBIDDEN,
                 StreamError::HotTierValidation(_) => StatusCode::BAD_REQUEST,
                 StreamError::HotTierError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+                StreamError::InvalidQueryParameter(_) => StatusCode::BAD_REQUEST,
             }
         }
 

--- a/src/handlers/http/modal/query/querier_logstream.rs
+++ b/src/handlers/http/modal/query/querier_logstream.rs
@@ -44,7 +44,7 @@ use crate::{
     },
     hottier::HotTierManager,
     parseable::{StreamNotFound, PARSEABLE},
-    stats::{self, Stats},
+    stats,
     storage::{ObjectStoreFormat, StreamType, STREAM_ROOT_DIRECTORY},
 };
 
@@ -178,12 +178,7 @@ pub async fn get_stats(
 
             let stats = fetch_daily_stats(date_value, &stream_jsons)?;
 
-            let total_stats = Stats {
-                events: stats.events,
-                ingestion: stats.ingestion,
-                storage: stats.storage,
-            };
-            let stats = serde_json::to_value(total_stats)?;
+            let stats = serde_json::to_value(stats)?;
 
             return Ok((web::Json(stats), StatusCode::OK));
         }

--- a/src/prism/home/mod.rs
+++ b/src/prism/home/mod.rs
@@ -30,10 +30,7 @@ use crate::{
     alerts::{get_alerts_info, AlertError, AlertsInfo, ALERTS},
     correlation::{CorrelationError, CORRELATIONS},
     event::format::LogSource,
-    handlers::http::{
-        cluster::fetch_daily_stats_from_ingestors,
-        logstream::{error::StreamError, get_stats_date},
-    },
+    handlers::http::{cluster::fetch_daily_stats, logstream::error::StreamError},
     parseable::PARSEABLE,
     rbac::{map::SessionKey, role::Action, Users},
     storage::{ObjectStorageError, ObjectStoreFormat, STREAM_ROOT_DIRECTORY},
@@ -221,9 +218,9 @@ async fn stats_for_date(
     };
 
     // Process each stream concurrently
-    let stream_stats_futures = stream_wise_meta.iter().map(|(stream, meta)| {
-        get_stream_stats_for_date(stream.clone(), date.clone(), meta.clone())
-    });
+    let stream_stats_futures = stream_wise_meta
+        .values()
+        .map(|meta| get_stream_stats_for_date(date.clone(), meta.clone()));
 
     let stream_stats_results = futures::future::join_all(stream_stats_futures).await;
 
@@ -246,18 +243,12 @@ async fn stats_for_date(
 }
 
 async fn get_stream_stats_for_date(
-    stream: String,
     date: String,
     meta: Vec<ObjectStoreFormat>,
 ) -> Result<(u64, u64, u64), PrismHomeError> {
-    let querier_stats = get_stats_date(&stream, &date).await?;
-    let ingestor_stats = fetch_daily_stats_from_ingestors(&date, &meta)?;
+    let stats = fetch_daily_stats(&date, &meta)?;
 
-    Ok((
-        querier_stats.events + ingestor_stats.events,
-        querier_stats.ingestion + ingestor_stats.ingestion,
-        querier_stats.storage + ingestor_stats.storage,
-    ))
+    Ok((stats.events, stats.ingestion, stats.storage))
 }
 
 pub async fn generate_home_search_response(

--- a/src/prism/home/mod.rs
+++ b/src/prism/home/mod.rs
@@ -220,7 +220,7 @@ async fn stats_for_date(
     // Process each stream concurrently
     let stream_stats_futures = stream_wise_meta
         .values()
-        .map(|meta| get_stream_stats_for_date(date.clone(), meta.clone()));
+        .map(|meta| get_stream_stats_for_date(date.clone(), meta));
 
     let stream_stats_results = futures::future::join_all(stream_stats_futures).await;
 
@@ -244,9 +244,9 @@ async fn stats_for_date(
 
 async fn get_stream_stats_for_date(
     date: String,
-    meta: Vec<ObjectStoreFormat>,
+    meta: &[ObjectStoreFormat],
 ) -> Result<(u64, u64, u64), PrismHomeError> {
-    let stats = fetch_daily_stats(&date, &meta)?;
+    let stats = fetch_daily_stats(&date, meta)?;
 
     Ok((stats.events, stats.ingestion, stats.storage))
 }


### PR DESCRIPTION
read all stream.json files for a dataset
get sum of stats for a given date from the manifest list in snapshot

no need to calculate querier / ingestor stats separately

fix applicable for - 
/api/v1/logstream/<name>/stats?date=yyyy-mm-dd
and
/api/prism/v1/home

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Simplified and unified the process for fetching daily stats by renaming and consolidating functions.
	- Streamlined logic for obtaining stats, removing redundant steps and unnecessary data aggregation.
	- Updated function signatures and imports to reflect these changes, resulting in a cleaner and more maintainable codebase.
- **Bug Fixes**
	- Improved accuracy of daily stats by eliminating duplicate aggregation and focusing on a single source of data.
	- Enhanced query parameter validation with clearer error handling for invalid or missing parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->