### PR TITLE
remove request timeout in INTRA_CLUSTER_CLIENT

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,6 @@ pub static HTTP_CLIENT: Lazy<Client> = Lazy::new(|| {
 pub static INTRA_CLUSTER_CLIENT: Lazy<Client> = Lazy::new(|| {
     ClientBuilder::new()
         .connect_timeout(Duration::from_secs(3)) // set a timeout of 3s for each connection setup
-        .timeout(Duration::from_secs(30)) // set a timeout of 30s for each request
         .pool_idle_timeout(Duration::from_secs(90)) // set a timeout of 90s for each idle connection
         .pool_max_idle_per_host(32) // max 32 idle connections per host
         .gzip(true) // gzip compress for all requests


### PR DESCRIPTION
current: timeout set to 30 secs
change: remove timeout

this is to ensure querier does not timeout while processing the request 
and prism does not throw exception to client when processing is still happening

we still need to handle the scenario when there is a timeout set in client while prism is still processing a request
