### PR TITLE
Update mod.rs

### DIFF
--- a/src/handlers/http/cluster/mod.rs
+++ b/src/handlers/http/cluster/mod.rs
@@ -1329,6 +1329,7 @@ pub async fn send_query_request(query_request: &Query) -> Result<(JsonValue, Str
 
     let res = match INTRA_CLUSTER_CLIENT
         .post(uri)
+        .timeout(Duration::from_secs(300))
         .header(header::AUTHORIZATION, &querier.token)
         .header(header::CONTENT_TYPE, "application/json")
         .body(body)


### PR DESCRIPTION
Added 5 minutes timeout for intra-cluster query request

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a 300-second timeout for HTTP POST requests when sending queries to a selected node, improving request reliability and preventing indefinite waits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->