### PR TITLE
Updates

### DIFF
--- a/src/alerts/alert_structs.rs
+++ b/src/alerts/alert_structs.rs
@@ -270,6 +270,13 @@ impl AlertRequest {
             TARGETS.get_target_by_id(id).await?;
         }
         let datasets = resolve_stream_names(&self.query)?;
+
+        if datasets.len() != 1 {
+            return Err(AlertError::ValidationFailure(format!(
+                "Query should include only one dataset. Found- {datasets:?}"
+            )));
+        }
+
         let config = AlertConfig {
             version: AlertVersion::from(CURRENT_ALERTS_VERSION),
             id: Ulid::new(),

--- a/src/alerts/alert_structs.rs
+++ b/src/alerts/alert_structs.rs
@@ -273,7 +273,7 @@ impl AlertRequest {
 
         if datasets.len() != 1 {
             return Err(AlertError::ValidationFailure(format!(
-                "Query should include only one dataset. Found- {datasets:?}"
+                "Query should include only one dataset. Found: {datasets:?}"
             )));
         }
 

--- a/src/handlers/http/cluster/mod.rs
+++ b/src/handlers/http/cluster/mod.rs
@@ -1114,7 +1114,7 @@ struct QuerierStatus {
     last_used: Option<Instant>,
 }
 
-async fn get_available_querier() -> Result<QuerierMetadata, QueryError> {
+pub async fn get_available_querier() -> Result<QuerierMetadata, QueryError> {
     // Get all querier metadata
     let querier_metadata: Vec<NodeMetadata> = get_node_info(NodeType::Querier).await?;
 

--- a/src/handlers/http/cluster/utils.rs
+++ b/src/handlers/http/cluster/utils.rs
@@ -135,7 +135,7 @@ impl StorageStats {
     }
 }
 
-pub fn merge_quried_stats(stats: Vec<QueriedStats>) -> QueriedStats {
+pub fn merge_queried_stats(stats: Vec<QueriedStats>) -> QueriedStats {
     // get the stream name
     let stream_name = stats[1].stream.clone();
 

--- a/src/handlers/http/cluster/utils.rs
+++ b/src/handlers/http/cluster/utils.rs
@@ -19,6 +19,7 @@
 use crate::{
     INTRA_CLUSTER_CLIENT,
     handlers::http::{base_path_without_preceding_slash, modal::NodeType},
+    prism::logstream::PrismLogstreamError,
 };
 use actix_web::http::header;
 use chrono::{DateTime, Utc};
@@ -135,7 +136,12 @@ impl StorageStats {
     }
 }
 
-pub fn merge_queried_stats(stats: Vec<QueriedStats>) -> QueriedStats {
+pub fn merge_queried_stats(stats: Vec<QueriedStats>) -> Result<QueriedStats, PrismLogstreamError> {
+    if stats.len() < 2 {
+        return Err(PrismLogstreamError::Anyhow(anyhow::Error::msg(
+            "Expected at least two logstreams in merge_queried_stats",
+        )));
+    }
     // get the stream name
     let stream_name = stats[1].stream.clone();
 
@@ -167,12 +173,12 @@ pub fn merge_queried_stats(stats: Vec<QueriedStats>) -> QueriedStats {
                 deleted_size: acc.deleted_size + x.deleted_size,
             });
 
-    QueriedStats::new(
+    Ok(QueriedStats::new(
         &stream_name,
         min_time,
         cumulative_ingestion,
         cumulative_storage,
-    )
+    ))
 }
 
 pub async fn check_liveness(domain_name: &str) -> bool {

--- a/src/handlers/http/modal/query/querier_logstream.rs
+++ b/src/handlers/http/modal/query/querier_logstream.rs
@@ -33,14 +33,17 @@ use tracing::{error, warn};
 static CREATE_STREAM_LOCK: Mutex<()> = Mutex::const_new(());
 
 use crate::{
-    handlers::http::{
-        base_path_without_preceding_slash,
-        cluster::{
-            self, fetch_daily_stats, fetch_stats_from_ingestors, sync_streams_with_ingestors,
-            utils::{IngestionStats, QueriedStats, StorageStats, merge_quried_stats},
+    handlers::{
+        UPDATE_STREAM_KEY,
+        http::{
+            base_path_without_preceding_slash,
+            cluster::{
+                self, fetch_daily_stats, fetch_stats_from_ingestors, sync_streams_with_ingestors,
+                utils::{IngestionStats, QueriedStats, StorageStats, merge_quried_stats},
+            },
+            logstream::error::StreamError,
+            modal::{NodeMetadata, NodeType},
         },
-        logstream::error::StreamError,
-        modal::{NodeMetadata, NodeType},
     },
     hottier::HotTierManager,
     parseable::{PARSEABLE, StreamNotFound},
@@ -120,9 +123,19 @@ pub async fn put_stream(
         .create_update_stream(req.headers(), &body, &stream_name)
         .await?;
 
+    let is_update = if let Some(val) = headers.get(UPDATE_STREAM_KEY) {
+        val.to_str().unwrap() == "true"
+    } else {
+        false
+    };
+
     sync_streams_with_ingestors(headers, body, &stream_name).await?;
 
-    Ok(("Log stream created", StatusCode::OK))
+    if is_update {
+        Ok(("Log stream updated", StatusCode::OK))
+    } else {
+        Ok(("Log stream created", StatusCode::OK))
+    }
 }
 
 pub async fn get_stats(

--- a/src/handlers/http/modal/query/querier_logstream.rs
+++ b/src/handlers/http/modal/query/querier_logstream.rs
@@ -39,7 +39,7 @@ use crate::{
             base_path_without_preceding_slash,
             cluster::{
                 self, fetch_daily_stats, fetch_stats_from_ingestors, sync_streams_with_ingestors,
-                utils::{IngestionStats, QueriedStats, StorageStats, merge_quried_stats},
+                utils::{IngestionStats, QueriedStats, StorageStats, merge_queried_stats},
             },
             logstream::error::StreamError,
             modal::{NodeMetadata, NodeType},
@@ -118,7 +118,7 @@ pub async fn put_stream(
     body: Bytes,
 ) -> Result<impl Responder, StreamError> {
     let stream_name = stream_name.into_inner();
-    let _ = CREATE_STREAM_LOCK.lock().await;
+    let _guard = CREATE_STREAM_LOCK.lock().await;
     let headers = PARSEABLE
         .create_update_stream(req.headers(), &body, &stream_name)
         .await?;
@@ -231,7 +231,7 @@ pub async fn get_stats(
 
     let stats = if let Some(mut ingestor_stats) = ingestor_stats {
         ingestor_stats.push(stats);
-        merge_quried_stats(ingestor_stats)
+        merge_queried_stats(ingestor_stats)
     } else {
         stats
     };

--- a/src/handlers/http/modal/query/querier_logstream.rs
+++ b/src/handlers/http/modal/query/querier_logstream.rs
@@ -232,6 +232,7 @@ pub async fn get_stats(
     let stats = if let Some(mut ingestor_stats) = ingestor_stats {
         ingestor_stats.push(stats);
         merge_queried_stats(ingestor_stats)
+            .map_err(|e| StreamError::Anyhow(anyhow::Error::msg(e.to_string())))?
     } else {
         stats
     };

--- a/src/prism/logstream/mod.rs
+++ b/src/prism/logstream/mod.rs
@@ -136,7 +136,7 @@ async fn get_stats(stream_name: &str) -> Result<QueriedStats, PrismLogstreamErro
 
     let stats = if let Some(mut ingestor_stats) = ingestor_stats {
         ingestor_stats.push(stats);
-        merge_queried_stats(ingestor_stats)
+        merge_queried_stats(ingestor_stats)?
     } else {
         stats
     };

--- a/src/prism/logstream/mod.rs
+++ b/src/prism/logstream/mod.rs
@@ -30,7 +30,7 @@ use crate::{
     handlers::http::{
         cluster::{
             fetch_stats_from_ingestors,
-            utils::{IngestionStats, QueriedStats, StorageStats, merge_quried_stats},
+            utils::{IngestionStats, QueriedStats, StorageStats, merge_queried_stats},
         },
         logstream::error::StreamError,
         query::{QueryError, update_schema_when_distributed},
@@ -136,7 +136,7 @@ async fn get_stats(stream_name: &str) -> Result<QueriedStats, PrismLogstreamErro
 
     let stats = if let Some(mut ingestor_stats) = ingestor_stats {
         ingestor_stats.push(stats);
-        merge_quried_stats(ingestor_stats)
+        merge_queried_stats(ingestor_stats)
     } else {
         stats
     };

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -56,7 +56,7 @@ use crate::catalog::Snapshot as CatalogSnapshot;
 use crate::catalog::column::{Int64Type, TypedStatistics};
 use crate::catalog::manifest::Manifest;
 use crate::catalog::snapshot::Snapshot;
-use crate::event::{self, DEFAULT_TIMESTAMP_KEY};
+use crate::event::DEFAULT_TIMESTAMP_KEY;
 use crate::handlers::http::query::QueryError;
 use crate::option::Mode;
 use crate::parseable::PARSEABLE;
@@ -345,7 +345,7 @@ impl CountsRequest {
             .get_stream(&self.stream)
             .map_err(|err| anyhow::Error::msg(err.to_string()))?
             .get_time_partition()
-            .unwrap_or(event::DEFAULT_TIMESTAMP_KEY.to_owned());
+            .unwrap_or_else(|| DEFAULT_TIMESTAMP_KEY.to_owned());
 
         // get time range
         let time_range = TimeRange::parse_human_time(&self.start_time, &self.end_time)?;
@@ -449,7 +449,7 @@ impl CountsRequest {
         let time_partition = PARSEABLE
             .get_stream(&self.stream)?
             .get_time_partition()
-            .unwrap_or(DEFAULT_TIMESTAMP_KEY.into());
+            .unwrap_or_else(|| DEFAULT_TIMESTAMP_KEY.into());
 
         let time_range = TimeRange::parse_human_time(&self.start_time, &self.end_time)?;
 
@@ -458,20 +458,20 @@ impl CountsRequest {
         let date_bin = if dur.num_minutes() <= 60 * 10 {
             // date_bin 1 minute
             format!(
-                "CAST(DATE_BIN('1 minute', \"{}\".\"{time_partition}\", TIMESTAMP '1970-01-01 00:00:00+00') AS TEXT) as start_time, DATE_BIN('1 minute', \"{time_partition}\", TIMESTAMP '1970-01-01 00:00:00+00') + INTERVAL '1 minute' as end_time",
-                self.stream
+                "CAST(DATE_BIN('1 minute', \"{}\".\"{time_partition}\", TIMESTAMP '1970-01-01 00:00:00+00') AS TEXT) as start_time, DATE_BIN('1 minute', \"{}\".\"{time_partition}\", TIMESTAMP '1970-01-01 00:00:00+00') + INTERVAL '1 minute' as end_time",
+                self.stream, self.stream
             )
         } else if dur.num_minutes() > 60 * 10 && dur.num_minutes() < 60 * 240 {
             // date_bin 1 hour
             format!(
-                "CAST(DATE_BIN('1 hour', \"{}\".\"{time_partition}\", TIMESTAMP '1970-01-01 00:00:00+00') AS TEXT) as start_time, DATE_BIN('1 hour', \"{time_partition}\", TIMESTAMP '1970-01-01 00:00:00+00') + INTERVAL '1 hour' as end_time",
-                self.stream
+                "CAST(DATE_BIN('1 hour', \"{}\".\"{time_partition}\", TIMESTAMP '1970-01-01 00:00:00+00') AS TEXT) as start_time, DATE_BIN('1 hour', \"{}\".\"{time_partition}\", TIMESTAMP '1970-01-01 00:00:00+00') + INTERVAL '1 hour' as end_time",
+                self.stream, self.stream
             )
         } else {
             // date_bin 1 day
             format!(
-                "CAST(DATE_BIN('1 day', \"{}\".\"{time_partition}\", TIMESTAMP '1970-01-01 00:00:00+00') AS TEXT) as start_time, DATE_BIN('1 day', \"{time_partition}\", TIMESTAMP '1970-01-01 00:00:00+00') + INTERVAL '1 day' as end_time",
-                self.stream
+                "CAST(DATE_BIN('1 day', \"{}\".\"{time_partition}\", TIMESTAMP '1970-01-01 00:00:00+00') AS TEXT) as start_time, DATE_BIN('1 day', \"{}\".\"{time_partition}\", TIMESTAMP '1970-01-01 00:00:00+00') + INTERVAL '1 day' as end_time",
+                self.stream, self.stream
             )
         };
 


### PR DESCRIPTION
- changes related to time-partition
- general updates

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Log stream API: requests can indicate update vs create; responses show "Log stream created" or "Log stream updated".
  - Counts/queries: per-stream time-partitioning is honored for binning; counts responses now include structured records.
  - Dataset API: dataset responses include counts and support per-user filtering.

- **Bug Fixes**
  - Alerts: validation now enforces exactly one dataset in alert queries.
  - Stats: corrected stats merge handling and added error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->