### PR TITLE
chore: update cargo toml for release v2.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3456,7 +3456,7 @@ dependencies = [
 
 [[package]]
 name = "parseable"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parseable"
-version = "2.4.0"
+version = "2.4.1"
 authors = ["Parseable Team <hi@parseable.com>"]
 edition = "2024"
 rust-version = "1.88.0"
@@ -157,8 +157,8 @@ arrow = "54.0.0"
 temp-dir = "0.1.14"
 
 [package.metadata.parseable_ui]
-assets-url = "https://parseable-prism-build.s3.us-east-2.amazonaws.com/v2.4.0/build.zip"
-assets-sha1 = "04632472a2174328cfea7a91a175f6f3795d7152"
+assets-url = "https://parseable-prism-build.s3.us-east-2.amazonaws.com/v2.4.1/build.zip"
+assets-sha1 = "19eec4d38b978270eca1026325350e38c235ac31"
 
 [features]
 debug = []


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Bumped application version to 2.4.1 for release.
  - Updated UI asset references to the v2.4.1 build, including new download URL and checksum for integrity verification.
  - Applied the same updates across all relevant configuration blocks to keep references consistent.
  - No user-facing feature changes; this aligns packaged assets with the new version for this release cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->