### PR TITLE
bugfixes for target separation

### DIFF
--- a/src/alerts/target.rs
+++ b/src/alerts/target.rs
@@ -164,10 +164,16 @@ impl Target {
                 })
             }
             TargetType::Other(other_web_hook) => {
+                let endpoint = other_web_hook.endpoint.to_string();
+                let masked_endpoint = if endpoint.len() > 20 {
+                    format!("{}********", &endpoint[..20])
+                } else {
+                    "********".to_string()
+                };
                 json!({
                     "name":self.name,
                     "type":"webhook",
-                    "endpoint":other_web_hook.endpoint,
+                    "endpoint":masked_endpoint,
                     "headers":other_web_hook.headers,
                     "skipTlsCheck":other_web_hook.skip_tls_check,
                     "notificationConfig":self.notification_config,
@@ -175,12 +181,18 @@ impl Target {
                 })
             }
             TargetType::AlertManager(alert_manager) => {
+                let endpoint = alert_manager.endpoint.to_string();
+                let masked_endpoint = if endpoint.len() > 20 {
+                    format!("{}********", &endpoint[..20])
+                } else {
+                    "********".to_string()
+                };
                 if let Some(auth) = alert_manager.auth {
                     let password = "********";
                     json!({
                         "name":self.name,
                         "type":"webhook",
-                        "endpoint":alert_manager.endpoint,
+                        "endpoint":masked_endpoint,
                         "username":auth.username,
                         "password":password,
                         "skipTlsCheck":alert_manager.skip_tls_check,
@@ -191,7 +203,7 @@ impl Target {
                     json!({
                         "name":self.name,
                         "type":"webhook",
-                        "endpoint":alert_manager.endpoint,
+                        "endpoint":masked_endpoint,
                         "username":Value::Null,
                         "password":Value::Null,
                         "skipTlsCheck":alert_manager.skip_tls_check,

--- a/src/alerts/target.rs
+++ b/src/alerts/target.rs
@@ -27,10 +27,10 @@ use base64::Engine;
 use bytes::Bytes;
 use chrono::Utc;
 use http::{header::AUTHORIZATION, HeaderMap, HeaderValue};
-use humantime_serde::re::humantime;
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use reqwest::ClientBuilder;
+use serde_json::{json, Value};
 use tokio::sync::RwLock;
 use tracing::{error, trace, warn};
 use ulid::Ulid;
@@ -66,14 +66,6 @@ impl TargetConfigs {
 
     pub async fn update(&self, target: Target) -> Result<(), AlertError> {
         let mut map = self.target_configs.write().await;
-        if map.values().any(|t| {
-            t.target == target.target
-                && t.timeout.interval == target.timeout.interval
-                && t.timeout.times == target.timeout.times
-                && t.id != target.id
-        }) {
-            return Err(AlertError::DuplicateTargetConfig);
-        }
         map.insert(target.id, target.clone());
 
         let path = target_json_path(&target.id);
@@ -148,16 +140,72 @@ pub struct Target {
     pub name: String,
     #[serde(flatten)]
     pub target: TargetType,
-    #[serde(default, rename = "repeat")]
-    pub timeout: Timeout,
+    pub notification_config: Timeout,
     #[serde(default = "Ulid::new")]
     pub id: Ulid,
 }
 
 impl Target {
+    pub fn mask(self) -> Value {
+        match self.target {
+            TargetType::Slack(slack_web_hook) => {
+                let endpoint = slack_web_hook.endpoint.to_string();
+                let masked_endpoint = if endpoint.len() > 20 {
+                    format!("{}********", &endpoint[..20])
+                } else {
+                    "********".to_string()
+                };
+                json!({
+                   "name":self.name,
+                   "type":"slack",
+                   "endpoint":masked_endpoint,
+                   "notificationConfig":self.notification_config,
+                   "id":self.id
+                })
+            }
+            TargetType::Other(other_web_hook) => {
+                json!({
+                    "name":self.name,
+                    "type":"webhook",
+                    "endpoint":other_web_hook.endpoint,
+                    "headers":other_web_hook.headers,
+                    "skipTlsCheck":other_web_hook.skip_tls_check,
+                    "notificationConfig":self.notification_config,
+                    "id":self.id
+                })
+            }
+            TargetType::AlertManager(alert_manager) => {
+                if let Some(auth) = alert_manager.auth {
+                    let password = "********";
+                    json!({
+                        "name":self.name,
+                        "type":"webhook",
+                        "endpoint":alert_manager.endpoint,
+                        "username":auth.username,
+                        "password":password,
+                        "skipTlsCheck":alert_manager.skip_tls_check,
+                        "notificationConfig":self.notification_config,
+                        "id":self.id
+                    })
+                } else {
+                    json!({
+                        "name":self.name,
+                        "type":"webhook",
+                        "endpoint":alert_manager.endpoint,
+                        "username":Value::Null,
+                        "password":Value::Null,
+                        "skipTlsCheck":alert_manager.skip_tls_check,
+                        "notificationConfig":self.notification_config,
+                        "id":self.id
+                    })
+                }
+            }
+        }
+    }
+
     pub fn call(&self, context: Context) {
         trace!("target.call context- {context:?}");
-        let timeout = &self.timeout;
+        let timeout = &self.notification_config;
         let resolves = context.alert_info.alert_state;
         let mut state = timeout.state.lock().unwrap();
         trace!("target.call state- {state:?}");
@@ -205,7 +253,7 @@ impl Target {
         let sleep_and_check_if_call =
             move |timeout_state: Arc<Mutex<TimeoutState>>, current_state: AlertState| {
                 async move {
-                    tokio::time::sleep(timeout).await;
+                    tokio::time::sleep(Duration::from_secs(timeout * 60)).await;
 
                     let mut state = timeout_state.lock().unwrap();
 
@@ -276,8 +324,8 @@ fn call_target(target: TargetType, context: Context) {
 }
 
 #[derive(Debug, serde::Deserialize)]
-pub struct RepeatVerifier {
-    interval: Option<String>,
+pub struct NotificationConfigVerifier {
+    interval: Option<u64>,
     times: Option<usize>,
 }
 
@@ -288,7 +336,7 @@ pub struct TargetVerifier {
     #[serde(flatten)]
     pub target: TargetType,
     #[serde(default)]
-    pub repeat: Option<RepeatVerifier>,
+    pub notification_config: Option<NotificationConfigVerifier>,
     #[serde(default = "Ulid::new")]
     pub id: Ulid,
 }
@@ -304,18 +352,14 @@ impl TryFrom<TargetVerifier> for Target {
             timeout.times = Retry::Infinite
         }
 
-        if let Some(repeat_config) = value.repeat {
-            let interval = repeat_config
-                .interval
-                .map(|ref interval| humantime::parse_duration(interval))
-                .transpose()
-                .map_err(|err| err.to_string())?;
+        if let Some(notification_config) = value.notification_config {
+            let interval = notification_config.interval.map(|ref interval| *interval);
 
             if let Some(interval) = interval {
                 timeout.interval = interval
             }
 
-            if let Some(times) = repeat_config.times {
+            if let Some(times) = notification_config.times {
                 timeout.times = Retry::Finite(times)
             }
         }
@@ -323,7 +367,7 @@ impl TryFrom<TargetVerifier> for Target {
         Ok(Target {
             name: value.name,
             target: value.target,
-            timeout,
+            notification_config: timeout,
             id: value.id,
         })
     }
@@ -518,8 +562,7 @@ impl CallableTarget for AlertManager {
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
 pub struct Timeout {
-    #[serde(with = "humantime_serde")]
-    pub interval: Duration,
+    pub interval: u64,
     #[serde(default = "Retry::default")]
     pub times: Retry,
     #[serde(skip)]
@@ -529,7 +572,7 @@ pub struct Timeout {
 impl Default for Timeout {
     fn default() -> Self {
         Self {
-            interval: Duration::from_secs(60),
+            interval: 1,
             times: Retry::default(),
             state: Arc::<Mutex<TimeoutState>>::default(),
         }

--- a/src/handlers/http/targets.rs
+++ b/src/handlers/http/targets.rs
@@ -2,6 +2,7 @@ use actix_web::{
     web::{self, Json, Path},
     HttpRequest, Responder,
 };
+use itertools::Itertools;
 use ulid::Ulid;
 
 use crate::alerts::{
@@ -18,13 +19,18 @@ pub async fn post(
     // add to the map
     TARGETS.update(target.clone()).await?;
 
-    Ok(web::Json(target))
+    Ok(web::Json(target.mask()))
 }
 
 // GET /targets
 pub async fn list(_req: HttpRequest) -> Result<impl Responder, AlertError> {
     // add to the map
-    let list = TARGETS.list().await?;
+    let list = TARGETS
+        .list()
+        .await?
+        .into_iter()
+        .map(|t| t.mask())
+        .collect_vec();
 
     Ok(web::Json(list))
 }
@@ -35,7 +41,7 @@ pub async fn get(_req: HttpRequest, target_id: Path<Ulid>) -> Result<impl Respon
 
     let target = TARGETS.get_target_by_id(&target_id).await?;
 
-    Ok(web::Json(target))
+    Ok(web::Json(target.mask()))
 }
 
 // PUT /targets/{target_id}
@@ -47,7 +53,14 @@ pub async fn update(
     let target_id = target_id.into_inner();
 
     // if target_id does not exist, error
-    TARGETS.get_target_by_id(&target_id).await?;
+    let old_target = TARGETS.get_target_by_id(&target_id).await?;
+
+    // do not allow modifying name
+    if old_target.name != target.name {
+        return Err(AlertError::InvalidTargetModification(
+            "Can't modify target name".to_string(),
+        ));
+    }
 
     // esnure that the supplied target id is assigned to the target config
     target.id = target_id;
@@ -56,7 +69,7 @@ pub async fn update(
     // add to the map
     TARGETS.update(target.clone()).await?;
 
-    Ok(web::Json(target))
+    Ok(web::Json(target.mask()))
 }
 
 // DELETE /targets/{target_id}
@@ -68,5 +81,5 @@ pub async fn delete(
 
     let target = TARGETS.delete(&target_id).await?;
 
-    Ok(web::Json(target))
+    Ok(web::Json(target.mask()))
 }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes include-
- Removal of duplication check
- Proper loading of targets on server init
- Masking of sensitive information (slack URL, alert manager auth credentials)
- Error on modifying name
- Renaming `repeat` to `notificationConfig` and setting least count of interval to 1 minute

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sensitive information in target data is now masked in all relevant API responses.
  * Added a new resource that is loaded during application initialization.

* **Bug Fixes**
  * Improved error handling for invalid modifications to target configurations, including clearer error messages when attempting to change a target's name.

* **Refactor**
  * Unified and simplified notification configuration fields and interval handling for targets.
  * Updated naming conventions for notification settings to improve clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->