### PR TITLE
fix: memory release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2900,9 +2900,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libm"
@@ -3487,6 +3487,7 @@ dependencies = [
  "humantime",
  "humantime-serde",
  "itertools 0.14.0",
+ "libc",
  "num_cpus",
  "object_store",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ static-files = "0.2"
 thiserror = "2.0"
 ulid = { version = "1.0", features = ["serde"] }
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
+libc = "0.2.172"
 
 [build-dependencies]
 cargo_toml = "0.21"

--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -150,6 +150,10 @@ pub async fn query(req: HttpRequest, query_request: Query) -> Result<HttpRespons
         .with_label_values(&[&table_name])
         .observe(time);
 
+    #[cfg(target_os = "linux")]
+    unsafe {
+        libc::malloc_trim(0);
+    }
     Ok(response)
 }
 


### PR DESCRIPTION
issue: server does not release memory after query execution completes 
fix: malloc_trim function releases unused memory from the application back to the OS
works only on the linux operating system


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependencies to include a new library for improved memory management on Linux systems.

- **Bug Fixes**
  - Improved memory handling after processing HTTP queries on Linux, potentially reducing memory usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->