### PR TITLE
null checks

### DIFF
--- a/src/alerts/mod.rs
+++ b/src/alerts/mod.rs
@@ -343,14 +343,24 @@ impl Conditions {
                 LogicalOperator::And | LogicalOperator::Or => {
                     let expr1 = &self.condition_config[0];
                     let expr2 = &self.condition_config[1];
-                    let expr1_msg = if let Some(val) = &expr1.value {
-                        format!("{} {} {}", expr1.column, expr1.operator, val)
+                    let expr1_msg = if expr1.value.as_ref().is_some_and(|v| !v.trim().is_empty()) {
+                        format!(
+                            "{} {} {}",
+                            expr1.column,
+                            expr1.operator,
+                            expr1.value.as_ref().unwrap()
+                        )
                     } else {
                         format!("{} {}", expr1.column, expr1.operator)
                     };
 
-                    let expr2_msg = if let Some(val) = &expr2.value {
-                        format!("{} {} {}", expr2.column, expr2.operator, val)
+                    let expr2_msg = if expr2.value.as_ref().is_some_and(|v| !v.trim().is_empty()) {
+                        format!(
+                            "{} {} {}",
+                            expr2.column,
+                            expr2.operator,
+                            expr2.value.as_ref().unwrap()
+                        )
                     } else {
                         format!("{} {}", expr2.column, expr2.operator)
                     };
@@ -661,7 +671,12 @@ impl AlertConfig {
                     WhereConfigOperator::IsNull | WhereConfigOperator::IsNotNull
                 );
 
-                if needs_no_value && condition.value.is_some() {
+                if needs_no_value
+                    && condition
+                        .value
+                        .as_ref()
+                        .is_some_and(|v| !v.trim().is_empty())
+                {
                     return Err(AlertError::CustomError(
                         "value must be null when operator is either `is null` or `is not null`"
                             .into(),


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->
A previous PR modified the conditions config to make the `value` field nullable. But the frontend is sometimes sending an empty string in case of `null`. This PR performs both the checks and rejects the request in case the operator is `is null` or `is not null` and the `value` is something other than `null` or an empty string.
<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation to ensure empty or whitespace-only strings are no longer treated as valid values in alert filters and configuration checks.
  - Enhanced filter message generation to exclude empty or whitespace-only strings, resulting in clearer and more accurate alert messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->