### PR TITLE
fix: docker image build for amd64 and arm64 separately

### DIFF
--- a/.github/workflows/build-push-edge-kafka.yaml
+++ b/.github/workflows/build-push-edge-kafka.yaml
@@ -43,7 +43,7 @@ jobs:
           context: .
           file: ./Dockerfile.kafka
           push: true
-          tags: parseable/parseable:edge-kafka
+          tags: parseable/parseable:edge-kafka-amd64
           platforms: linux/amd64
           build-args: |
             LIB_DIR=x86_64-linux-gnu
@@ -54,7 +54,7 @@ jobs:
           context: .
           file: ./Dockerfile.kafka
           push: true
-          tags: parseable/parseable:edge-kafka
+          tags: parseable/parseable:edge-kafka-arm64
           platforms: linux/arm64
           build-args: |
             LIB_DIR=aarch64-linux-gnu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,3 +229,25 @@ jobs:
           push: true
           tags: parseable/parseable:${{ github.ref_name }}
           platforms: linux/amd64,linux/arm64
+      
+      - name: Build and push kafka amd64
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.kafka
+          push: true
+          tags: parseable/parseable:${{ github.ref_name }}-kafka-amd64
+          platforms: linux/amd64
+          build-args: |
+            LIB_DIR=x86_64-linux-gnu
+
+      - name: Build and push kafka arm64
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.kafka
+          push: true
+          tags: parseable/parseable:${{ github.ref_name }}-kafka-arm64
+          platforms: linux/arm64
+          build-args: |
+            LIB_DIR=aarch64-linux-gnu


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image tags in build and release workflows to include architecture-specific suffixes for Kafka images.
  * Added steps in the release workflow to build and push Kafka Docker images separately for AMD64 and ARM64 platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->