### PR TITLE
fix: allow multiple tags in dashboards list_by_tag API

### DIFF
--- a/src/handlers/http/modal/server.rs
+++ b/src/handlers/http/modal/server.rs
@@ -308,13 +308,6 @@ impl Server {
                 ),
             )
             .service(
-                web::resource("/list_by_tag/{tags}").route(
-                    web::get()
-                        .to(dashboards::list_dashboards_by_tags)
-                        .authorize(Action::ListDashboard),
-                ),
-            )
-            .service(
                 web::scope("/{dashboard_id}")
                     .service(
                         web::resource("")

--- a/src/handlers/http/modal/server.rs
+++ b/src/handlers/http/modal/server.rs
@@ -308,9 +308,9 @@ impl Server {
                 ),
             )
             .service(
-                web::resource("/list_by_tag/{tag}").route(
+                web::resource("/list_by_tag/{tags}").route(
                     web::get()
-                        .to(dashboards::list_dashboards_by_tag)
+                        .to(dashboards::list_dashboards_by_tags)
                         .authorize(Action::ListDashboard),
                 ),
             )

--- a/src/handlers/http/users/dashboards.rs
+++ b/src/handlers/http/users/dashboards.rs
@@ -215,13 +215,21 @@ pub async fn list_tags() -> Result<impl Responder, DashboardError> {
     Ok((web::Json(tags), StatusCode::OK))
 }
 
-pub async fn list_dashboards_by_tag(tag: Path<String>) -> Result<impl Responder, DashboardError> {
-    let tag = tag.into_inner();
-    if tag.is_empty() {
-        return Err(DashboardError::Metadata("Tag cannot be empty"));
+pub async fn list_dashboards_by_tags(tags: Path<String>) -> Result<impl Responder, DashboardError> {
+    let tags = tags.into_inner();
+    if tags.is_empty() {
+        return Err(DashboardError::Metadata("Tags cannot be empty"));
     }
-
-    let dashboards = DASHBOARDS.list_dashboards_by_tag(&tag).await;
+    // tags can be comma separated list of tags
+    let tags = tags
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>();
+    if tags.is_empty() {
+        return Err(DashboardError::Metadata("Tags cannot be empty"));
+    }
+    let dashboards = DASHBOARDS.list_dashboards_by_tags(tags).await;
     let dashboard_summaries = dashboards
         .iter()
         .map(|dashboard| dashboard.to_summary())

--- a/src/users/dashboards.rs
+++ b/src/users/dashboards.rs
@@ -375,14 +375,17 @@ impl Dashboards {
     }
 
     /// List dashboards by tag
-    /// This function returns a list of dashboards that have the specified tag
+    /// This function returns a list of dashboards that match any of the provided tags
+    /// If no tags are provided, it returns an empty list
     pub async fn list_dashboards_by_tags(&self, tags: Vec<String>) -> Vec<Dashboard> {
         let dashboards = self.0.read().await;
         dashboards
             .iter()
             .filter(|d| {
                 if let Some(dashboard_tags) = &d.tags {
-                    !tags.is_empty() && dashboard_tags.iter().any(|tag| tags.contains(tag))
+                    dashboard_tags
+                        .iter()
+                        .any(|dashboard_tag| tags.contains(dashboard_tag))
                 } else {
                     false
                 }

--- a/src/users/dashboards.rs
+++ b/src/users/dashboards.rs
@@ -376,14 +376,16 @@ impl Dashboards {
 
     /// List dashboards by tag
     /// This function returns a list of dashboards that have the specified tag
-    pub async fn list_dashboards_by_tag(&self, tag: &str) -> Vec<Dashboard> {
+    pub async fn list_dashboards_by_tags(&self, tags: Vec<String>) -> Vec<Dashboard> {
         let dashboards = self.0.read().await;
         dashboards
             .iter()
             .filter(|d| {
-                d.tags
-                    .as_ref()
-                    .is_some_and(|tags| tags.contains(&tag.to_string()))
+                if let Some(dashboard_tags) = &d.tags {
+                    !tags.is_empty() && dashboard_tags.iter().any(|tag| tags.contains(tag))
+                } else {
+                    false
+                }
             })
             .cloned()
             .collect()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the dashboards listing endpoint to support filtering by multiple tags instead of just one. Users can now provide a comma-separated list of tags to retrieve dashboards matching any of the specified tags.

* **Bug Fixes**
  * Improved input validation to handle empty or invalid tag lists when filtering dashboards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->