### PR TITLE
chore: find tables from DFParser, schema merge when required

### DIFF
--- a/src/alerts/alerts_utils.rs
+++ b/src/alerts/alerts_utils.rs
@@ -29,10 +29,14 @@ use datafusion::{
     logical_expr::{BinaryExpr, Literal, Operator},
     prelude::{col, lit, DataFrame, Expr},
 };
-use tracing::trace;
+use tokio::task::JoinSet;
+use tracing::{trace, warn};
 
 use crate::{
-    alerts::LogicalOperator, parseable::PARSEABLE, query::QUERY_SESSION, utils::time::TimeRange,
+    alerts::LogicalOperator,
+    parseable::PARSEABLE,
+    query::{resolve_stream_names, QUERY_SESSION},
+    utils::time::TimeRange,
 };
 
 use super::{
@@ -71,11 +75,37 @@ async fn prepare_query(alert: &AlertConfig) -> Result<crate::query::Query, Alert
 
     let session_state = QUERY_SESSION.state();
     let select_query = alert.get_base_query();
-    let raw_logical_plan = session_state.create_logical_plan(&select_query).await?;
-
     let time_range = TimeRange::parse_human_time(start_time, end_time)
         .map_err(|err| AlertError::CustomError(err.to_string()))?;
 
+    let streams = resolve_stream_names(&select_query)?;
+    let raw_logical_plan = match session_state.create_logical_plan(&select_query).await {
+        Ok(plan) => plan,
+        Err(_) => {
+            let mut join_set = JoinSet::new();
+            for stream_name in streams {
+                let stream_name = stream_name.clone();
+                join_set.spawn(async move {
+                    let result = PARSEABLE
+                        .create_stream_and_schema_from_storage(&stream_name)
+                        .await;
+
+                    if let Err(e) = &result {
+                        warn!("Failed to create stream '{}': {}", stream_name, e);
+                    }
+
+                    (stream_name, result)
+                });
+            }
+
+            while let Some(result) = join_set.join_next().await {
+                if let Err(join_error) = result {
+                    warn!("Task join error: {}", join_error);
+                }
+            }
+            session_state.create_logical_plan(&select_query).await?
+        }
+    };
     Ok(crate::query::Query {
         raw_logical_plan,
         time_range,
@@ -87,7 +117,8 @@ async fn execute_base_query(
     query: &crate::query::Query,
     original_query: &str,
 ) -> Result<DataFrame, AlertError> {
-    let stream_name = query.first_table_name().ok_or_else(|| {
+    let streams = resolve_stream_names(&original_query)?;
+    let stream_name = streams.first().ok_or_else(|| {
         AlertError::CustomError(format!("Table name not found in query- {original_query}"))
     })?;
 

--- a/src/alerts/mod.rs
+++ b/src/alerts/mod.rs
@@ -19,6 +19,7 @@
 use actix_web::http::header::ContentType;
 use async_trait::async_trait;
 use chrono::Utc;
+use datafusion::sql::sqlparser::parser::ParserError;
 use derive_more::derive::FromStr;
 use derive_more::FromStrError;
 use http::StatusCode;
@@ -860,6 +861,8 @@ pub enum AlertError {
     InvalidTargetModification(String),
     #[error("Can't delete a Target which is being used")]
     TargetInUse,
+    #[error("{0}")]
+    ParserError(#[from] ParserError),
 }
 
 impl actix_web::ResponseError for AlertError {
@@ -880,6 +883,7 @@ impl actix_web::ResponseError for AlertError {
             Self::InvalidTargetID(_) => StatusCode::BAD_REQUEST,
             Self::InvalidTargetModification(_) => StatusCode::BAD_REQUEST,
             Self::TargetInUse => StatusCode::CONFLICT,
+            Self::ParserError(_) => StatusCode::BAD_REQUEST,
         }
     }
 

--- a/src/correlation.rs
+++ b/src/correlation.rs
@@ -87,7 +87,7 @@ impl Correlations {
                 .iter()
                 .map(|t| t.table_name.clone())
                 .collect_vec();
-            if user_auth_for_datasets(&permissions, tables).is_ok() {
+            if user_auth_for_datasets(&permissions, tables).await.is_ok() {
                 user_correlations.push(correlation.clone());
             }
         }
@@ -281,7 +281,7 @@ impl CorrelationConfig {
             .map(|t| t.table_name.clone())
             .collect_vec();
 
-        user_auth_for_datasets(&permissions, tables)?;
+        user_auth_for_datasets(&permissions, tables).await?;
 
         // to validate table config, we need to check whether the mentioned fields
         // are present in the table or not

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -123,7 +123,7 @@ pub fn commit_schema(stream_name: &str, schema: Arc<Schema>) -> Result<(), Stagi
 
     let map = &mut stream_metadata
         .get_mut(stream_name)
-        .expect("map has entry for this stream name")
+        .ok_or_else(|| StagingError::NotFound(stream_name.to_string()))?
         .metadata
         .write()
         .expect(LOCK_EXPECT)

--- a/src/handlers/airplane.rs
+++ b/src/handlers/airplane.rs
@@ -143,8 +143,7 @@ impl FlightService for AirServiceImpl {
         // create a visitor to extract the table name
 
         let stream_name = streams
-            .iter()
-            .next()
+            .first()
             .ok_or_else(|| Status::aborted("Malformed SQL Provided, Table Name Not Found"))?
             .to_owned();
 
@@ -199,9 +198,11 @@ impl FlightService for AirServiceImpl {
 
         let permissions = Users.get_permissions(&key);
 
-        user_auth_for_datasets(&permissions, &streams).await.map_err(|_| {
-            Status::permission_denied("User Does not have permission to access this")
-        })?;
+        user_auth_for_datasets(&permissions, &streams)
+            .await
+            .map_err(|_| {
+                Status::permission_denied("User Does not have permission to access this")
+            })?;
         let time = Instant::now();
 
         let (records, _) = execute(query, &stream_name, false)

--- a/src/handlers/http/correlation.rs
+++ b/src/handlers/http/correlation.rs
@@ -54,7 +54,7 @@ pub async fn get(
         .map(|t| t.table_name.clone())
         .collect_vec();
 
-    user_auth_for_datasets(&permissions, tables)?;
+    user_auth_for_datasets(&permissions, tables).await?;
 
     Ok(web::Json(correlation))
 }

--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -25,9 +25,9 @@ use actix_web::{Either, FromRequest, HttpRequest, HttpResponse, Responder};
 use arrow_array::RecordBatch;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
-use datafusion::common::tree_node::TreeNode;
 use datafusion::error::DataFusionError;
 use datafusion::execution::context::SessionState;
+use datafusion::sql::sqlparser::parser::ParserError;
 use futures::stream::once;
 use futures::{future, Stream, StreamExt};
 use futures_util::Future;
@@ -44,11 +44,10 @@ use tracing::{error, warn};
 
 use crate::event::commit_schema;
 use crate::metrics::QUERY_EXECUTE_TIME;
-use crate::option::Mode;
 use crate::parseable::{StreamNotFound, PARSEABLE};
 use crate::query::error::ExecuteError;
+use crate::query::{resolve_stream_names, QUERY_SESSION};
 use crate::query::{execute, CountsRequest, Query as LogicalQuery};
-use crate::query::{TableScanVisitor, QUERY_SESSION};
 use crate::rbac::Users;
 use crate::response::QueryResponse;
 use crate::storage::ObjectStorageError;
@@ -81,31 +80,21 @@ pub async fn get_records_and_fields(
     query_request: &Query,
     req: &HttpRequest,
 ) -> Result<(Option<Vec<RecordBatch>>, Option<Vec<String>>), QueryError> {
+    let tables = resolve_stream_names(&query_request.query)?;
     let session_state = QUERY_SESSION.state();
-
-    // get the logical plan and extract the table name
-    let raw_logical_plan = session_state
-        .create_logical_plan(&query_request.query)
-        .await?;
 
     let time_range =
         TimeRange::parse_human_time(&query_request.start_time, &query_request.end_time)?;
-    // create a visitor to extract the table name
-    let mut visitor = TableScanVisitor::default();
-    let _ = raw_logical_plan.visit(&mut visitor);
 
-    let tables = visitor.into_inner();
-    update_schema_when_distributed(&tables).await?;
-    let query: LogicalQuery = into_query(query_request, &session_state, time_range).await?;
-
+    let query: LogicalQuery =
+        into_query(query_request, &session_state, time_range, &tables).await?;
     let creds = extract_session_key_from_req(req)?;
     let permissions = Users.get_permissions(&creds);
 
-    let table_name = query
-        .first_table_name()
+    let table_name = tables
+        .first()
         .ok_or_else(|| QueryError::MalformedQuery("No table name found in query"))?;
-
-    user_auth_for_datasets(&permissions, &tables)?;
+    user_auth_for_datasets(&permissions, &tables).await?;
 
     let (records, fields) = execute(query, &table_name, false).await?;
 
@@ -121,35 +110,18 @@ pub async fn get_records_and_fields(
 
 pub async fn query(req: HttpRequest, query_request: Query) -> Result<HttpResponse, QueryError> {
     let session_state = QUERY_SESSION.state();
-    let raw_logical_plan = match session_state
-        .create_logical_plan(&query_request.query)
-        .await
-    {
-        Ok(raw_logical_plan) => raw_logical_plan,
-        Err(_) => {
-            create_streams_for_querier().await?;
-            session_state
-                .create_logical_plan(&query_request.query)
-                .await?
-        }
-    };
     let time_range =
         TimeRange::parse_human_time(&query_request.start_time, &query_request.end_time)?;
-
-    let mut visitor = TableScanVisitor::default();
-    let _ = raw_logical_plan.visit(&mut visitor);
-    let tables = visitor.into_inner();
-    update_schema_when_distributed(&tables).await?;
-    let query: LogicalQuery = into_query(&query_request, &session_state, time_range).await?;
-
+    let tables = resolve_stream_names(&query_request.query)?;
+    let query: LogicalQuery =
+        into_query(&query_request, &session_state, time_range, &tables).await?;
     let creds = extract_session_key_from_req(&req)?;
     let permissions = Users.get_permissions(&creds);
 
-    let table_name = query
-        .first_table_name()
+    let table_name = tables
+        .first()
         .ok_or_else(|| QueryError::MalformedQuery("No table name found in query"))?;
-
-    user_auth_for_datasets(&permissions, &tables)?;
+    user_auth_for_datasets(&permissions, &tables).await?;
 
     let time = Instant::now();
 
@@ -372,7 +344,7 @@ pub async fn get_counts(
     let body = counts_request.into_inner();
 
     // does user have access to table?
-    user_auth_for_datasets(&permissions, &[body.stream.clone()])?;
+    user_auth_for_datasets(&permissions, &[body.stream.clone()]).await?;
 
     // if the user has given a sql query (counts call with filters applied), then use this flow
     // this could include filters or group by
@@ -420,11 +392,9 @@ pub async fn update_schema_when_distributed(tables: &Vec<String>) -> Result<(), 
     // if the mode is query or prism, we need to update the schema in memory
     // no need to commit schema to storage
     // as the schema is read from memory everytime
-    if PARSEABLE.options.mode == Mode::Query || PARSEABLE.options.mode == Mode::Prism {
-        for table in tables {
-            if let Ok(new_schema) = fetch_schema(table).await {
-                commit_schema(table, Arc::new(new_schema))?;
-            }
+    for table in tables {
+        if let Ok(new_schema) = fetch_schema(table).await {
+            commit_schema(table, Arc::new(new_schema))?;
         }
     }
 
@@ -520,6 +490,7 @@ pub async fn into_query(
     query: &Query,
     session_state: &SessionState,
     time_range: TimeRange,
+    tables: &Vec<String>,
 ) -> Result<LogicalQuery, QueryError> {
     if query.query.is_empty() {
         return Err(QueryError::EmptyQuery);
@@ -532,9 +503,36 @@ pub async fn into_query(
     if query.end_time.is_empty() {
         return Err(QueryError::EmptyEndTime);
     }
+    let raw_logical_plan = match session_state.create_logical_plan(&query.query).await {
+        Ok(plan) => plan,
+        Err(_) => {
+            let mut join_set = JoinSet::new();
+            for stream_name in tables {
+                let stream_name = stream_name.clone();
+                join_set.spawn(async move {
+                    let result = PARSEABLE
+                        .create_stream_and_schema_from_storage(&stream_name)
+                        .await;
+
+                    if let Err(e) = &result {
+                        warn!("Failed to create stream '{}': {}", stream_name, e);
+                    }
+
+                    (stream_name, result)
+                });
+            }
+
+            while let Some(result) = join_set.join_next().await {
+                if let Err(join_error) = result {
+                    warn!("Task join error: {}", join_error);
+                }
+            }
+            session_state.create_logical_plan(&query.query).await?
+        }
+    };
 
     Ok(crate::query::Query {
-        raw_logical_plan: session_state.create_logical_plan(&query.query).await?,
+        raw_logical_plan,
         time_range,
         filter_tag: query.filter_tags.clone(),
     })
@@ -618,6 +616,8 @@ Description: {0}"#
     CustomError(String),
     #[error("No available queriers found")]
     NoAvailableQuerier,
+    #[error("{0}")]
+    ParserError(#[from] ParserError),
 }
 
 impl actix_web::ResponseError for QueryError {

--- a/src/parseable/staging/mod.rs
+++ b/src/parseable/staging/mod.rs
@@ -30,6 +30,8 @@ pub enum StagingError {
     ObjectStorage(#[from] std::io::Error),
     #[error("Could not generate parquet file")]
     Create,
+    #[error("Could not find stream {0}")]
+    NotFound(String),
     // #[error("Metadata Error: {0}")]
     // Metadata(#[from] MetadataError),
 }

--- a/src/users/filters.rs
+++ b/src/users/filters.rs
@@ -193,7 +193,7 @@ impl Filters {
                 }
             } else if *filter_type == FilterType::Search || *filter_type == FilterType::Filter {
                 let dataset_name = &f.stream_name;
-                if user_auth_for_datasets(&permissions, &[dataset_name.to_string()]).is_ok() {
+                if user_auth_for_datasets(&permissions, &[dataset_name.to_string()]).await.is_ok() {
                     filters.push(f.clone())
                 }
             }

--- a/src/users/filters.rs
+++ b/src/users/filters.rs
@@ -193,7 +193,10 @@ impl Filters {
                 }
             } else if *filter_type == FilterType::Search || *filter_type == FilterType::Filter {
                 let dataset_name = &f.stream_name;
-                if user_auth_for_datasets(&permissions, &[dataset_name.to_string()]).await.is_ok() {
+                if user_auth_for_datasets(&permissions, &[dataset_name.to_string()])
+                    .await
+                    .is_ok()
+                {
                     filters.push(f.clone())
                 }
             }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -104,7 +104,7 @@ pub async fn user_auth_for_datasets(
                     break;
                 }
                 Permission::Resource(Action::Query, ParseableResourceType::Stream(stream)) => {
-                    if !PARSEABLE.check_or_load_stream(&stream).await {
+                    if !PARSEABLE.check_or_load_stream(stream).await {
                         return Err(actix_web::error::ErrorUnauthorized(format!(
                             "Stream not found: {stream}"
                         )));

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -106,7 +106,7 @@ pub async fn user_auth_for_datasets(
                 Permission::Resource(Action::Query, ParseableResourceType::Stream(stream)) => {
                     if !PARSEABLE.check_or_load_stream(stream).await {
                         return Err(actix_web::error::ErrorUnauthorized(format!(
-                            "Stream not found: {stream}"
+                            "Stream not found: {table_name}"
                         )));
                     }
                     let is_internal = PARSEABLE.get_stream(table_name).is_ok_and(|stream| {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -27,14 +27,13 @@ pub mod update;
 
 use crate::handlers::http::rbac::RBACError;
 use crate::parseable::PARSEABLE;
-use crate::query::{TableScanVisitor, QUERY_SESSION};
+use crate::query::resolve_stream_names;
 use crate::rbac::map::SessionKey;
 use crate::rbac::role::{Action, ParseableResourceType, Permission};
 use crate::rbac::Users;
 use actix::extract_session_key_from_req;
 use actix_web::HttpRequest;
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime, Utc};
-use datafusion::common::tree_node::TreeNode;
 use regex::Regex;
 use sha2::{Digest, Sha256};
 
@@ -78,28 +77,18 @@ pub fn get_hash(key: &str) -> String {
     result
 }
 
-async fn get_tables_from_query(query: &str) -> Result<TableScanVisitor, actix_web::error::Error> {
-    let session_state = QUERY_SESSION.state();
-    let raw_logical_plan = session_state
-        .create_logical_plan(query)
-        .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(format!("Query error: {e}")))?;
-
-    let mut visitor = TableScanVisitor::default();
-    let _ = raw_logical_plan.visit(&mut visitor);
-    Ok(visitor)
-}
-
 pub async fn user_auth_for_query(
     session_key: &SessionKey,
     query: &str,
 ) -> Result<(), actix_web::error::Error> {
-    let tables = get_tables_from_query(query).await?.into_inner();
+    let tables = resolve_stream_names(query).map_err(|e| {
+        actix_web::error::ErrorBadRequest(format!("Failed to extract table names: {e}"))
+    })?;
     let permissions = Users.get_permissions(session_key);
-    user_auth_for_datasets(&permissions, &tables)
+    user_auth_for_datasets(&permissions, &tables).await
 }
 
-pub fn user_auth_for_datasets(
+pub async fn user_auth_for_datasets(
     permissions: &[Permission],
     tables: &[String],
 ) -> Result<(), actix_web::error::Error> {
@@ -115,6 +104,11 @@ pub fn user_auth_for_datasets(
                     break;
                 }
                 Permission::Resource(Action::Query, ParseableResourceType::Stream(stream)) => {
+                    if !PARSEABLE.check_or_load_stream(&stream).await {
+                        return Err(actix_web::error::ErrorUnauthorized(format!(
+                            "Stream not found: {stream}"
+                        )));
+                    }
                     let is_internal = PARSEABLE.get_stream(table_name).is_ok_and(|stream| {
                         stream
                             .get_stream_type()
@@ -153,23 +147,4 @@ pub fn user_auth_for_datasets(
     }
 
     Ok(())
-}
-
-/// A function to extract table names from a SQL string
-pub async fn extract_tables(sql: &str) -> Option<Vec<String>> {
-    let session_state = QUERY_SESSION.state();
-
-    // get the logical plan and extract the table name
-    let raw_logical_plan = match session_state.create_logical_plan(sql).await {
-        Ok(plan) => plan,
-        Err(_) => return None,
-    };
-
-    // create a visitor to extract the table name
-    let mut visitor = TableScanVisitor::default();
-    let _ = raw_logical_plan.visit(&mut visitor);
-
-    let tables = visitor.into_inner();
-
-    Some(tables)
 }


### PR DESCRIPTION
find table list from DFParser
create logical plan for the query
if fails, create from storage, merge schema
then create logical plan again

similar logic in user_auth_for_dataset -
check if stream exists locally, if not create from storage
then perform the check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved error handling for queries by automatically creating missing streams and schemas when needed.
  * Enhanced error messages for SQL parsing errors, now returning clear HTTP 400 Bad Request responses.

* **Refactor**
  * Streamlined table/stream name extraction from SQL queries for more reliable and direct resolution.
  * Replaced logical plan visitor approach with direct SQL parsing for identifying stream names.
  * Simplified and unified authorization checks to be fully asynchronous across the application.

* **Bug Fixes**
  * Fixed issues where missing streams could cause query failures by introducing a recovery mechanism.
  * Resolved inconsistencies in stream/table resolution and authorization logic.
  * Converted potential panics on missing streams to recoverable errors with clear messaging.

* **Chores**
  * Removed unused code and outdated helper functions related to table extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->