### PR TITLE
Bugfixes

### DIFF
--- a/src/rbac/map.rs
+++ b/src/rbac/map.rs
@@ -239,7 +239,16 @@ impl Sessions {
                             | ParseableResourceType::Llm(resource_id) => {
                                 let ok_resource =
                                     if let Some(context_resource_id) = context_resource {
-                                        resource_id == context_resource_id || resource_id == "*"
+                                        let is_internal = PARSEABLE
+                                            .get_stream(context_resource_id)
+                                            .is_ok_and(|stream| {
+                                                stream
+                                                    .get_stream_type()
+                                                    .eq(&crate::storage::StreamType::Internal)
+                                            });
+                                        resource_id == context_resource_id
+                                            || resource_id == "*"
+                                            || is_internal
                                     } else {
                                         // if no resource to match then resource check is not needed
                                         // WHEN IS THIS VALID??


### PR DESCRIPTION
- RBAC fix for internal datasets

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded authorization to grant access to internal streams, even if resource IDs do not directly match.
  * Permissions with resource type "All" now authorize access for most actions, excluding certain administrative ones.

* **Bug Fixes**
  * Improved logic for checking stream access, ensuring internal streams are properly recognized for authorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->