### PR TITLE
Add `count distinct` aggregate function

### DIFF
--- a/src/alerts/alerts_utils.rs
+++ b/src/alerts/alerts_utils.rs
@@ -19,7 +19,7 @@
 use arrow_array::{Float64Array, Int64Array, RecordBatch};
 use datafusion::{
     functions_aggregate::{
-        count::count,
+        count::{count, count_distinct},
         expr_fn::avg,
         min_max::{max, min},
         sum::sum,
@@ -387,6 +387,7 @@ fn match_aggregate_operation(agg: &AggregateConfig) -> Expr {
     let column = format!(r#""{}""#, agg.column);
     match agg.aggregate_function {
         AggregateFunction::Avg => avg(col(column)),
+        AggregateFunction::CountDistinct => count_distinct(col(column)),
         AggregateFunction::Count => count(col(column)),
         AggregateFunction::Min => min(col(column)),
         AggregateFunction::Max => max(col(column)),

--- a/src/alerts/mod.rs
+++ b/src/alerts/mod.rs
@@ -290,6 +290,7 @@ impl Display for WhereConfigOperator {
 pub enum AggregateFunction {
     Avg,
     Count,
+    CountDistinct,
     Min,
     Max,
     Sum,
@@ -300,6 +301,7 @@ impl Display for AggregateFunction {
         match self {
             AggregateFunction::Avg => write!(f, "Avg"),
             AggregateFunction::Count => write!(f, "Count"),
+            AggregateFunction::CountDistinct => write!(f, "CountDistinct"),
             AggregateFunction::Min => write!(f, "Min"),
             AggregateFunction::Max => write!(f, "Max"),
             AggregateFunction::Sum => write!(f, "Sum"),


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the CountDistinct aggregate function in alert evaluations. This allows users to create alerts based on the count of distinct values in a dataset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->