### PR TITLE
fix: use userid, username and method in a usergroup

### DIFF
--- a/src/handlers/http/cluster/mod.rs
+++ b/src/handlers/http/cluster/mod.rs
@@ -331,21 +331,21 @@ pub async fn sync_user_creation_with_ingestors(
     if let Some(role) = role {
         user.roles.clone_from(role);
     }
-    let username = user.username();
+    let userid = user.userid();
 
     let user_data = to_vec(&user).map_err(|err| {
         error!("Fatal: failed to serialize user: {:?}", err);
         RBACError::SerdeError(err)
     })?;
 
-    let username = username.to_string();
+    let userid = userid.to_string();
 
     for_each_live_ingestor(move |ingestor| {
         let url = format!(
             "{}{}/user/{}/sync",
             ingestor.domain_name,
             base_path_without_preceding_slash(),
-            username
+            userid
         );
 
         let user_data = user_data.clone();

--- a/src/handlers/http/cluster/mod.rs
+++ b/src/handlers/http/cluster/mod.rs
@@ -253,7 +253,7 @@ pub async fn sync_users_with_roles_with_ingestors(
 
         async move {
             let res = INTRA_CLUSTER_CLIENT
-                .put(url)
+                .patch(url)
                 .header(header::AUTHORIZATION, &ingestor.token)
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(role_data)

--- a/src/handlers/http/cluster/mod.rs
+++ b/src/handlers/http/cluster/mod.rs
@@ -222,7 +222,7 @@ pub async fn get_demo_data_from_ingestor(action: &str) -> Result<(), PostError> 
 
 // forward the role update request to all ingestors to keep them in sync
 pub async fn sync_users_with_roles_with_ingestors(
-    username: &str,
+    userid: &str,
     role: &HashSet<String>,
     operation: &str,
 ) -> Result<(), RBACError> {
@@ -236,7 +236,7 @@ pub async fn sync_users_with_roles_with_ingestors(
         RBACError::SerdeError(err)
     })?;
 
-    let username = username.to_owned();
+    let userid = userid.to_owned();
 
     let op = operation.to_string();
 
@@ -245,7 +245,7 @@ pub async fn sync_users_with_roles_with_ingestors(
             "{}{}/user/{}/role/sync/{}",
             ingestor.domain_name,
             base_path_without_preceding_slash(),
-            username,
+            userid,
             op
         );
 
@@ -282,15 +282,15 @@ pub async fn sync_users_with_roles_with_ingestors(
 }
 
 // forward the delete user request to all ingestors to keep them in sync
-pub async fn sync_user_deletion_with_ingestors(username: &str) -> Result<(), RBACError> {
-    let username = username.to_owned();
+pub async fn sync_user_deletion_with_ingestors(userid: &str) -> Result<(), RBACError> {
+    let userid = userid.to_owned();
 
     for_each_live_ingestor(move |ingestor| {
         let url = format!(
             "{}{}/user/{}/sync",
             ingestor.domain_name,
             base_path_without_preceding_slash(),
-            username
+            userid
         );
 
         async move {

--- a/src/handlers/http/modal/ingest/ingestor_rbac.rs
+++ b/src/handlers/http/modal/ingest/ingestor_rbac.rs
@@ -18,7 +18,7 @@
 
 use std::collections::HashSet;
 
-use actix_web::{Responder, web};
+use actix_web::{HttpResponse, Responder, web};
 
 use crate::{
     handlers::http::{
@@ -51,7 +51,7 @@ pub async fn post_user(
         Users.add_roles(&username, created_role.clone());
     }
 
-    Ok(generated_password)
+    Ok(HttpResponse::Ok().json(generated_password))
 }
 
 // Handler for DELETE /api/v1/user/delete/{userid}
@@ -78,7 +78,7 @@ pub async fn delete_user(userid: web::Path<String>) -> Result<impl Responder, RB
 
     // update in mem table
     Users.delete_user(&userid);
-    Ok(format!("deleted user: {username}"))
+    Ok(HttpResponse::Ok().json(format!("deleted user: {username}")))
 }
 
 // Handler PATCH /user/{userid}/role/sync/add => Add roles to a user
@@ -128,7 +128,6 @@ pub async fn add_roles_to_user(
     let _ = storage::put_staging_metadata(&metadata);
     // update in mem table
     Users.add_roles(&userid.clone(), roles_to_add.clone());
-
     Ok(format!("Roles updated successfully for {username}"))
 }
 
@@ -218,6 +217,5 @@ pub async fn post_gen_password(username: web::Path<String>) -> Result<impl Respo
         return Err(RBACError::UserDoesNotExist);
     }
     Users.change_password_hash(&username, &new_hash);
-
-    Ok("Updated")
+    Ok(HttpResponse::Ok().json("Updated"))
 }

--- a/src/handlers/http/modal/ingest/ingestor_rbac.rs
+++ b/src/handlers/http/modal/ingest/ingestor_rbac.rs
@@ -19,10 +19,12 @@
 use std::collections::HashSet;
 
 use actix_web::{Responder, web};
-use tokio::sync::Mutex;
 
 use crate::{
-    handlers::http::{modal::utils::rbac_utils::get_metadata, rbac::RBACError},
+    handlers::http::{
+        modal::utils::rbac_utils::get_metadata,
+        rbac::{RBACError, UPDATE_LOCK},
+    },
     rbac::{
         Users,
         map::roles,
@@ -30,9 +32,6 @@ use crate::{
     },
     storage,
 };
-
-// async aware lock for updating storage metadata and user map atomicically
-static UPDATE_LOCK: Mutex<()> = Mutex::const_new(());
 
 // Handler for POST /api/v1/user/{username}
 // Creates a new user by username if it does not exists

--- a/src/handlers/http/modal/ingest/ingestor_rbac.rs
+++ b/src/handlers/http/modal/ingest/ingestor_rbac.rs
@@ -58,7 +58,7 @@ pub async fn post_user(
 // Handler for DELETE /api/v1/user/delete/{username}
 pub async fn delete_user(username: web::Path<String>) -> Result<impl Responder, RBACError> {
     let username = username.into_inner();
-    let _ = UPDATE_LOCK.lock().await;
+    let _guard = UPDATE_LOCK.lock().await;
     // fail this request if the user does not exists
     if !Users.contains(&username) {
         return Err(RBACError::UserDoesNotExist);

--- a/src/handlers/http/modal/ingest/ingestor_rbac.rs
+++ b/src/handlers/http/modal/ingest/ingestor_rbac.rs
@@ -117,7 +117,7 @@ pub async fn add_roles_to_user(
     Ok(HttpResponse::Ok().status(StatusCode::OK).finish())
 }
 
-// Handler PATCH /user/{userid}/role/sync/add => Add roles to a user
+// Handler PATCH /user/{userid}/role/sync/remove => Remove roles to a user
 pub async fn remove_roles_from_user(
     userid: web::Path<String>,
     roles_to_remove: web::Json<HashSet<String>>,

--- a/src/handlers/http/modal/ingest/ingestor_role.rs
+++ b/src/handlers/http/modal/ingest/ingestor_role.rs
@@ -50,7 +50,7 @@ pub async fn put(
     let mut session_refresh_users: HashSet<String> = HashSet::new();
     for user_group in read_user_groups().values() {
         if user_group.roles.contains(&name) {
-            session_refresh_users.extend(user_group.get_usernames());
+            session_refresh_users.extend(user_group.users.iter().map(|u| u.userid().to_string()));
         }
     }
 

--- a/src/handlers/http/modal/ingest/ingestor_role.rs
+++ b/src/handlers/http/modal/ingest/ingestor_role.rs
@@ -57,12 +57,12 @@ pub async fn put(
     // iterate over all users to see if they have this role
     for user in users().values() {
         if user.roles.contains(&name) {
-            session_refresh_users.insert(user.username().to_string());
+            session_refresh_users.insert(user.userid().to_string());
         }
     }
 
-    for username in session_refresh_users {
-        mut_sessions().remove_user(&username);
+    for userid in session_refresh_users {
+        mut_sessions().remove_user(&userid);
     }
 
     Ok(HttpResponse::Ok().finish())

--- a/src/handlers/http/modal/ingest/ingestor_role.rs
+++ b/src/handlers/http/modal/ingest/ingestor_role.rs
@@ -48,14 +48,14 @@ pub async fn put(
     // refresh the sessions of all users using this role
     // for this, iterate over all user_groups and users and create a hashset of users
     let mut session_refresh_users: HashSet<String> = HashSet::new();
-    for user_group in read_user_groups().values().cloned() {
+    for user_group in read_user_groups().values() {
         if user_group.roles.contains(&name) {
-            session_refresh_users.extend(user_group.users);
+            session_refresh_users.extend(user_group.get_usernames());
         }
     }
 
     // iterate over all users to see if they have this role
-    for user in users().values().cloned() {
+    for user in users().values() {
         if user.roles.contains(&name) {
             session_refresh_users.insert(user.username().to_string());
         }

--- a/src/handlers/http/modal/ingest_server.rs
+++ b/src/handlers/http/modal/ingest_server.rs
@@ -190,7 +190,7 @@ impl IngestServer {
                             .to(ingestor_rbac::post_user)
                             .authorize(Action::PutUser),
                     )
-                    // DELETE /user/{username} => Sync deletion of a user
+                    // DELETE /user/{userid} => Sync deletion of a user
                     .route(
                         web::delete()
                             .to(ingestor_rbac::delete_user)
@@ -199,8 +199,8 @@ impl IngestServer {
                     .wrap(DisAllowRootUser),
             )
             .service(
-                web::resource("/{username}/role/sync/add")
-                    // PATCH /user/{username}/role/sync/add => Add roles to a user
+                web::resource("/{userid}/role/sync/add")
+                    // PATCH /user/{userid}/role/sync/add => Add roles to a user
                     .route(
                         web::patch()
                             .to(ingestor_rbac::add_roles_to_user)
@@ -209,8 +209,8 @@ impl IngestServer {
                     ),
             )
             .service(
-                web::resource("/{username}/role/sync/remove")
-                    // PATCH /user/{username}/role/sync/remove => Remove roles from a user
+                web::resource("/{userid}/role/sync/remove")
+                    // PATCH /user/{userid}/role/sync/remove => Remove roles from a user
                     .route(
                         web::patch()
                             .to(ingestor_rbac::remove_roles_from_user)

--- a/src/handlers/http/modal/ingest_server.rs
+++ b/src/handlers/http/modal/ingest_server.rs
@@ -184,7 +184,7 @@ impl IngestServer {
         web::scope("/user")
             .service(
                 web::resource("/{username}/sync")
-                    // PUT /user/{username}/sync => Sync creation of a new user
+                    // POST /user/{username}/sync => Sync creation of a new user
                     .route(
                         web::post()
                             .to(ingestor_rbac::post_user)

--- a/src/handlers/http/modal/query/querier_rbac.rs
+++ b/src/handlers/http/modal/query/querier_rbac.rs
@@ -18,7 +18,7 @@
 
 use std::collections::HashSet;
 
-use actix_web::{Responder, web};
+use actix_web::{HttpResponse, Responder, web};
 
 use crate::{
     handlers::http::{
@@ -157,7 +157,7 @@ pub async fn delete_user(userid: web::Path<String>) -> Result<impl Responder, RB
 
     // update in mem table
     Users.delete_user(&userid);
-    Ok(format!("deleted user: {username}"))
+    Ok(HttpResponse::Ok().json(format!("deleted user: {username}")))
 }
 
 // Handler PATCH /user/{userid}/role/add => Add roles to a user
@@ -218,7 +218,7 @@ pub async fn add_roles_to_user(
 pub async fn remove_roles_from_user(
     userid: web::Path<String>,
     roles_to_remove: web::Json<HashSet<String>>,
-) -> Result<String, RBACError> {
+) -> Result<impl Responder, RBACError> {
     let userid = userid.into_inner();
     let roles_to_remove = roles_to_remove.into_inner();
 
@@ -279,7 +279,7 @@ pub async fn remove_roles_from_user(
 
     sync_users_with_roles_with_ingestors(&userid, &roles_to_remove, "remove").await?;
 
-    Ok(format!("Roles updated successfully for {username}"))
+    Ok(HttpResponse::Ok().json(format!("Roles updated successfully for {username}")))
 }
 
 // Handler for POST /api/v1/user/{username}/generate-new-password

--- a/src/handlers/http/modal/query/querier_rbac.rs
+++ b/src/handlers/http/modal/query/querier_rbac.rs
@@ -168,8 +168,6 @@ pub async fn add_roles_to_user(
     let userid = userid.into_inner();
     let roles_to_add = roles_to_add.into_inner();
 
-    let _guard = UPDATE_LOCK.lock().await;
-
     if !Users.contains(&userid) {
         return Err(RBACError::UserDoesNotExist);
     };
@@ -225,7 +223,7 @@ pub async fn remove_roles_from_user(
     let roles_to_remove = roles_to_remove.into_inner();
 
     let _guard = UPDATE_LOCK.lock().await;
-    
+
     if !Users.contains(&userid) {
         return Err(RBACError::UserDoesNotExist);
     };

--- a/src/handlers/http/modal/query/querier_rbac.rs
+++ b/src/handlers/http/modal/query/querier_rbac.rs
@@ -168,6 +168,8 @@ pub async fn add_roles_to_user(
     let userid = userid.into_inner();
     let roles_to_add = roles_to_add.into_inner();
 
+    let _guard = UPDATE_LOCK.lock().await;
+
     if !Users.contains(&userid) {
         return Err(RBACError::UserDoesNotExist);
     };
@@ -222,6 +224,8 @@ pub async fn remove_roles_from_user(
     let userid = userid.into_inner();
     let roles_to_remove = roles_to_remove.into_inner();
 
+    let _guard = UPDATE_LOCK.lock().await;
+    
     if !Users.contains(&userid) {
         return Err(RBACError::UserDoesNotExist);
     };

--- a/src/handlers/http/modal/query/querier_rbac.rs
+++ b/src/handlers/http/modal/query/querier_rbac.rs
@@ -71,8 +71,15 @@ pub async fn post_user(
         }
     }
     let _guard = UPDATE_LOCK.lock().await;
-    if Users.contains(&username) || metadata.users.iter().any(|user| user.userid() == username) {
-        return Err(RBACError::UserExists);
+    if Users.contains(&username) {
+        if Users.contains(&username)
+            || metadata.users.iter().any(|user| match &user.ty {
+                UserType::Native(basic) => basic.username == username,
+                UserType::OAuth(_) => false, // OAuth users should be created differently
+            })
+        {
+            return Err(RBACError::UserExists);
+        }
     }
 
     let (user, password) = user::User::new_basic(username.clone());

--- a/src/handlers/http/modal/query/querier_rbac.rs
+++ b/src/handlers/http/modal/query/querier_rbac.rs
@@ -19,7 +19,6 @@
 use std::collections::HashSet;
 
 use actix_web::{Responder, web};
-use tokio::sync::Mutex;
 
 use crate::{
     handlers::http::{
@@ -28,7 +27,7 @@ use crate::{
             sync_user_deletion_with_ingestors, sync_users_with_roles_with_ingestors,
         },
         modal::utils::rbac_utils::{get_metadata, put_metadata},
-        rbac::RBACError,
+        rbac::{RBACError, UPDATE_LOCK},
     },
     rbac::{
         Users,
@@ -37,9 +36,6 @@ use crate::{
     },
     validator,
 };
-
-// async aware lock for updating storage metadata and user map atomically
-static UPDATE_LOCK: Mutex<()> = Mutex::const_new(());
 
 // Handler for POST /api/v1/user/{username}
 // Creates a new user by username if it does not exists

--- a/src/handlers/http/modal/query/querier_rbac.rs
+++ b/src/handlers/http/modal/query/querier_rbac.rs
@@ -71,11 +71,11 @@ pub async fn post_user(
         }
     }
     let _guard = UPDATE_LOCK.lock().await;
-    if Users.contains(&username) && Users.contains(&username)
-        || metadata.users.iter().any(|user| match &user.ty {
-            UserType::Native(basic) => basic.username == username,
-            UserType::OAuth(_) => false, // OAuth users should be created differently
-        })
+    if Users.contains(&username)
+        || metadata
+            .users
+            .iter()
+            .any(|user| matches!(&user.ty, UserType::Native(basic) if basic.username == username))
     {
         return Err(RBACError::UserExists);
     }

--- a/src/handlers/http/modal/query/querier_role.rs
+++ b/src/handlers/http/modal/query/querier_role.rs
@@ -60,12 +60,12 @@ pub async fn put(
     // iterate over all users to see if they have this role
     for user in users().values() {
         if user.roles.contains(&name) {
-            session_refresh_users.insert(user.username().to_string());
+            session_refresh_users.insert(user.userid().to_string());
         }
     }
 
-    for username in session_refresh_users {
-        mut_sessions().remove_user(&username);
+    for userid in session_refresh_users {
+        mut_sessions().remove_user(&userid);
     }
 
     sync_role_update_with_ingestors(name.clone(), privileges.clone()).await?;

--- a/src/handlers/http/modal/query/querier_role.rs
+++ b/src/handlers/http/modal/query/querier_role.rs
@@ -53,7 +53,7 @@ pub async fn put(
     let mut session_refresh_users: HashSet<String> = HashSet::new();
     for user_group in read_user_groups().values() {
         if user_group.roles.contains(&name) {
-            session_refresh_users.extend(user_group.get_usernames());
+            session_refresh_users.extend(user_group.users.iter().map(|u| u.userid().to_string()));
         }
     }
 

--- a/src/handlers/http/modal/query/querier_role.rs
+++ b/src/handlers/http/modal/query/querier_role.rs
@@ -51,14 +51,14 @@ pub async fn put(
     // refresh the sessions of all users using this role
     // for this, iterate over all user_groups and users and create a hashset of users
     let mut session_refresh_users: HashSet<String> = HashSet::new();
-    for user_group in read_user_groups().values().cloned() {
+    for user_group in read_user_groups().values() {
         if user_group.roles.contains(&name) {
-            session_refresh_users.extend(user_group.users);
+            session_refresh_users.extend(user_group.get_usernames());
         }
     }
 
     // iterate over all users to see if they have this role
-    for user in users().values().cloned() {
+    for user in users().values() {
         if user.roles.contains(&name) {
             session_refresh_users.insert(user.username().to_string());
         }

--- a/src/handlers/http/modal/query_server.rs
+++ b/src/handlers/http/modal/query_server.rs
@@ -200,7 +200,7 @@ impl QueryServer {
                             .to(querier_rbac::post_user)
                             .authorize(Action::PutUser),
                     )
-                    // DELETE /user/{username} => Delete a user
+                    // DELETE /user/{userid} => Delete a user
                     .route(
                         web::delete()
                             .to(querier_rbac::delete_user)
@@ -209,15 +209,15 @@ impl QueryServer {
                     .wrap(DisAllowRootUser),
             )
             .service(
-                web::resource("/{username}/role").route(
+                web::resource("/{userid}/role").route(
                     web::get()
                         .to(rbac::get_role)
                         .authorize_for_user(Action::GetUserRoles),
                 ),
             )
             .service(
-                web::resource("/{username}/role/add")
-                    // PATCH /user/{username}/role/add => Add roles to a user
+                web::resource("/{userid}/role/add")
+                    // PATCH /user/{userid}/role/add => Add roles to a user
                     .route(
                         web::patch()
                             .to(rbac::add_roles_to_user)
@@ -226,8 +226,8 @@ impl QueryServer {
                     ),
             )
             .service(
-                web::resource("/{username}/role/remove")
-                    // PATCH /user/{username}/role/remove => Remove roles from a user
+                web::resource("/{userid}/role/remove")
+                    // PATCH /user/{userid}/role/remove => Remove roles from a user
                     .route(
                         web::patch()
                             .to(rbac::remove_roles_from_user)

--- a/src/handlers/http/oidc.rs
+++ b/src/handlers/http/oidc.rs
@@ -367,7 +367,7 @@ pub async fn request_token(
 // put new user in metadata if does not exits
 // update local cache
 pub async fn put_user(
-    username: &str,
+    userid: &str,
     group: HashSet<String>,
     user_info: user::UserInfo,
 ) -> Result<User, ObjectStorageError> {
@@ -376,10 +376,10 @@ pub async fn put_user(
     let user = metadata
         .users
         .iter()
-        .find(|user| user.username() == username)
+        .find(|user| user.userid() == userid)
         .cloned()
         .unwrap_or_else(|| {
-            let user = User::new_oauth(username.to_owned(), group, user_info);
+            let user = User::new_oauth(userid.to_owned(), group, user_info);
             metadata.users.push(user.clone());
             user
         });
@@ -395,7 +395,7 @@ pub async fn update_user_if_changed(
     user_info: user::UserInfo,
 ) -> Result<User, ObjectStorageError> {
     // Store the old username before modifying the user object
-    let old_username = user.username().to_string();
+    let old_username = user.userid().to_string();
     let User { ty, roles, .. } = &mut user;
     let UserType::OAuth(oauth_user) = ty else {
         unreachable!()
@@ -427,7 +427,7 @@ pub async fn update_user_if_changed(
     if let Some(entry) = metadata
         .users
         .iter_mut()
-        .find(|x| x.username() == old_username)
+        .find(|x| x.userid() == old_username)
     {
         entry.clone_from(&user);
         // migrate user references inside user groups

--- a/src/handlers/http/rbac.rs
+++ b/src/handlers/http/rbac.rs
@@ -125,15 +125,13 @@ pub async fn post_user(
         }
     }
     let _guard = UPDATE_LOCK.lock().await;
-    if Users.contains(&username) {
-        if Users.contains(&username)
-            || metadata.users.iter().any(|user| match &user.ty {
-                UserType::Native(basic) => basic.username == username,
-                UserType::OAuth(_) => false, // OAuth users should be created differently
-            })
-        {
-            return Err(RBACError::UserExists);
-        }
+    if Users.contains(&username) && Users.contains(&username)
+        || metadata.users.iter().any(|user| match &user.ty {
+            UserType::Native(basic) => basic.username == username,
+            UserType::OAuth(_) => false, // OAuth users should be created differently
+        })
+    {
+        return Err(RBACError::UserExists);
     }
 
     let (user, password) = user::User::new_basic(username.clone());

--- a/src/handlers/http/rbac.rs
+++ b/src/handlers/http/rbac.rs
@@ -42,7 +42,7 @@ use tokio::sync::Mutex;
 
 use super::modal::utils::rbac_utils::{get_metadata, put_metadata};
 
-// async aware lock for updating storage metadata and user map atomicically
+// async aware lock for updating storage metadata and user map atomically
 static UPDATE_LOCK: Mutex<()> = Mutex::const_new(());
 
 #[derive(serde::Serialize)]
@@ -66,13 +66,13 @@ impl From<&user::User> for User {
 }
 
 // Handler for GET /api/v1/user
-// returns list of all registerd users
+// returns list of all registered users
 pub async fn list_users() -> impl Responder {
     web::Json(Users.collect_user::<User>())
 }
 
 /// Handler for GET /api/v1/users
-/// returns list of all registerd users along with their roles and other info
+/// returns list of all registered users along with their roles and other info
 pub async fn list_users_prism() -> impl Responder {
     // get all users
     let prism_users = rbac::map::users().values().map(to_prism_user).collect_vec();
@@ -350,7 +350,7 @@ pub async fn remove_roles_from_user(
 }
 
 #[derive(Debug, Serialize)]
-#[serde(rename = "camelCase")]
+#[serde(rename_all = "camelCase")]
 pub struct InvalidUserGroupError {
     pub valid_name: bool,
     pub non_existent_roles: Vec<String>,
@@ -390,7 +390,7 @@ pub enum RBACError {
     InvalidUserGroupRequest(Box<InvalidUserGroupError>),
     #[error("{0}")]
     InvalidSyncOperation(String),
-    #[error("User group `{0}` is still being used")]
+    #[error("UserGroup `{0}` is still in use")]
     UserGroupNotEmpty(String),
     #[error("Resource `{0}` is still in use")]
     ResourceInUse(String),

--- a/src/handlers/http/rbac.rs
+++ b/src/handlers/http/rbac.rs
@@ -20,7 +20,11 @@ use std::collections::{HashMap, HashSet};
 
 use crate::{
     rbac::{
-        self, map::{read_user_groups, roles, users}, role::model::DefaultPrivilege, user::{self, UserType}, utils::to_prism_user, Users
+        self, Users,
+        map::{read_user_groups, roles, users},
+        role::model::DefaultPrivilege,
+        user::{self, UserType},
+        utils::to_prism_user,
     },
     storage::ObjectStorageError,
     validator::{self, error::UsernameValidationError},

--- a/src/handlers/http/rbac.rs
+++ b/src/handlers/http/rbac.rs
@@ -43,7 +43,7 @@ use tokio::sync::Mutex;
 use super::modal::utils::rbac_utils::{get_metadata, put_metadata};
 
 // async aware lock for updating storage metadata and user map atomically
-static UPDATE_LOCK: Mutex<()> = Mutex::const_new(());
+pub(crate) static UPDATE_LOCK: Mutex<()> = Mutex::const_new(());
 
 #[derive(serde::Serialize)]
 struct User {

--- a/src/handlers/http/rbac.rs
+++ b/src/handlers/http/rbac.rs
@@ -20,11 +20,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::{
     rbac::{
-        self, Users,
-        map::{read_user_groups, roles, users},
-        role::model::DefaultPrivilege,
-        user,
-        utils::to_prism_user,
+        self, map::{read_user_groups, roles, users}, role::model::DefaultPrivilege, user::{self, UserType}, utils::to_prism_user, Users
     },
     storage::ObjectStorageError,
     validator::{self, error::UsernameValidationError},
@@ -125,8 +121,15 @@ pub async fn post_user(
         }
     }
     let _guard = UPDATE_LOCK.lock().await;
-    if Users.contains(&username) || metadata.users.iter().any(|user| user.userid() == username) {
-        return Err(RBACError::UserExists);
+    if Users.contains(&username) {
+        if Users.contains(&username)
+            || metadata.users.iter().any(|user| match &user.ty {
+                UserType::Native(basic) => basic.username == username,
+                UserType::OAuth(_) => false, // OAuth users should be created differently
+            })
+        {
+            return Err(RBACError::UserExists);
+        }
     }
 
     let (user, password) = user::User::new_basic(username.clone());

--- a/src/handlers/http/rbac.rs
+++ b/src/handlers/http/rbac.rs
@@ -30,7 +30,7 @@ use crate::{
     validator::{self, error::UsernameValidationError},
 };
 use actix_web::{
-    Responder,
+    HttpResponse, Responder,
     http::header::ContentType,
     web::{self, Path},
 };
@@ -251,14 +251,14 @@ pub async fn delete_user(userid: web::Path<String>) -> Result<impl Responder, RB
 
     // update in mem table
     Users.delete_user(&userid);
-    Ok(format!("deleted user: {username}"))
+    Ok(HttpResponse::Ok().json(format!("deleted user: {username}")))
 }
 
 // Handler PATCH /user/{userid}/role/add => Add roles to a user
 pub async fn add_roles_to_user(
     userid: web::Path<String>,
     roles_to_add: web::Json<HashSet<String>>,
-) -> Result<String, RBACError> {
+) -> Result<impl Responder, RBACError> {
     let userid = userid.into_inner();
     let roles_to_add = roles_to_add.into_inner();
 
@@ -303,14 +303,14 @@ pub async fn add_roles_to_user(
     // update in mem table
     Users.add_roles(&userid.clone(), roles_to_add);
 
-    Ok(format!("Roles updated successfully for {username}"))
+    Ok(HttpResponse::Ok().json(format!("Roles updated successfully for {username}")))
 }
 
 // Handler PATCH /user/{userid}/role/remove => Remove roles from a user
 pub async fn remove_roles_from_user(
     userid: web::Path<String>,
     roles_to_remove: web::Json<HashSet<String>>,
-) -> Result<String, RBACError> {
+) -> Result<impl Responder, RBACError> {
     let userid = userid.into_inner();
     let roles_to_remove = roles_to_remove.into_inner();
 
@@ -367,7 +367,7 @@ pub async fn remove_roles_from_user(
     // update in mem table
     Users.remove_roles(&userid.clone(), roles_to_remove);
 
-    Ok(format!("Roles updated successfully for {username}"))
+    Ok(HttpResponse::Ok().json(format!("Roles updated successfully for {username}")))
 }
 
 #[derive(Debug, Serialize)]

--- a/src/handlers/http/rbac.rs
+++ b/src/handlers/http/rbac.rs
@@ -124,7 +124,7 @@ pub async fn post_user(
             return Err(RBACError::RolesDoNotExist(non_existent_roles));
         }
     }
-    let _ = UPDATE_LOCK.lock().await;
+    let _guard = UPDATE_LOCK.lock().await;
     if Users.contains(&username)
         || metadata
             .users
@@ -159,7 +159,7 @@ pub async fn post_gen_password(username: web::Path<String>) -> Result<impl Respo
     let mut new_hash = String::default();
     let mut metadata = get_metadata().await?;
 
-    let _ = UPDATE_LOCK.lock().await;
+    let _guard = UPDATE_LOCK.lock().await;
     let user::PassCode { password, hash } = user::Basic::gen_new_password();
     new_password.clone_from(&password);
     new_hash.clone_from(&hash);
@@ -235,7 +235,7 @@ pub async fn delete_user(username: web::Path<String>) -> Result<impl Responder, 
     if !Users.contains(&username) {
         return Err(RBACError::UserDoesNotExist);
     };
-    let _ = UPDATE_LOCK.lock().await;
+    let _guard = UPDATE_LOCK.lock().await;
 
     // delete from parseable.json first
     let mut metadata = get_metadata().await?;

--- a/src/handlers/http/rbac.rs
+++ b/src/handlers/http/rbac.rs
@@ -224,7 +224,7 @@ pub async fn get_role(userid: web::Path<String>) -> Result<impl Responder, RBACE
 // Handler for DELETE /api/v1/user/delete/{userid}
 pub async fn delete_user(userid: web::Path<String>) -> Result<impl Responder, RBACError> {
     let userid = userid.into_inner();
-
+    let _guard = UPDATE_LOCK.lock().await;
     // if user is a part of any groups then don't allow deletion
     if !Users.get_user_groups(&userid).is_empty() {
         return Err(RBACError::InvalidDeletionRequest(format!(
@@ -242,8 +242,6 @@ pub async fn delete_user(userid: web::Path<String>) -> Result<impl Responder, RB
     } else {
         return Err(RBACError::UserDoesNotExist);
     };
-
-    let _guard = UPDATE_LOCK.lock().await;
 
     // delete from parseable.json first
     let mut metadata = get_metadata().await?;

--- a/src/handlers/http/rbac.rs
+++ b/src/handlers/http/rbac.rs
@@ -185,6 +185,7 @@ pub async fn post_gen_password(username: web::Path<String>) -> Result<impl Respo
 // Handler for GET /api/v1/user/{userid}/role
 // returns role for a user if that user exists
 pub async fn get_role(userid: web::Path<String>) -> Result<impl Responder, RBACError> {
+    let userid = userid.into_inner();
     if !Users.contains(&userid) {
         return Err(RBACError::UserDoesNotExist);
     };

--- a/src/handlers/http/role.rs
+++ b/src/handlers/http/role.rs
@@ -52,7 +52,7 @@ pub async fn put(
     let mut session_refresh_users: HashSet<String> = HashSet::new();
     for user_group in read_user_groups().values() {
         if user_group.roles.contains(&name) {
-            session_refresh_users.extend(user_group.get_usernames());
+            session_refresh_users.extend(user_group.users.iter().map(|u| u.userid().to_string()));
         }
     }
 

--- a/src/handlers/http/role.rs
+++ b/src/handlers/http/role.rs
@@ -50,14 +50,14 @@ pub async fn put(
     // refresh the sessions of all users using this role
     // for this, iterate over all user_groups and users and create a hashset of users
     let mut session_refresh_users: HashSet<String> = HashSet::new();
-    for user_group in read_user_groups().values().cloned() {
+    for user_group in read_user_groups().values() {
         if user_group.roles.contains(&name) {
-            session_refresh_users.extend(user_group.users);
+            session_refresh_users.extend(user_group.get_usernames());
         }
     }
 
     // iterate over all users to see if they have this role
-    for user in users().values().cloned() {
+    for user in users().values() {
         if user.roles.contains(&name) {
             session_refresh_users.insert(user.username().to_string());
         }

--- a/src/handlers/http/role.rs
+++ b/src/handlers/http/role.rs
@@ -59,12 +59,12 @@ pub async fn put(
     // iterate over all users to see if they have this role
     for user in users().values() {
         if user.roles.contains(&name) {
-            session_refresh_users.insert(user.username().to_string());
+            session_refresh_users.insert(user.userid().to_string());
         }
     }
 
-    for username in session_refresh_users {
-        mut_sessions().remove_user(&username);
+    for userid in session_refresh_users {
+        mut_sessions().remove_user(&userid);
     }
 
     Ok(HttpResponse::Ok().finish())

--- a/src/rbac/map.rs
+++ b/src/rbac/map.rs
@@ -123,7 +123,7 @@ pub fn init(metadata: &StorageMetadata) {
 
     let mut users = Users::from(users);
     let admin = user::get_admin_user();
-    let admin_username = admin.username().to_owned();
+    let admin_username = admin.userid().to_owned();
     users.insert(admin);
 
     let mut sessions = Sessions::default();
@@ -274,8 +274,8 @@ impl Sessions {
         })
     }
 
-    pub fn get_username(&self, key: &SessionKey) -> Option<&String> {
-        self.active_sessions.get(key).map(|(username, _)| username)
+    pub fn get_userid(&self, key: &SessionKey) -> Option<&String> {
+        self.active_sessions.get(key).map(|(userid, _)| userid)
     }
 }
 
@@ -286,7 +286,7 @@ pub struct Users(HashMap<String, User>);
 
 impl Users {
     pub fn insert(&mut self, user: User) {
-        self.0.insert(user.username().to_owned(), user);
+        self.0.insert(user.userid().to_owned(), user);
     }
 }
 
@@ -296,7 +296,7 @@ impl From<Vec<User>> for Users {
         map.extend(
             users
                 .into_iter()
-                .map(|user| (user.username().to_owned(), user)),
+                .map(|user| (user.userid().to_owned(), user)),
         );
         map
     }

--- a/src/rbac/mod.rs
+++ b/src/rbac/mod.rs
@@ -50,80 +50,80 @@ pub struct Users;
 
 impl Users {
     pub fn put_user(&self, user: User) {
-        mut_sessions().remove_user(user.username());
+        mut_sessions().remove_user(user.userid());
         mut_users().insert(user);
     }
 
-    pub fn get_user_groups(&self, username: &str) -> HashSet<String> {
+    pub fn get_user_groups(&self, userid: &str) -> HashSet<String> {
         users()
-            .get(username)
+            .get(userid)
             .map(|user| user.user_groups.clone())
             .unwrap_or_default()
     }
 
-    pub fn get_user(&self, username: &str) -> Option<User> {
-        users().get(username).cloned()
+    pub fn get_user(&self, userid: &str) -> Option<User> {
+        users().get(userid).cloned()
     }
 
-    pub fn is_oauth(&self, username: &str) -> Option<bool> {
-        users().get(username).map(|user| user.is_oauth())
+    pub fn is_oauth(&self, userid: &str) -> Option<bool> {
+        users().get(userid).map(|user| user.is_oauth())
     }
 
     pub fn collect_user<T: for<'a> From<&'a User> + 'static>(&self) -> Vec<T> {
         users().values().map(|user| user.into()).collect_vec()
     }
 
-    pub fn get_role(&self, username: &str) -> Vec<String> {
+    pub fn get_role(&self, userid: &str) -> Vec<String> {
         users()
-            .get(username)
+            .get(userid)
             .map(|user| user.roles.iter().cloned().collect())
             .unwrap_or_default()
     }
 
-    pub fn delete_user(&self, username: &str) {
-        mut_users().remove(username);
-        mut_sessions().remove_user(username);
+    pub fn delete_user(&self, userid: &str) {
+        mut_users().remove(userid);
+        mut_sessions().remove_user(userid);
     }
 
     // caller ensures that this operation is valid for the user
-    pub fn change_password_hash(&self, username: &str, hash: &String) {
+    pub fn change_password_hash(&self, userid: &str, hash: &String) {
         if let Some(User {
             ty: UserType::Native(user),
             ..
-        }) = mut_users().get_mut(username)
+        }) = mut_users().get_mut(userid)
         {
             user.password_hash.clone_from(hash);
-            mut_sessions().remove_user(username);
+            mut_sessions().remove_user(userid);
         };
     }
 
-    pub fn add_roles(&self, username: &str, roles: HashSet<String>) {
-        if let Some(user) = mut_users().get_mut(username) {
+    pub fn add_roles(&self, userid: &str, roles: HashSet<String>) {
+        if let Some(user) = mut_users().get_mut(userid) {
             user.roles.extend(roles);
-            mut_sessions().remove_user(username)
+            mut_sessions().remove_user(userid)
         };
     }
 
-    pub fn remove_roles(&self, username: &str, roles: HashSet<String>) {
-        if let Some(user) = mut_users().get_mut(username) {
+    pub fn remove_roles(&self, userid: &str, roles: HashSet<String>) {
+        if let Some(user) = mut_users().get_mut(userid) {
             let diff = HashSet::from_iter(user.roles.difference(&roles).cloned());
             user.roles = diff;
-            mut_sessions().remove_user(username)
+            mut_sessions().remove_user(userid)
         };
     }
 
-    pub fn contains(&self, username: &str) -> bool {
-        users().contains_key(username)
+    pub fn contains(&self, userid: &str) -> bool {
+        users().contains_key(userid)
     }
 
     pub fn get_permissions(&self, session: &SessionKey) -> Vec<Permission> {
         let mut permissions = sessions().get(session).cloned().unwrap_or_default();
 
-        let Some(username) = self.get_username_from_session(session) else {
+        let Some(userid) = self.get_userid_from_session(session) else {
             return permissions.into_iter().collect_vec();
         };
 
-        let user_groups = self.get_user_groups(&username);
+        let user_groups = self.get_user_groups(&userid);
         for group in user_groups {
             if let Some(group) = read_user_groups().get(&group) {
                 let group_roles = &group.roles;
@@ -149,7 +149,7 @@ impl Users {
 
     pub fn new_session(&self, user: &User, session: SessionKey) {
         mut_sessions().track_new(
-            user.username().to_owned(),
+            user.userid().to_owned(),
             session,
             Utc::now() + Days::new(7),
             roles_to_permission(user.roles()),
@@ -199,8 +199,8 @@ impl Users {
         Response::UnAuthorized
     }
 
-    pub fn get_username_from_session(&self, session: &SessionKey) -> Option<String> {
-        sessions().get_username(session).cloned()
+    pub fn get_userid_from_session(&self, session: &SessionKey) -> Option<String> {
+        sessions().get_userid(session).cloned()
     }
 }
 

--- a/src/rbac/user.rs
+++ b/src/rbac/user.rs
@@ -66,14 +66,14 @@ impl User {
         )
     }
 
-    pub fn new_oauth(username: String, roles: HashSet<String>, user_info: UserInfo) -> Self {
+    pub fn new_oauth(userid: String, roles: HashSet<String>, user_info: UserInfo) -> Self {
         Self {
             ty: UserType::OAuth(OAuth {
                 userid: user_info
                     .sub
                     .clone()
                     .or_else(|| user_info.name.clone())
-                    .unwrap_or(username),
+                    .unwrap_or(userid),
                 user_info,
             }),
             roles,
@@ -81,13 +81,25 @@ impl User {
         }
     }
 
-    pub fn username(&self) -> &str {
+    pub fn userid(&self) -> &str {
         match self.ty {
             UserType::Native(Basic { ref username, .. }) => username,
-            UserType::OAuth(OAuth {
-                userid: ref username,
-                ..
-            }) => username,
+            UserType::OAuth(OAuth { ref userid, .. }) => userid,
+        }
+    }
+
+    pub fn username_by_userid(&self) -> String {
+        match &self.ty {
+            UserType::Native(basic) => basic.username.clone(),
+            UserType::OAuth(oauth) => {
+                let user_info = oauth.user_info.clone();
+                user_info.name.clone().unwrap_or_else(|| {
+                    user_info
+                        .email
+                        .clone()
+                        .unwrap_or_else(|| oauth.userid.clone())
+                })
+            }
         }
     }
 

--- a/src/rbac/user.rs
+++ b/src/rbac/user.rs
@@ -204,11 +204,23 @@ impl From<openid::Userinfo> for UserInfo {
 }
 
 /// Represents a user in a UserGroup - simplified structure for both user types
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct GroupUser {
     pub userid: String,
     pub username: String,
     pub method: String,
+}
+
+impl PartialEq for GroupUser {
+    fn eq(&self, other: &Self) -> bool {
+        self.userid == other.userid
+    }
+}
+impl Eq for GroupUser {}
+impl std::hash::Hash for GroupUser {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.userid.hash(state)
+    }
 }
 
 impl GroupUser {

--- a/src/rbac/user.rs
+++ b/src/rbac/user.rs
@@ -69,11 +69,7 @@ impl User {
     pub fn new_oauth(userid: String, roles: HashSet<String>, user_info: UserInfo) -> Self {
         Self {
             ty: UserType::OAuth(OAuth {
-                userid: user_info
-                    .sub
-                    .clone()
-                    .or_else(|| user_info.name.clone())
-                    .unwrap_or(userid),
+                userid: user_info.sub.clone().unwrap_or(userid),
                 user_info,
             }),
             roles,

--- a/src/rbac/user.rs
+++ b/src/rbac/user.rs
@@ -407,10 +407,7 @@ impl UserGroup {
 
     /// Get all user IDs in this group
     pub fn get_userids(&self) -> Vec<String> {
-        self.users
-            .iter()
-            .map(|u| u.userid().to_string())
-            .collect()
+        self.users.iter().map(|u| u.userid().to_string()).collect()
     }
 
     /// Add users by converting from User references

--- a/src/rbac/user.rs
+++ b/src/rbac/user.rs
@@ -315,7 +315,7 @@ impl UserGroup {
             // validate that the users exist
             for group_user in &self.users {
                 if !users().contains_key(group_user.userid()) {
-                    non_existent_users.push(group_user.username().to_string());
+                    non_existent_users.push(group_user.userid().to_string());
                 }
             }
         }
@@ -405,11 +405,11 @@ impl UserGroup {
         Ok(())
     }
 
-    /// Get all usernames in this group
-    pub fn get_usernames(&self) -> Vec<String> {
+    /// Get all user IDs in this group
+    pub fn get_userids(&self) -> Vec<String> {
         self.users
             .iter()
-            .map(|u| u.username().to_string())
+            .map(|u| u.userid().to_string())
             .collect()
     }
 

--- a/src/rbac/utils.rs
+++ b/src/rbac/utils.rs
@@ -30,12 +30,12 @@ use super::{
 
 pub fn to_prism_user(user: &User) -> UsersPrism {
     let (id, username, method, email, picture) = match &user.ty {
-        UserType::Native(_) => (user.username(), user.username(), "native", None, None),
+        UserType::Native(_) => (user.userid(), user.userid(), "native", None, None),
         UserType::OAuth(oauth) => {
-            let username = user.username();
-            let display_name = oauth.user_info.name.as_deref().unwrap_or(username);
+            let userid = user.userid();
+            let display_name = oauth.user_info.name.as_deref().unwrap_or(userid);
             (
-                username,
+                userid,
                 display_name,
                 "oauth",
                 oauth.user_info.email.clone(),
@@ -56,7 +56,7 @@ pub fn to_prism_user(user: &User) -> UsersPrism {
     let mut group_roles: HashMap<String, HashMap<String, Vec<DefaultPrivilege>>> = HashMap::new();
     let mut user_groups = HashSet::new();
     // user might be part of some user groups, fetch the roles from there as well
-    for user_group in Users.get_user_groups(user.username()) {
+    for user_group in Users.get_user_groups(user.userid()) {
         if let Some(group) = read_user_groups().get(&user_group) {
             let ug_roles: HashMap<String, Vec<DefaultPrivilege>> = group
                 .roles

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -59,7 +59,7 @@ pub fn extract_datetime(path: &str) -> Option<NaiveDateTime> {
 
 pub fn get_user_from_request(req: &HttpRequest) -> Result<String, RBACError> {
     let session_key = extract_session_key_from_req(req).unwrap();
-    let user_id = Users.get_username_from_session(&session_key);
+    let user_id = Users.get_userid_from_session(&session_key);
     if user_id.is_none() {
         return Err(RBACError::UserDoesNotExist);
     }


### PR DESCRIPTION
new structure for POST /usergroup

```
{
  "name": "parseable",
  "roles": [],
  "users": [
    {
      "username": "nikhil",
      "method": "native"
    }
  ]
}
```

new structure for add/remove user - PATCH /usergroup/{name}/add(remove)

```
{
  "users": [
    {
      "username": "authentik Default Admin",
      "method": "oauth"
    }
  ]
}
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a Prism user lookup endpoint.

- Refactor
  - Switched RBAC, sessions, and group membership to canonical user IDs (userid) across APIs, routes and storage; user-facing endpoints now use {userid}.
  - Introduced a canonical group-user representation and migrated role/user management and session refresh to operate on user IDs.
  - Centralized update concurrency guard and standardized several handlers to return HTTP 200 responses.

- Documentation
  - Route docs and comments updated to reflect userid-based endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->