### PR TITLE
Bring targets out of alerts

### DIFF
--- a/src/handlers/http/alerts.rs
+++ b/src/handlers/http/alerts.rs
@@ -48,7 +48,7 @@ pub async fn post(
     req: HttpRequest,
     Json(alert): Json<AlertRequest>,
 ) -> Result<impl Responder, AlertError> {
-    let alert: AlertConfig = alert.into();
+    let alert: AlertConfig = alert.into().await?;
     alert.validate().await?;
 
     // validate the incoming alert query

--- a/src/handlers/http/mod.rs
+++ b/src/handlers/http/mod.rs
@@ -47,6 +47,7 @@ pub mod prism_logstream;
 pub mod query;
 pub mod rbac;
 pub mod role;
+pub mod targets;
 pub mod users;
 pub const MAX_EVENT_PAYLOAD_SIZE: usize = 10485760;
 pub const API_BASE_PATH: &str = "api";

--- a/src/handlers/http/modal/server.rs
+++ b/src/handlers/http/modal/server.rs
@@ -26,6 +26,7 @@ use crate::handlers::http::base_path;
 use crate::handlers::http::health_check;
 use crate::handlers::http::prism_base_path;
 use crate::handlers::http::query;
+use crate::handlers::http::targets;
 use crate::handlers::http::users::dashboards;
 use crate::handlers::http::users::filters;
 use crate::hottier::HotTierManager;
@@ -87,6 +88,7 @@ impl ParseableServer for Server {
                     .service(Self::get_roles_webscope())
                     .service(Self::get_counts_webscope())
                     .service(Self::get_alerts_webscope())
+                    .service(Self::get_targets_webscope())
                     .service(Self::get_metrics_webscope()),
             )
             .service(
@@ -248,6 +250,25 @@ impl Server {
                     .route(
                         web::delete()
                             .to(alerts::delete)
+                            .authorize(Action::DeleteAlert),
+                    ),
+            )
+    }
+
+    pub fn get_targets_webscope() -> Scope {
+        web::scope("/targets")
+            .service(
+                web::resource("")
+                    .route(web::get().to(targets::list).authorize(Action::GetAlert))
+                    .route(web::post().to(targets::post).authorize(Action::PutAlert)),
+            )
+            .service(
+                web::resource("/{target_id}")
+                    .route(web::get().to(targets::get).authorize(Action::GetAlert))
+                    .route(web::put().to(targets::update).authorize(Action::PutAlert))
+                    .route(
+                        web::delete()
+                            .to(targets::delete)
                             .authorize(Action::DeleteAlert),
                     ),
             )

--- a/src/handlers/http/targets.rs
+++ b/src/handlers/http/targets.rs
@@ -1,0 +1,75 @@
+use actix_web::{
+    web::{self, Json, Path},
+    HttpRequest, Responder,
+};
+use ulid::Ulid;
+
+use crate::alerts::{
+    target::{Target, TARGETS},
+    AlertError,
+};
+
+// POST /targets
+pub async fn post(
+    _req: HttpRequest,
+    Json(target): Json<Target>,
+) -> Result<impl Responder, AlertError> {
+    // should check for duplicacy and liveness (??)
+    target.validate().await;
+
+    // add to the map
+    TARGETS.update(target.clone()).await?;
+
+    Ok(web::Json(target))
+}
+
+// GET /targets
+pub async fn list(_req: HttpRequest) -> Result<impl Responder, AlertError> {
+    // add to the map
+    let list = TARGETS.list().await?;
+
+    Ok(web::Json(list))
+}
+
+// GET /targets/{target_id}
+pub async fn get(_req: HttpRequest, target_id: Path<Ulid>) -> Result<impl Responder, AlertError> {
+    let target_id = target_id.into_inner();
+
+    let target = TARGETS.get_target_by_id(target_id).await?;
+
+    Ok(web::Json(target))
+}
+
+// POST /targets/{target_id}
+pub async fn update(
+    _req: HttpRequest,
+    target_id: Path<Ulid>,
+    Json(mut target): Json<Target>,
+) -> Result<impl Responder, AlertError> {
+    let target_id = target_id.into_inner();
+
+    // if target_id does not exist, error
+    TARGETS.get_target_by_id(target_id).await?;
+
+    // esnure that the supplied target id is assigned to the target config
+    target.id = target_id;
+    // should check for duplicacy and liveness (??)
+    target.validate().await;
+
+    // add to the map
+    TARGETS.update(target.clone()).await?;
+
+    Ok(web::Json(target))
+}
+
+// DELETE /targets/{target_id}
+pub async fn delete(
+    _req: HttpRequest,
+    target_id: Path<Ulid>,
+) -> Result<impl Responder, AlertError> {
+    let target_id = target_id.into_inner();
+
+    let target = TARGETS.delete(target_id).await?;
+
+    Ok(web::Json(target))
+}


### PR DESCRIPTION
Adds CRUD operations for targets

TODO-
- Storage of targets depending upon RBAC discussion
- Modify alerts to use targets using ID (AlertConfig update)

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
