### PR TITLE
fix: update correct server mode in parseable.json

### DIFF
--- a/src/storage/store_metadata.rs
+++ b/src/storage/store_metadata.rs
@@ -117,9 +117,23 @@ pub async fn resolve_parseable_metadata(
     let mut overwrite_remote = false;
 
     let res = match check {
-        EnvChange::None(metadata) => {
+        EnvChange::None(mut metadata) => {
             // overwrite staging anyways so that it matches remote in case of any divergence
             overwrite_staging = true;
+            match PARSEABLE.options.mode {
+                Mode::All => {
+                    metadata.server_mode.standalone_after_distributed()?;
+                    overwrite_remote = true;
+                    metadata.server_mode = PARSEABLE.options.mode;
+                    metadata.staging = PARSEABLE.options.staging_dir().to_path_buf();
+                }
+                Mode::Query => {
+                    overwrite_remote = true;
+                    metadata.server_mode = PARSEABLE.options.mode;
+                    metadata.staging = PARSEABLE.options.staging_dir().to_path_buf();
+                }
+                _=> {}
+            }
             if PARSEABLE.options.mode ==  Mode::All {
                 metadata.server_mode.standalone_after_distributed()?;
             }


### PR DESCRIPTION
 Steps to reproduce issue -
    1. start prism and query node with enterprise build, stop both nodes
    2. start standalone/distributed-Query with same staging and s3 bucket -- No env change -- hence Deployment ID remains same, server_mode remains Prism

Fix: for mode `All` and `Query`
even for no env change,
update server_mode in parseable.json in storage


