### PR TITLE
Update: add last triggered timestamp to alerts

### DIFF
--- a/src/alerts/alert_structs.rs
+++ b/src/alerts/alert_structs.rs
@@ -316,6 +316,7 @@ impl AlertRequest {
             notification_config: self.notification_config,
             created: Utc::now(),
             tags: self.tags,
+            last_triggered_at: None,
         };
         Ok(config)
     }
@@ -342,6 +343,7 @@ pub struct AlertConfig {
     pub notification_config: NotificationConfig,
     pub created: DateTime<Utc>,
     pub tags: Option<Vec<String>>,
+    pub last_triggered_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
@@ -367,6 +369,7 @@ pub struct AlertConfigResponse {
     pub notification_config: NotificationConfig,
     pub created: DateTime<Utc>,
     pub tags: Option<Vec<String>>,
+    pub last_triggered_at: Option<DateTime<Utc>>,
 }
 
 impl AlertConfig {
@@ -405,6 +408,7 @@ impl AlertConfig {
             notification_config: self.notification_config,
             created: self.created,
             tags: self.tags,
+            last_triggered_at: self.last_triggered_at,
         }
     }
 }

--- a/src/alerts/mod.rs
+++ b/src/alerts/mod.rs
@@ -134,6 +134,7 @@ impl AlertConfig {
             notification_config: NotificationConfig::default(),
             created: Utc::now(),
             tags: None,
+            last_triggered_at: None,
         };
 
         // Save the migrated alert back to storage


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Alerts now track and expose the “Last triggered” timestamp.
  * API responses include last_triggered_at, allowing clients to see when an alert last fired.
  * Timestamp updates automatically whenever an alert transitions to Triggered.

* **Chores**
  * Data migration sets the “Last triggered” timestamp to empty for existing alerts.
  * Newly created alerts start with no timestamp until their first trigger.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->