### PR TITLE
Allow OIDC scopes to be configured via P_OIDC_SCOPE environment variable

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -451,6 +451,16 @@ pub struct Options {
         help = "Object store sync threshold in seconds"
     )]
     pub object_store_sync_threshold: u64,
+    // the oidc scope 
+    #[arg(
+        long = "oidc-scope",
+        name = "oidc-scope",
+        env = "P_OIDC_SCOPE",
+        default_value = "openid profile email",
+        required = false,
+        help = "OIDC scope to request (default: openid profile email)"
+    )]
+    pub scope: String,
 }
 
 #[derive(Parser, Debug)]

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -30,7 +30,6 @@ const STATIC_SCHEMA_FLAG: &str = "x-p-static-schema-flag";
 const AUTHORIZATION_KEY: &str = "authorization";
 const UPDATE_STREAM_KEY: &str = "x-p-update-stream";
 pub const STREAM_TYPE_KEY: &str = "x-p-stream-type";
-const OIDC_SCOPE: &str = "openid profile email";
 const COOKIE_AGE_DAYS: usize = 7;
 const SESSION_COOKIE_NAME: &str = "session";
 const USER_COOKIE_NAME: &str = "username";


### PR DESCRIPTION
### Description

This PR adds support for customizing the OIDC scopes used during authentication by introducing a new environment variable:
```
P_OIDC_SCOPE
```
By default, the OIDC scope remains unchanged, as the current implementation: `openid profile email`
If P_OIDC_SCOPE is set, its value will be used instead during the OIDC authorization request.
This allows integrations (e.g., with Dex) to request additional claims like groups when needed for RBAC.
### Motivation
In some OIDC providers (e.g., Dex), claims such as groups are only included in tokens if explicitly requested via the scope parameter. Since Parseable currently hardcodes the OIDC scope, there is no way to request such claims without modifying the code.

This PR enables more flexible OIDC integrations and ensures that role-based access control can work correctly with group-based identity providers.
### Changes Introduced
- Adds P_OIDC_SCOPE as an optional environment variable
- Falls back to "openid profile email" if unset
- Uses the configured scope during the OIDC authorization URL construction
- Main change in handlers/http/oidc.rs in function redirect_to_oidc where the hardcoded scope string is replaced with variable


This PR has:
- [X] been tested to ensure log ingestion and log query works.
- [X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable OIDC scope option, allowing users to specify the scope via a command-line flag or environment variable.

* **Refactor**
  * Updated the application to use the user-defined OIDC scope at runtime instead of a fixed value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->