### PR TITLE
feat: streaming response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3478,6 +3478,7 @@ dependencies = [
  "derive_more 1.0.0",
  "fs_extra",
  "futures",
+ "futures-core",
  "futures-util",
  "hex",
  "hostname",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ static-files = "0.2"
 thiserror = "2.0"
 ulid = { version = "1.0", features = ["serde"] }
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
+futures-core = "0.3.31"
 
 [build-dependencies]
 cargo_toml = "0.21"

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -16,7 +16,7 @@
  *
  */
 
-use std::{io::ErrorKind, sync::Arc};
+use std::sync::Arc;
 
 use chrono::{DateTime, Local, NaiveTime, Utc};
 use column::Column;
@@ -259,10 +259,7 @@ async fn create_manifest(
         .date_naive()
         .and_time(
             NaiveTime::from_num_seconds_from_midnight_opt(23 * 3600 + 59 * 60 + 59, 999_999_999)
-                .ok_or(IOError::new(
-                    ErrorKind::Other,
-                    "Failed to create upper bound for manifest",
-                ))?,
+                .ok_or(IOError::other("Failed to create upper bound for manifest"))?,
         )
         .and_utc();
 

--- a/src/handlers/airplane.rs
+++ b/src/handlers/airplane.rs
@@ -126,9 +126,11 @@ impl FlightService for AirServiceImpl {
     }
 
     async fn do_get(&self, req: Request<Ticket>) -> Result<Response<Self::DoGetStream>, Status> {
-        let key = extract_session_key(req.metadata())?;
+        let key = extract_session_key(req.metadata())
+            .map_err(|e| Status::unauthenticated(e.to_string()))?;
 
-        let ticket = get_query_from_ticket(&req)?;
+        let ticket =
+            get_query_from_ticket(&req).map_err(|e| Status::invalid_argument(e.to_string()))?;
 
         info!("query requested to airplane: {:?}", ticket);
 
@@ -246,7 +248,7 @@ impl FlightService for AirServiceImpl {
             .observe(time);
 
         // Airplane takes off 🛫
-        out
+        out.map_err(|e| *e)
     }
 
     async fn do_put(

--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -151,7 +151,7 @@ pub async fn query(req: HttpRequest, query_request: Query) -> Result<HttpRespons
                     error!("Failed to parse record batch into JSON: {}", e);
                     json!({})
                 });
-                Ok(Bytes::from(response.to_string()))
+                Ok(Bytes::from(format!("{}\n", response.to_string())))
             }
             Err(e) => Err(actix_web::error::ErrorInternalServerError(e)),
         }

--- a/src/response.rs
+++ b/src/response.rs
@@ -17,7 +17,6 @@
  */
 
 use crate::{handlers::http::query::QueryError, utils::arrow::record_batches_to_json};
-use actix_web::HttpResponse;
 use datafusion::arrow::record_batch::RecordBatch;
 use itertools::Itertools;
 use serde_json::{json, Value};
@@ -30,11 +29,10 @@ pub struct QueryResponse {
     pub fields: Vec<String>,
     pub fill_null: bool,
     pub with_fields: bool,
-    pub total_time: String,
 }
 
 impl QueryResponse {
-    pub fn to_http(&self) -> Result<HttpResponse, QueryError> {
+    pub fn to_http(&self) -> Result<Value, QueryError> {
         info!("{}", "Returning query results");
         let mut json_records = record_batches_to_json(&self.records)?;
 
@@ -58,8 +56,6 @@ impl QueryResponse {
             Value::Array(values)
         };
 
-        Ok(HttpResponse::Ok()
-            .insert_header((TIME_ELAPSED_HEADER, self.total_time.as_str()))
-            .json(response))
+        Ok(response)
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -22,8 +22,6 @@ use itertools::Itertools;
 use serde_json::{json, Value};
 use tracing::info;
 
-pub const TIME_ELAPSED_HEADER: &str = "p-time-elapsed";
-
 pub struct QueryResponse {
     pub records: Vec<RecordBatch>,
     pub fields: Vec<String>,
@@ -32,7 +30,7 @@ pub struct QueryResponse {
 }
 
 impl QueryResponse {
-    pub fn to_http(&self) -> Result<Value, QueryError> {
+    pub fn to_json(&self) -> Result<Value, QueryError> {
         info!("{}", "Returning query results");
         let mut json_records = record_batches_to_json(&self.records)?;
 

--- a/src/utils/arrow/flight.rs
+++ b/src/utils/arrow/flight.rs
@@ -41,9 +41,9 @@ use tonic::transport::{Channel, Uri};
 
 pub type DoGetStream = stream::BoxStream<'static, Result<FlightData, Status>>;
 
-pub fn get_query_from_ticket(req: &Request<Ticket>) -> Result<QueryJson, Status> {
+pub fn get_query_from_ticket(req: &Request<Ticket>) -> Result<QueryJson, Box<Status>> {
     serde_json::from_slice::<QueryJson>(&req.get_ref().ticket)
-        .map_err(|err| Status::internal(err.to_string()))
+        .map_err(|err| Box::new(Status::internal(err.to_string())))
 }
 
 pub async fn run_do_get_rpc(
@@ -141,7 +141,7 @@ fn lit_timestamp_milli(time: i64) -> Expr {
     Expr::Literal(ScalarValue::TimestampMillisecond(Some(time), None))
 }
 
-pub fn into_flight_data(records: Vec<RecordBatch>) -> Result<Response<DoGetStream>, Status> {
+pub fn into_flight_data(records: Vec<RecordBatch>) -> Result<Response<DoGetStream>, Box<Status>> {
     let input_stream = futures::stream::iter(records.into_iter().map(Ok));
     let write_options = IpcWriteOptions::default()
         .try_with_compression(Some(arrow_ipc::CompressionType(1)))


### PR DESCRIPTION
use datafusion's execute_stream function that sends streaming response
use query param `streaming=true` to get the streaming response
defaulted to false, for prism or other clients to work as usual

query response (with streaming=true) sends multiple batches one after the other split by new line character


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced streaming query support, allowing clients to receive query results as a stream.
  - Added a new query parameter to enable streaming mode for queries.

- **Refactor**
  - Improved separation of query handling for count, streaming, and non-streaming queries.
  - Enhanced modularity by moving logic into specialized helper functions.
  - Updated query response handling to return JSON directly without HTTP-specific wrappers.

- **Bug Fixes**
  - Improved error handling for streaming queries, ensuring errors are logged and handled gracefully.
  - Standardized error handling in flight and livetail handlers for consistent error propagation.

- **Chores**
  - Updated dependencies to include the latest async-related crate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->