### PR TITLE
fix: add empty check before removing users from session

### DIFF
--- a/src/rbac/user.rs
+++ b/src/rbac/user.rs
@@ -271,6 +271,9 @@ impl UserGroup {
     }
 
     pub fn add_roles(&mut self, roles: HashSet<String>) -> Result<(), RBACError> {
+        if roles.is_empty() {
+            return Ok(());
+        }
         self.roles.extend(roles);
         // also refresh all user sessions
         for username in &self.users {
@@ -280,6 +283,9 @@ impl UserGroup {
     }
 
     pub fn add_users(&mut self, users: HashSet<String>) -> Result<(), RBACError> {
+        if users.is_empty() {
+            return Ok(());
+        }
         self.users.extend(users.clone());
         // also refresh all user sessions
         for username in &users {
@@ -289,6 +295,9 @@ impl UserGroup {
     }
 
     pub fn remove_roles(&mut self, roles: HashSet<String>) -> Result<(), RBACError> {
+        if roles.is_empty() {
+            return Ok(());
+        }
         let old_roles = &self.roles;
         let new_roles = HashSet::from_iter(self.roles.difference(&roles).cloned());
 
@@ -305,6 +314,9 @@ impl UserGroup {
     }
 
     pub fn remove_users(&mut self, users: HashSet<String>) -> Result<(), RBACError> {
+        if users.is_empty() {
+            return Ok(());
+        }
         let old_users = &self.users;
         let new_users = HashSet::from_iter(self.users.difference(&users).cloned());
 


### PR DESCRIPTION
issue - when user is added to group, all existing users in the group get logged out

the change fixes the issue by not removing users from session
when users / roles in the modify / delete request are empty
