### PR TITLE
Feat: Metastore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,6 +2002,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "erased-serde"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3de9ad4541d99dc22b59134e7ff8dc3d6c988c89ecd7324bf10a8362b07a2afa"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3485,6 +3494,7 @@ dependencies = [
  "crossterm",
  "datafusion",
  "derive_more 1.0.0",
+ "erased-serde",
  "fs_extra",
  "futures",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3492,6 +3492,7 @@ dependencies = [
  "clokwerk",
  "cookie 0.18.1",
  "crossterm",
+ "dashmap",
  "datafusion",
  "derive_more 1.0.0",
  "erased-serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,7 @@ futures-core = "0.3.31"
 tempfile = "3.20.0"
 lazy_static = "1.4.0"
 prost = "0.13.1"
+dashmap = "6.1.0"
 
 [build-dependencies]
 cargo_toml = "0.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ sha2 = "0.10.8"
 
 # Serialization and Data Formats
 byteorder = "1.4.3"
+erased-serde = "=0.3.16"
 serde = { version = "1.0", features = ["rc", "derive"] }
 serde_json = "1.0"
 serde_repr = "0.1.17"

--- a/src/alerts/alert_structs.rs
+++ b/src/alerts/alert_structs.rs
@@ -531,11 +531,11 @@ pub struct NotificationStateRequest {
 }
 
 impl MetastoreObject for AlertConfig {
-    fn get_id(&self) -> String {
+    fn get_object_id(&self) -> String {
         self.id.to_string()
     }
 
-    fn get_path(&self) -> String {
+    fn get_object_path(&self) -> String {
         alert_json_path(self.id).to_string()
     }
 }

--- a/src/alerts/alert_structs.rs
+++ b/src/alerts/alert_structs.rs
@@ -35,6 +35,7 @@ use crate::{
     },
     metastore::metastore_traits::MetastoreObject,
     query::resolve_stream_names,
+    storage::object_storage::alert_json_path,
 };
 
 /// Helper struct for basic alert fields during migration
@@ -530,7 +531,11 @@ pub struct NotificationStateRequest {
 }
 
 impl MetastoreObject for AlertConfig {
-    // fn get_object(self) -> T {
-    //     return self;
-    // }
+    fn get_id(&self) -> String {
+        self.id.to_string()
+    }
+
+    fn get_path(&self) -> String {
+        alert_json_path(self.id).to_string()
+    }
 }

--- a/src/alerts/alert_structs.rs
+++ b/src/alerts/alert_structs.rs
@@ -33,6 +33,7 @@ use crate::{
         alert_traits::AlertTrait,
         target::{NotificationConfig, TARGETS},
     },
+    metastore::metastore_traits::MetastoreObject,
     query::resolve_stream_names,
 };
 
@@ -526,4 +527,10 @@ impl AlertQueryResult {
 #[derive(serde::Deserialize)]
 pub struct NotificationStateRequest {
     pub state: String,
+}
+
+impl MetastoreObject for AlertConfig {
+    // fn get_object(self) -> T {
+    //     return self;
+    // }
 }

--- a/src/alerts/alert_traits.rs
+++ b/src/alerts/alert_traits.rs
@@ -22,6 +22,7 @@ use crate::{
         alert_enums::NotificationState,
         alert_structs::{Context, ThresholdConfig},
     },
+    metastore::metastore_traits::MetastoreObject,
     rbac::map::SessionKey,
 };
 use chrono::{DateTime, Utc};
@@ -47,7 +48,7 @@ pub trait MessageCreation {
 }
 
 #[async_trait]
-pub trait AlertTrait: Debug + Send + Sync {
+pub trait AlertTrait: Debug + Send + Sync + MetastoreObject {
     async fn eval_alert(&self) -> Result<Option<String>, AlertError>;
     async fn validate(&self, session_key: &SessionKey) -> Result<(), AlertError>;
     async fn update_notification_state(

--- a/src/alerts/alert_types.rs
+++ b/src/alerts/alert_types.rs
@@ -170,11 +170,13 @@ impl AlertTrait for ThresholdAlert {
         &mut self,
         new_notification_state: NotificationState,
     ) -> Result<(), AlertError> {
-        let store = PARSEABLE.storage.get_object_store();
         // update state in memory
         self.notification_state = new_notification_state;
         // update on disk
-        store.put_alert(self.id, &self.to_alert_config()).await?;
+        PARSEABLE
+            .metastore
+            .update_object(&self.to_alert_config(), &self.get_id().to_string())
+            .await?;
 
         Ok(())
     }
@@ -184,7 +186,6 @@ impl AlertTrait for ThresholdAlert {
         new_state: AlertState,
         trigger_notif: Option<String>,
     ) -> Result<(), AlertError> {
-        let store = PARSEABLE.storage.get_object_store();
         if self.state.eq(&AlertState::Disabled) {
             warn!(
                 "Alert- {} is currently Disabled. Updating state to {new_state}.",
@@ -199,7 +200,10 @@ impl AlertTrait for ThresholdAlert {
             }
 
             // update on disk
-            store.put_alert(self.id, &self.to_alert_config()).await?;
+            PARSEABLE
+                .metastore
+                .update_object(&self.to_alert_config(), &self.get_id().to_string())
+                .await?;
             // The task should have already been removed from the list of running tasks
             return Ok(());
         }
@@ -232,7 +236,10 @@ impl AlertTrait for ThresholdAlert {
         }
 
         // update on disk
-        store.put_alert(self.id, &self.to_alert_config()).await?;
+        PARSEABLE
+            .metastore
+            .update_object(&self.to_alert_config(), &self.get_id().to_string())
+            .await?;
 
         if trigger_notif.is_some() && self.notification_state.eq(&NotificationState::Notify) {
             trace!("trigger notif on-\n{}", self.state);

--- a/src/alerts/alert_types.rs
+++ b/src/alerts/alert_types.rs
@@ -182,14 +182,14 @@ impl AlertTrait for ThresholdAlert {
         &mut self,
         new_notification_state: NotificationState,
     ) -> Result<(), AlertError> {
+        // update state in memory
+        self.notification_state = new_notification_state;
+
         // update on disk
         PARSEABLE
             .metastore
             .put_alert(&self.to_alert_config())
             .await?;
-        // update state in memory
-        self.notification_state = new_notification_state;
-
         Ok(())
     }
 

--- a/src/alerts/alert_types.rs
+++ b/src/alerts/alert_types.rs
@@ -35,9 +35,11 @@ use crate::{
         target::{self, NotificationConfig},
     },
     handlers::http::query::create_streams_for_distributed,
+    metastore::metastore_traits::MetastoreObject,
     parseable::PARSEABLE,
     query::resolve_stream_names,
     rbac::map::SessionKey,
+    storage::object_storage::alert_json_path,
     utils::user_auth_for_query,
 };
 
@@ -63,6 +65,16 @@ pub struct ThresholdAlert {
     pub tags: Option<Vec<String>>,
     pub datasets: Vec<String>,
     pub last_triggered_at: Option<DateTime<Utc>>,
+}
+
+impl MetastoreObject for ThresholdAlert {
+    fn get_object_path(&self) -> String {
+        alert_json_path(self.id).to_string()
+    }
+
+    fn get_object_id(&self) -> String {
+        self.id.to_string()
+    }
 }
 
 #[async_trait]

--- a/src/alerts/alert_types.rs
+++ b/src/alerts/alert_types.rs
@@ -182,13 +182,13 @@ impl AlertTrait for ThresholdAlert {
         &mut self,
         new_notification_state: NotificationState,
     ) -> Result<(), AlertError> {
-        // update state in memory
-        self.notification_state = new_notification_state;
         // update on disk
         PARSEABLE
             .metastore
             .put_alert(&self.to_alert_config())
             .await?;
+        // update state in memory
+        self.notification_state = new_notification_state;
 
         Ok(())
     }

--- a/src/alerts/alert_types.rs
+++ b/src/alerts/alert_types.rs
@@ -175,7 +175,7 @@ impl AlertTrait for ThresholdAlert {
         // update on disk
         PARSEABLE
             .metastore
-            .update_object(&self.to_alert_config(), &self.get_id().to_string())
+            .put_alert(&self.to_alert_config())
             .await?;
 
         Ok(())
@@ -202,7 +202,7 @@ impl AlertTrait for ThresholdAlert {
             // update on disk
             PARSEABLE
                 .metastore
-                .update_object(&self.to_alert_config(), &self.get_id().to_string())
+                .put_alert(&self.to_alert_config())
                 .await?;
             // The task should have already been removed from the list of running tasks
             return Ok(());
@@ -238,7 +238,7 @@ impl AlertTrait for ThresholdAlert {
         // update on disk
         PARSEABLE
             .metastore
-            .update_object(&self.to_alert_config(), &self.get_id().to_string())
+            .put_alert(&self.to_alert_config())
             .await?;
 
         if trigger_notif.is_some() && self.notification_state.eq(&NotificationState::Notify) {

--- a/src/alerts/mod.rs
+++ b/src/alerts/mod.rs
@@ -948,7 +948,7 @@ pub enum AlertError {
     Unimplemented(String),
     #[error("{0}")]
     ValidationFailure(String),
-    #[error("{0}")]
+    #[error(transparent)]
     MetastoreError(#[from] MetastoreError),
 }
 
@@ -1245,8 +1245,6 @@ impl AlertManagerTrait for Alerts {
         alert_id: Ulid,
         new_notification_state: NotificationState,
     ) -> Result<(), AlertError> {
-        // let store = PARSEABLE.storage.get_object_store();
-
         // read and modify alert
         let mut write_access = self.alerts.write().await;
         let mut alert: Box<dyn AlertTrait> = if let Some(alert) = write_access.get(&alert_id) {

--- a/src/alerts/mod.rs
+++ b/src/alerts/mod.rs
@@ -995,7 +995,7 @@ impl AlertManagerTrait for Alerts {
         let mut map = self.alerts.write().await;
 
         // Get alerts path and read raw bytes for migration handling
-        let raw_objects = PARSEABLE.metastore.get_alerts().await.unwrap_or_default();
+        let raw_objects = PARSEABLE.metastore.get_alerts().await?;
 
         for raw_bytes in raw_objects {
             // First, try to parse as JSON Value to check version

--- a/src/alerts/mod.rs
+++ b/src/alerts/mod.rs
@@ -992,10 +992,10 @@ impl actix_web::ResponseError for AlertError {
 impl AlertManagerTrait for Alerts {
     /// Loads alerts from disk, blocks
     async fn load(&self) -> anyhow::Result<()> {
-        let mut map = self.alerts.write().await;
-
         // Get alerts path and read raw bytes for migration handling
         let raw_objects = PARSEABLE.metastore.get_alerts().await?;
+
+        let mut map = self.alerts.write().await;
 
         for raw_bytes in raw_objects {
             // First, try to parse as JSON Value to check version

--- a/src/alerts/mod.rs
+++ b/src/alerts/mod.rs
@@ -63,7 +63,7 @@ use crate::parseable::{PARSEABLE, StreamNotFound};
 use crate::query::{QUERY_SESSION, resolve_stream_names};
 use crate::rbac::map::SessionKey;
 use crate::storage;
-use crate::storage::{ALERTS_ROOT_DIRECTORY, ObjectStorageError};
+use crate::storage::ObjectStorageError;
 use crate::sync::alert_runtime;
 use crate::utils::user_auth_for_query;
 
@@ -136,10 +136,7 @@ impl AlertConfig {
         };
 
         // Save the migrated alert back to storage
-        PARSEABLE
-            .metastore
-            .update_object(&migrated_alert, &basic_fields.id.to_string())
-            .await?;
+        PARSEABLE.metastore.put_alert(&migrated_alert).await?;
 
         Ok(migrated_alert)
     }
@@ -998,11 +995,7 @@ impl AlertManagerTrait for Alerts {
         let mut map = self.alerts.write().await;
 
         // Get alerts path and read raw bytes for migration handling
-        let raw_objects = PARSEABLE
-            .metastore
-            .get_objects(ALERTS_ROOT_DIRECTORY)
-            .await
-            .unwrap_or_default();
+        let raw_objects = PARSEABLE.metastore.get_alerts().await.unwrap_or_default();
 
         for raw_bytes in raw_objects {
             // First, try to parse as JSON Value to check version

--- a/src/alerts/target.rs
+++ b/src/alerts/target.rs
@@ -56,9 +56,9 @@ pub struct TargetConfigs {
 impl TargetConfigs {
     /// Loads alerts from disk, blocks
     pub async fn load(&self) -> anyhow::Result<()> {
+        let targets = PARSEABLE.metastore.get_targets().await?;
         let mut map = self.target_configs.write().await;
-
-        for target in PARSEABLE.metastore.get_targets().await.unwrap_or_default() {
+        for target in targets {
             map.insert(target.id, target);
         }
 
@@ -66,9 +66,9 @@ impl TargetConfigs {
     }
 
     pub async fn update(&self, target: Target) -> Result<(), AlertError> {
+        PARSEABLE.metastore.put_target(&target).await?;
         let mut map = self.target_configs.write().await;
         map.insert(target.id, target.clone());
-        PARSEABLE.metastore.put_target(&target).await?;
         Ok(())
     }
 

--- a/src/catalog/manifest.rs
+++ b/src/catalog/manifest.rs
@@ -21,6 +21,8 @@ use std::collections::HashMap;
 use itertools::Itertools;
 use parquet::{file::reader::FileReader, format::SortingColumn};
 
+use crate::metastore::metastore_traits::MetastoreObject;
+
 use super::column::Column;
 
 #[derive(
@@ -85,6 +87,16 @@ impl Manifest {
         } else {
             self.files.push(change)
         }
+    }
+}
+
+impl MetastoreObject for Manifest {
+    fn get_object_path(&self) -> String {
+        unimplemented!()
+    }
+
+    fn get_object_id(&self) -> String {
+        unimplemented!()
     }
 }
 

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -307,6 +307,7 @@ async fn handle_existing_partition(
                 stream_name,
                 manifests[pos].time_lower_bound,
                 manifests[pos].time_upper_bound,
+                Some(manifests[pos].manifest_path.clone()),
             )
             .await
             .map_err(|e| ObjectStorageError::MetastoreError(Box::new(e.to_detail())))?

--- a/src/enterprise/utils.rs
+++ b/src/enterprise/utils.rs
@@ -100,6 +100,7 @@ pub async fn fetch_parquet_file_paths(
                     stream,
                     manifest_item.time_lower_bound,
                     manifest_item.time_upper_bound,
+                    Some(manifest_item.manifest_path),
                 )
                 .await
                 .map_err(|e| ObjectStorageError::MetastoreError(Box::new(e.to_detail())))?

--- a/src/handlers/http/alerts.rs
+++ b/src/handlers/http/alerts.rs
@@ -208,14 +208,14 @@ pub async fn post(
 
     alert.validate(&session_key).await?;
 
-    // now that we've validated that the user can run this query
-    // move on to saving the alert in ObjectStore
-    alerts.update(alert).await;
-
+    // update persistent storage first
     PARSEABLE
         .metastore
         .put_alert(&alert.to_alert_config())
         .await?;
+
+    // update in memory
+    alerts.update(alert).await;
 
     // start the task
     alerts.start_task(alert.clone_box()).await?;

--- a/src/handlers/http/alerts.rs
+++ b/src/handlers/http/alerts.rs
@@ -216,7 +216,7 @@ pub async fn post(
 
     PARSEABLE
         .metastore
-        .create_object(&alert.to_alert_config(), &alert.get_id().to_string())
+        .put_alert(&alert.to_alert_config())
         .await?;
 
     // start the task

--- a/src/handlers/http/alerts.rs
+++ b/src/handlers/http/alerts.rs
@@ -262,10 +262,7 @@ pub async fn delete(req: HttpRequest, alert_id: Path<Ulid>) -> Result<impl Respo
     // validate that the user has access to the tables mentioned in the query
     user_auth_for_query(&session_key, alert.get_query()).await?;
 
-    PARSEABLE
-        .metastore
-        .delete_object(alert_json_path(alert_id).as_ref())
-        .await?;
+    PARSEABLE.metastore.delete_alert(&*alert).await?;
 
     // delete from memory
     alerts.delete(alert_id).await?;

--- a/src/handlers/http/ingest.rs
+++ b/src/handlers/http/ingest.rs
@@ -482,34 +482,36 @@ pub enum PostError {
 
 impl actix_web::ResponseError for PostError {
     fn status_code(&self) -> http::StatusCode {
+        use PostError::*;
         match self {
-            PostError::SerdeError(_) => StatusCode::BAD_REQUEST,
-            PostError::Header(_) => StatusCode::BAD_REQUEST,
-            PostError::Event(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            PostError::Invalid(_) => StatusCode::BAD_REQUEST,
-            PostError::CreateStream(CreateStreamError::StreamNameValidation(_)) => {
-                StatusCode::BAD_REQUEST
-            }
-            PostError::CreateStream(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            PostError::StreamNotFound(_) => StatusCode::NOT_FOUND,
-            PostError::CustomError(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            PostError::NetworkError(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            PostError::ObjectStorageError(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            PostError::DashboardError(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            PostError::FiltersError(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            PostError::StreamError(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            PostError::JsonFlattenError(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            PostError::OtelNotSupported => StatusCode::BAD_REQUEST,
-            PostError::InternalStream(_) => StatusCode::BAD_REQUEST,
-            PostError::IncorrectLogSource(_) => StatusCode::BAD_REQUEST,
-            PostError::IngestionNotAllowed => StatusCode::BAD_REQUEST,
-            PostError::MissingTimePartition(_) => StatusCode::BAD_REQUEST,
-            PostError::KnownFormat(_) => StatusCode::BAD_REQUEST,
-            PostError::IncorrectLogFormat(_) => StatusCode::BAD_REQUEST,
-            PostError::FieldsCountLimitExceeded(_, _, _) => StatusCode::BAD_REQUEST,
-            PostError::InvalidQueryParameter => StatusCode::BAD_REQUEST,
-            PostError::MissingQueryParameter => StatusCode::BAD_REQUEST,
-            PostError::MetastoreError(e) => e.status_code(),
+            SerdeError(_)
+            | Header(_)
+            | Invalid(_)
+            | InternalStream(_)
+            | IncorrectLogSource(_)
+            | IngestionNotAllowed
+            | MissingTimePartition(_)
+            | KnownFormat(_)
+            | IncorrectLogFormat(_)
+            | FieldsCountLimitExceeded(_, _, _)
+            | InvalidQueryParameter
+            | MissingQueryParameter
+            | CreateStream(CreateStreamError::StreamNameValidation(_))
+            | OtelNotSupported => StatusCode::BAD_REQUEST,
+
+            Event(_)
+            | CreateStream(_)
+            | CustomError(_)
+            | NetworkError(_)
+            | ObjectStorageError(_)
+            | DashboardError(_)
+            | FiltersError(_)
+            | StreamError(_)
+            | JsonFlattenError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+
+            StreamNotFound(_) => StatusCode::NOT_FOUND,
+
+            MetastoreError(e) => e.status_code(),
         }
     }
 

--- a/src/handlers/http/logstream.rs
+++ b/src/handlers/http/logstream.rs
@@ -90,8 +90,7 @@ pub async fn list(req: HttpRequest) -> Result<impl Responder, StreamError> {
     let res = PARSEABLE
         .metastore
         .list_streams()
-        .await
-        .unwrap()
+        .await?
         .into_iter()
         .filter(|logstream| {
             Users.authorize(key.clone(), Action::ListStream, Some(logstream), None)

--- a/src/handlers/http/logstream.rs
+++ b/src/handlers/http/logstream.rs
@@ -473,6 +473,19 @@ pub async fn delete_stream_hot_tier(
 
     hot_tier_manager.delete_hot_tier(&stream_name).await?;
 
+    let mut stream_metadata: ObjectStoreFormat = serde_json::from_slice(
+        &PARSEABLE
+            .metastore
+            .get_stream_json(&stream_name, false)
+            .await?,
+    )?;
+    stream_metadata.hot_tier_enabled = false;
+
+    PARSEABLE
+        .metastore
+        .put_stream_json(&stream_metadata, &stream_name)
+        .await?;
+
     Ok((
         format!("hot tier deleted for stream {stream_name}"),
         StatusCode::OK,

--- a/src/handlers/http/logstream.rs
+++ b/src/handlers/http/logstream.rs
@@ -28,7 +28,7 @@ use crate::rbac::Users;
 use crate::rbac::role::Action;
 use crate::stats::{Stats, event_labels_date, storage_size_labels_date};
 use crate::storage::retention::Retention;
-use crate::storage::{StreamInfo, StreamType};
+use crate::storage::{ObjectStoreFormat, StreamInfo, StreamType};
 use crate::utils::actix::extract_session_key_from_req;
 use crate::utils::json::flatten::{
     self, convert_to_array, generic_flattening, has_more_than_max_allowed_levels,
@@ -413,7 +413,12 @@ pub async fn put_stream_hot_tier(
         .put_hot_tier(&stream_name, &mut hottier)
         .await?;
     let storage = PARSEABLE.storage().get_object_store();
-    let mut stream_metadata = storage.get_object_store_format(&stream_name).await?;
+    let mut stream_metadata: ObjectStoreFormat = serde_json::from_slice(
+        &PARSEABLE
+            .metastore
+            .get_stream_json(&stream_name, false)
+            .await?,
+    )?;
     stream_metadata.hot_tier_enabled = true;
     storage
         .put_stream_manifest(&stream_name, &stream_metadata)
@@ -491,6 +496,7 @@ pub mod error {
 
     use crate::{
         hottier::HotTierError,
+        metastore::MetastoreError,
         parseable::StreamNotFound,
         storage::ObjectStorageError,
         validator::error::{
@@ -563,6 +569,8 @@ pub mod error {
         HotTierError(#[from] HotTierError),
         #[error("Invalid query parameter: {0}")]
         InvalidQueryParameter(String),
+        #[error("{0:?}")]
+        MetastoreError(#[from] MetastoreError),
     }
 
     impl actix_web::ResponseError for StreamError {
@@ -599,13 +607,21 @@ pub mod error {
                 StreamError::HotTierValidation(_) => StatusCode::BAD_REQUEST,
                 StreamError::HotTierError(_) => StatusCode::INTERNAL_SERVER_ERROR,
                 StreamError::InvalidQueryParameter(_) => StatusCode::BAD_REQUEST,
+                StreamError::MetastoreError(e) => e.status_code(),
             }
         }
 
         fn error_response(&self) -> actix_web::HttpResponse<actix_web::body::BoxBody> {
-            actix_web::HttpResponse::build(self.status_code())
-                .insert_header(ContentType::plaintext())
-                .body(self.to_string())
+            match self {
+                StreamError::MetastoreError(metastore_error) => {
+                    actix_web::HttpResponse::build(metastore_error.status_code())
+                        .insert_header(ContentType::json())
+                        .json(metastore_error.to_detail())
+                }
+                _ => actix_web::HttpResponse::build(self.status_code())
+                    .insert_header(ContentType::plaintext())
+                    .body(self.to_string()),
+            }
         }
     }
 }

--- a/src/handlers/http/mod.rs
+++ b/src/handlers/http/mod.rs
@@ -21,11 +21,10 @@ use actix_web::Responder;
 use arrow_schema::Schema;
 use cluster::get_node_info;
 use http::StatusCode;
-use itertools::Itertools;
 use modal::{NodeMetadata, NodeType};
 use serde_json::Value;
 
-use crate::{INTRA_CLUSTER_CLIENT, parseable::PARSEABLE, storage::STREAM_ROOT_DIRECTORY};
+use crate::{INTRA_CLUSTER_CLIENT, parseable::PARSEABLE};
 
 use self::query::Query;
 
@@ -89,19 +88,7 @@ pub fn base_path_without_preceding_slash() -> String {
 ///
 /// An `anyhow::Result` containing the `arrow_schema::Schema` for the specified stream.
 pub async fn fetch_schema(stream_name: &str) -> anyhow::Result<arrow_schema::Schema> {
-    let path_prefix =
-        relative_path::RelativePathBuf::from(format!("{stream_name}/{STREAM_ROOT_DIRECTORY}"));
-    let store = PARSEABLE.storage.get_object_store();
-    let res: Vec<Schema> = store
-        .get_objects(
-            Some(&path_prefix),
-            Box::new(|file_name: String| file_name.contains(".schema")),
-        )
-        .await?
-        .iter()
-        // we should be able to unwrap as we know the data is valid schema
-        .map(|byte_obj| serde_json::from_slice(byte_obj).expect("data is valid json"))
-        .collect_vec();
+    let res: Vec<Schema> = PARSEABLE.metastore.get_all_schemas(stream_name).await?;
 
     let new_schema = Schema::try_merge(res)?;
     Ok(new_schema)

--- a/src/handlers/http/modal/query/querier_logstream.rs
+++ b/src/handlers/http/modal/query/querier_logstream.rs
@@ -26,7 +26,6 @@ use actix_web::{
 use bytes::Bytes;
 use chrono::Utc;
 use http::StatusCode;
-use relative_path::RelativePathBuf;
 use tokio::sync::Mutex;
 use tracing::{error, warn};
 
@@ -48,7 +47,7 @@ use crate::{
     hottier::HotTierManager,
     parseable::{PARSEABLE, StreamNotFound},
     stats,
-    storage::{ObjectStoreFormat, STREAM_ROOT_DIRECTORY, StreamType},
+    storage::{ObjectStoreFormat, StreamType},
 };
 const STATS_DATE_QUERY_PARAM: &str = "date";
 
@@ -165,14 +164,9 @@ pub async fn get_stats(
 
         if !date_value.is_empty() {
             // this function requires all the ingestor stream jsons
-            let path = RelativePathBuf::from_iter([&stream_name, STREAM_ROOT_DIRECTORY]);
             let obs = PARSEABLE
-                .storage
-                .get_object_store()
-                .get_objects(
-                    Some(&path),
-                    Box::new(|file_name| file_name.ends_with("stream.json")),
-                )
+                .metastore
+                .get_all_stream_jsons(&stream_name, None)
                 .await?;
 
             let mut stream_jsons = Vec::new();

--- a/src/handlers/http/modal/query/querier_logstream.rs
+++ b/src/handlers/http/modal/query/querier_logstream.rs
@@ -163,7 +163,6 @@ pub async fn get_stats(
         })?;
 
         if !date_value.is_empty() {
-            // this function requires all the ingestor stream jsons
             let obs = PARSEABLE
                 .metastore
                 .get_all_stream_jsons(&stream_name, None)

--- a/src/handlers/http/modal/utils/rbac_utils.rs
+++ b/src/handlers/http/modal/utils/rbac_utils.rs
@@ -23,12 +23,12 @@ use crate::{
 
 pub async fn get_metadata() -> Result<crate::storage::StorageMetadata, ObjectStorageError> {
     let metadata = PARSEABLE
-        .storage
-        .get_object_store()
-        .get_metadata()
-        .await?
+        .metastore
+        .get_parseable_metadata()
+        .await
+        .map_err(|e| ObjectStorageError::MetastoreError(Box::new(e.to_detail())))?
         .expect("metadata is initialized");
-    Ok(metadata)
+    Ok(serde_json::from_slice::<StorageMetadata>(&metadata)?)
 }
 
 pub async fn put_metadata(metadata: &StorageMetadata) -> Result<(), ObjectStorageError> {

--- a/src/handlers/http/modal/utils/rbac_utils.rs
+++ b/src/handlers/http/modal/utils/rbac_utils.rs
@@ -27,7 +27,7 @@ pub async fn get_metadata() -> Result<crate::storage::StorageMetadata, ObjectSto
         .get_parseable_metadata()
         .await
         .map_err(|e| ObjectStorageError::MetastoreError(Box::new(e.to_detail())))?
-        .expect("metadata is initialized");
+        .ok_or_else(|| ObjectStorageError::Custom("parseable metadata not initialized".into()))?;
     Ok(serde_json::from_slice::<StorageMetadata>(&metadata)?)
 }
 

--- a/src/handlers/http/oidc.rs
+++ b/src/handlers/http/oidc.rs
@@ -448,7 +448,7 @@ async fn get_metadata() -> Result<crate::storage::StorageMetadata, ObjectStorage
         .get_parseable_metadata()
         .await
         .map_err(|e| ObjectStorageError::MetastoreError(Box::new(e.to_detail())))?
-        .expect("metadata is initialized");
+        .ok_or_else(|| ObjectStorageError::Custom("parseable metadata not initialized".into()))?;
     Ok(serde_json::from_slice::<StorageMetadata>(&metadata)?)
 }
 

--- a/src/handlers/http/oidc.rs
+++ b/src/handlers/http/oidc.rs
@@ -444,12 +444,12 @@ pub async fn update_user_if_changed(
 
 async fn get_metadata() -> Result<crate::storage::StorageMetadata, ObjectStorageError> {
     let metadata = PARSEABLE
-        .storage
-        .get_object_store()
-        .get_metadata()
-        .await?
+        .metastore
+        .get_parseable_metadata()
+        .await
+        .map_err(|e| ObjectStorageError::MetastoreError(Box::new(e.to_detail())))?
         .expect("metadata is initialized");
-    Ok(metadata)
+    Ok(serde_json::from_slice::<StorageMetadata>(&metadata)?)
 }
 
 async fn put_metadata(metadata: &StorageMetadata) -> Result<(), ObjectStorageError> {

--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -579,7 +579,7 @@ Description: {0}"#
     NoAvailableQuerier,
     #[error("{0}")]
     ParserError(#[from] ParserError),
-    #[error("{0:?}")]
+    #[error(transparent)]
     MetastoreError(#[from] MetastoreError),
 }
 

--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -18,6 +18,7 @@
 
 use crate::event::error::EventError;
 use crate::handlers::http::fetch_schema;
+use crate::metastore::MetastoreError;
 use crate::option::Mode;
 use crate::rbac::map::SessionKey;
 use crate::utils::arrow::record_batches_to_json;
@@ -578,12 +579,15 @@ Description: {0}"#
     NoAvailableQuerier,
     #[error("{0}")]
     ParserError(#[from] ParserError),
+    #[error("{0:?}")]
+    MetastoreError(#[from] MetastoreError),
 }
 
 impl actix_web::ResponseError for QueryError {
     fn status_code(&self) -> http::StatusCode {
         match self {
             QueryError::Execute(_) | QueryError::JsonParse(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            QueryError::MetastoreError(e) => e.status_code(),
             _ => StatusCode::BAD_REQUEST,
         }
     }

--- a/src/handlers/http/role.rs
+++ b/src/handlers/http/role.rs
@@ -146,7 +146,7 @@ async fn get_metadata() -> Result<crate::storage::StorageMetadata, ObjectStorage
         .get_parseable_metadata()
         .await
         .map_err(|e| ObjectStorageError::MetastoreError(Box::new(e.to_detail())))?
-        .expect("metadata is initialized");
+        .ok_or_else(|| ObjectStorageError::Custom("parseable metadata not initialized".into()))?;
     Ok(serde_json::from_slice::<StorageMetadata>(&metadata)?)
 }
 

--- a/src/handlers/http/role.rs
+++ b/src/handlers/http/role.rs
@@ -142,12 +142,12 @@ pub async fn get_default() -> Result<impl Responder, RoleError> {
 
 async fn get_metadata() -> Result<crate::storage::StorageMetadata, ObjectStorageError> {
     let metadata = PARSEABLE
-        .storage
-        .get_object_store()
-        .get_metadata()
-        .await?
+        .metastore
+        .get_parseable_metadata()
+        .await
+        .map_err(|e| ObjectStorageError::MetastoreError(Box::new(e.to_detail())))?
         .expect("metadata is initialized");
-    Ok(metadata)
+    Ok(serde_json::from_slice::<StorageMetadata>(&metadata)?)
 }
 
 async fn put_metadata(metadata: &StorageMetadata) -> Result<(), ObjectStorageError> {

--- a/src/handlers/http/users/dashboards.rs
+++ b/src/handlers/http/users/dashboards.rs
@@ -20,6 +20,7 @@ use std::collections::HashMap;
 
 use crate::{
     handlers::http::rbac::RBACError,
+    metastore::MetastoreError,
     storage::ObjectStorageError,
     users::dashboards::{DASHBOARDS, Dashboard, Tile, validate_dashboard_id},
     utils::{get_hash, get_user_from_request},
@@ -248,6 +249,8 @@ pub enum DashboardError {
     Unauthorized,
     #[error("Invalid query parameter")]
     InvalidQueryParameter,
+    #[error("{0:?}")]
+    MetastoreError(#[from] MetastoreError),
 }
 
 impl actix_web::ResponseError for DashboardError {
@@ -260,12 +263,20 @@ impl actix_web::ResponseError for DashboardError {
             Self::Custom(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Self::Unauthorized => StatusCode::UNAUTHORIZED,
             Self::InvalidQueryParameter => StatusCode::BAD_REQUEST,
+            Self::MetastoreError(e) => e.status_code(),
         }
     }
 
     fn error_response(&self) -> actix_web::HttpResponse<actix_web::body::BoxBody> {
-        actix_web::HttpResponse::build(self.status_code())
-            .insert_header(ContentType::plaintext())
-            .body(self.to_string())
+        match self {
+            DashboardError::MetastoreError(metastore_error) => {
+                actix_web::HttpResponse::build(self.status_code())
+                    .insert_header(ContentType::json())
+                    .body(metastore_error.to_string())
+            }
+            _ => actix_web::HttpResponse::build(self.status_code())
+                .insert_header(ContentType::plaintext())
+                .body(self.to_string()),
+        }
     }
 }

--- a/src/handlers/http/users/dashboards.rs
+++ b/src/handlers/http/users/dashboards.rs
@@ -249,7 +249,7 @@ pub enum DashboardError {
     Unauthorized,
     #[error("Invalid query parameter")]
     InvalidQueryParameter,
-    #[error("{0:?}")]
+    #[error(transparent)]
     MetastoreError(#[from] MetastoreError),
 }
 
@@ -269,10 +269,8 @@ impl actix_web::ResponseError for DashboardError {
 
     fn error_response(&self) -> actix_web::HttpResponse<actix_web::body::BoxBody> {
         match self {
-            DashboardError::MetastoreError(metastore_error) => {
-                actix_web::HttpResponse::build(self.status_code())
-                    .insert_header(ContentType::json())
-                    .body(metastore_error.to_string())
+            DashboardError::MetastoreError(e) => {
+                actix_web::HttpResponse::build(self.status_code()).json(e.to_detail())
             }
             _ => actix_web::HttpResponse::build(self.status_code())
                 .insert_header(ContentType::plaintext())

--- a/src/handlers/http/users/filters.rs
+++ b/src/handlers/http/users/filters.rs
@@ -122,7 +122,7 @@ pub enum FiltersError {
     UserDoesNotExist(#[from] RBACError),
     #[error("Error: {0}")]
     Custom(String),
-    #[error("{0:?}")]
+    #[error(transparent)]
     MetastoreError(#[from] MetastoreError),
 }
 
@@ -143,7 +143,7 @@ impl actix_web::ResponseError for FiltersError {
             FiltersError::MetastoreError(metastore_error) => {
                 actix_web::HttpResponse::build(self.status_code())
                     .insert_header(ContentType::json())
-                    .body(metastore_error.to_string())
+                    .json(metastore_error.to_detail())
             }
             _ => actix_web::HttpResponse::build(self.status_code())
                 .insert_header(ContentType::plaintext())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod handlers;
 pub mod hottier;
 mod livetail;
 mod metadata;
+pub mod metastore;
 pub mod metrics;
 pub mod migration;
 pub mod oidc;

--- a/src/metastore/metastore_traits.rs
+++ b/src/metastore/metastore_traits.rs
@@ -21,6 +21,7 @@ use std::collections::{BTreeMap, HashSet};
 use arrow_schema::Schema;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
+use dashmap::DashMap;
 use erased_serde::Serialize as ErasedSerialize;
 use tonic::async_trait;
 
@@ -57,6 +58,11 @@ pub trait Metastore: std::fmt::Debug + Send + Sync {
     async fn get_dashboards(&self) -> Result<Vec<Bytes>, MetastoreError>;
     async fn put_dashboard(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError>;
     async fn delete_dashboard(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError>;
+
+    /// chats
+    async fn get_chats(&self) -> Result<DashMap<String, Vec<Bytes>>, MetastoreError>;
+    async fn put_chat(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError>;
+    async fn delete_chat(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError>;
 
     /// filters
     async fn get_filters(&self) -> Result<Vec<Filter>, MetastoreError>;

--- a/src/metastore/metastore_traits.rs
+++ b/src/metastore/metastore_traits.rs
@@ -20,7 +20,7 @@ use bytes::Bytes;
 use erased_serde::Serialize as ErasedSerialize;
 use tonic::async_trait;
 
-use crate::metastore::MetastoreError;
+use crate::{metastore::MetastoreError, users::filters::Filter};
 
 /// A metastore is a logically separated compartment to store metadata for Parseable.
 ///
@@ -42,6 +42,11 @@ pub trait Metastore: std::fmt::Debug + Send + Sync {
     async fn get_dashboards(&self) -> Result<Vec<Bytes>, MetastoreError>;
     async fn put_dashboard(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError>;
     async fn delete_dashboard(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError>;
+
+    /// filters
+    async fn get_filters(&self) -> Result<Vec<Filter>, MetastoreError>;
+    async fn put_filter(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError>;
+    async fn delete_filter(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError>;
 
     /// correlations
     async fn get_correlations(&self) -> Result<Vec<Bytes>, MetastoreError>;

--- a/src/metastore/metastore_traits.rs
+++ b/src/metastore/metastore_traits.rs
@@ -101,6 +101,7 @@ pub trait Metastore: std::fmt::Debug + Send + Sync {
         stream_name: &str,
         lower_bound: DateTime<Utc>,
         upper_bound: DateTime<Utc>,
+        manifest_url: Option<String>,
     ) -> Result<Option<Manifest>, MetastoreError>;
     async fn put_manifest(
         &self,

--- a/src/metastore/metastore_traits.rs
+++ b/src/metastore/metastore_traits.rs
@@ -36,8 +36,6 @@ use crate::{
 #[async_trait]
 pub trait Metastore: std::fmt::Debug + Send + Sync {
     async fn initiate_connection(&self) -> Result<(), MetastoreError>;
-    async fn list_objects(&self) -> Result<(), MetastoreError>;
-    async fn get_object(&self) -> Result<(), MetastoreError>;
     async fn get_objects(&self, parent_path: &str) -> Result<Vec<Bytes>, MetastoreError>;
 
     /// alerts

--- a/src/metastore/metastore_traits.rs
+++ b/src/metastore/metastore_traits.rs
@@ -1,0 +1,57 @@
+/*
+ * Parseable Server (C) 2022 - 2024 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use bytes::Bytes;
+use erased_serde::Serialize as ErasedSerialize;
+use tonic::async_trait;
+
+use crate::metastore::MetastoreError;
+
+/// A metastore is a logically separated compartment to store metadata for Parseable.
+///
+/// Before this, the object store (be it S3, local store, azure) was being used as a metastore. With this trait, we do not
+/// need different methods for different kinds of metadata.
+#[async_trait]
+pub trait Metastore: std::fmt::Debug + Send + Sync {
+    async fn initiate_connection(&self) -> Result<(), MetastoreError>;
+    async fn list_objects(&self) -> Result<(), MetastoreError>;
+    async fn get_object(&self) -> Result<(), MetastoreError>;
+    async fn get_objects(&self, parent_path: &str) -> Result<Vec<Bytes>, MetastoreError>;
+    async fn create_object(
+        &self,
+        obj: &dyn MetastoreObject,
+        path: &str,
+    ) -> Result<(), MetastoreError>;
+    async fn update_object(
+        &self,
+        obj: &dyn MetastoreObject,
+        path: &str,
+    ) -> Result<(), MetastoreError>;
+    async fn delete_object(&self, path: &str) -> Result<(), MetastoreError>;
+}
+
+/// This trait allows a struct to get treated as a Metastore Object
+///
+/// A metastore object can be anything like configurations, user preferences, etc. Basically
+/// anything that  has a defined structure can possibly be treated as an object.
+pub trait MetastoreObject: ErasedSerialize + Sync {
+    // fn get_object(self) -> T;
+}
+
+// This macro makes the trait dyn-compatible
+erased_serde::serialize_trait_object!(MetastoreObject);

--- a/src/metastore/metastore_traits.rs
+++ b/src/metastore/metastore_traits.rs
@@ -43,6 +43,11 @@ pub trait Metastore: std::fmt::Debug + Send + Sync {
     async fn put_alert(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError>;
     async fn delete_alert(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError>;
 
+    /// llmconfig
+    async fn get_llmconfigs(&self) -> Result<Vec<Bytes>, MetastoreError>;
+    async fn put_llmconfig(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError>;
+    async fn delete_llmconfig(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError>;
+
     /// targets
     async fn get_targets(&self) -> Result<Vec<Target>, MetastoreError>;
     async fn put_target(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError>;

--- a/src/metastore/metastore_traits.rs
+++ b/src/metastore/metastore_traits.rs
@@ -32,16 +32,23 @@ pub trait Metastore: std::fmt::Debug + Send + Sync {
     async fn list_objects(&self) -> Result<(), MetastoreError>;
     async fn get_object(&self) -> Result<(), MetastoreError>;
     async fn get_objects(&self, parent_path: &str) -> Result<Vec<Bytes>, MetastoreError>;
-    async fn create_object(
-        &self,
-        obj: &dyn MetastoreObject,
-        path: &str,
-    ) -> Result<(), MetastoreError>;
-    async fn update_object(
-        &self,
-        obj: &dyn MetastoreObject,
-        path: &str,
-    ) -> Result<(), MetastoreError>;
+
+    /// alerts
+    async fn get_alerts(&self) -> Result<Vec<Bytes>, MetastoreError>;
+    async fn put_alert(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError>;
+    async fn delete_alert(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError>;
+
+    /// dashboards
+    async fn get_dashboards(&self) -> Result<Vec<Bytes>, MetastoreError>;
+    async fn put_dashboard(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError>;
+    async fn delete_dashboard(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError>;
+
+    /// correlations
+    async fn get_correlations(&self) -> Result<Vec<Bytes>, MetastoreError>;
+    async fn put_correlation(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError>;
+    async fn delete_correlation(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError>;
+
+    /// filters
     async fn delete_object(&self, path: &str) -> Result<(), MetastoreError>;
 }
 
@@ -50,7 +57,8 @@ pub trait Metastore: std::fmt::Debug + Send + Sync {
 /// A metastore object can be anything like configurations, user preferences, etc. Basically
 /// anything that  has a defined structure can possibly be treated as an object.
 pub trait MetastoreObject: ErasedSerialize + Sync {
-    // fn get_object(self) -> T;
+    fn get_path(&self) -> String;
+    fn get_id(&self) -> String;
 }
 
 // This macro makes the trait dyn-compatible

--- a/src/metastore/metastores/mod.rs
+++ b/src/metastore/metastores/mod.rs
@@ -1,0 +1,19 @@
+/*
+ * Parseable Server (C) 2022 - 2024 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+pub mod object_store_metastore;

--- a/src/metastore/metastores/object_store_metastore.rs
+++ b/src/metastore/metastores/object_store_metastore.rs
@@ -114,6 +114,39 @@ impl Metastore for ObjectStoreMetastore {
             .await?)
     }
 
+    /// This function fetches all the llmconfigs from the underlying object store
+    async fn get_llmconfigs(&self) -> Result<Vec<Bytes>, MetastoreError> {
+        let base_path = RelativePathBuf::from_iter([SETTINGS_ROOT_DIRECTORY, "llmconfigs"]);
+        let conf_bytes = self
+            .storage
+            .get_objects(
+                Some(&base_path),
+                Box::new(|file_name| file_name.ends_with(".json")),
+            )
+            .await?;
+
+        Ok(conf_bytes)
+    }
+
+    /// This function puts an llmconfig in the object store at the given path
+    async fn put_llmconfig(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError> {
+        let path = obj.get_object_path();
+
+        Ok(self
+            .storage
+            .put_object(&RelativePathBuf::from(path), to_bytes(obj))
+            .await?)
+    }
+
+    /// Delete an llmconfig
+    async fn delete_llmconfig(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError> {
+        let path = obj.get_object_path();
+        Ok(self
+            .storage
+            .delete_object(&RelativePathBuf::from(path))
+            .await?)
+    }
+
     /// Fetch all dashboards
     async fn get_dashboards(&self) -> Result<Vec<Bytes>, MetastoreError> {
         let mut dashboards = Vec::new();

--- a/src/metastore/metastores/object_store_metastore.rs
+++ b/src/metastore/metastores/object_store_metastore.rs
@@ -733,7 +733,7 @@ impl Metastore for ObjectStoreMetastore {
 
     async fn list_streams(&self) -> Result<HashSet<String>, MetastoreError> {
         // using LocalFS list_streams because it doesn't implement list_with_delimiter
-        if PARSEABLE.get_storage_mode_string() == "drive" {
+        if PARSEABLE.storage.name() == "drive" {
             PARSEABLE
                 .storage
                 .get_object_store()

--- a/src/metastore/metastores/object_store_metastore.rs
+++ b/src/metastore/metastores/object_store_metastore.rs
@@ -16,9 +16,14 @@
  *
  */
 
-use std::sync::Arc;
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+};
 
+use arrow_schema::Schema;
 use bytes::Bytes;
+use chrono::{DateTime, Utc};
 use http::StatusCode;
 use relative_path::RelativePathBuf;
 use tonic::async_trait;
@@ -26,15 +31,26 @@ use tracing::warn;
 use ulid::Ulid;
 
 use crate::{
-    handlers::http::users::USERS_ROOT_DIR,
+    alerts::target::Target,
+    catalog::{manifest::Manifest, partition_path},
+    handlers::http::{
+        modal::{Metadata, NodeMetadata, NodeType},
+        users::USERS_ROOT_DIR,
+    },
     metastore::{
         MetastoreError,
         metastore_traits::{Metastore, MetastoreObject},
     },
     option::Mode,
+    parseable::PARSEABLE,
     storage::{
-        ALERTS_ROOT_DIRECTORY, ObjectStorage, STREAM_METADATA_FILE_NAME, STREAM_ROOT_DIRECTORY,
-        object_storage::{alert_json_path, filter_path, stream_json_path, to_bytes},
+        ALERTS_ROOT_DIRECTORY, ObjectStorage, ObjectStorageError, PARSEABLE_ROOT_DIRECTORY,
+        SETTINGS_ROOT_DIRECTORY, STREAM_METADATA_FILE_NAME, STREAM_ROOT_DIRECTORY,
+        TARGETS_ROOT_DIRECTORY,
+        object_storage::{
+            alert_json_path, filter_path, manifest_path, parseable_json_path, schema_path,
+            stream_json_path, to_bytes,
+        },
     },
     users::filters::{Filter, migrate_v1_v2},
 };
@@ -47,16 +63,22 @@ pub struct ObjectStoreMetastore {
 
 #[async_trait]
 impl Metastore for ObjectStoreMetastore {
+    /// Since Parseable already starts with a connection to an object store, no need to implement this
     async fn initiate_connection(&self) -> Result<(), MetastoreError> {
         unimplemented!()
     }
+
+    /// Might implement later
     async fn list_objects(&self) -> Result<(), MetastoreError> {
         unimplemented!()
     }
+
+    /// Might implement later
     async fn get_object(&self) -> Result<(), MetastoreError> {
         unimplemented!()
     }
 
+    /// Fetch mutiple .json objects
     async fn get_objects(&self, parent_path: &str) -> Result<Vec<Bytes>, MetastoreError> {
         Ok(self
             .storage
@@ -88,6 +110,7 @@ impl Metastore for ObjectStoreMetastore {
         Ok(self.storage.put_object(&path, to_bytes(obj)).await?)
     }
 
+    /// Delete an alert
     async fn delete_alert(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError> {
         let path = obj.get_object_path();
         Ok(self
@@ -96,6 +119,7 @@ impl Metastore for ObjectStoreMetastore {
             .await?)
     }
 
+    /// Fetch all dashboards
     async fn get_dashboards(&self) -> Result<Vec<Bytes>, MetastoreError> {
         let mut dashboards = Vec::new();
 
@@ -116,6 +140,7 @@ impl Metastore for ObjectStoreMetastore {
         Ok(dashboards)
     }
 
+    /// Save a dashboard
     async fn put_dashboard(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError> {
         // we need the path to store in obj store
         let path = obj.get_object_path();
@@ -126,6 +151,7 @@ impl Metastore for ObjectStoreMetastore {
             .await?)
     }
 
+    /// Delete a dashboard
     async fn delete_dashboard(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError> {
         let path = obj.get_object_path();
         Ok(self
@@ -207,6 +233,7 @@ impl Metastore for ObjectStoreMetastore {
         Ok(this)
     }
 
+    /// Save a filter
     async fn put_filter(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError> {
         // we need the path to store in obj store
         let path = obj.get_object_path();
@@ -217,27 +244,59 @@ impl Metastore for ObjectStoreMetastore {
             .await?)
     }
 
+    /// Delete a filter
     async fn delete_filter(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError> {
         let path = obj.get_object_path();
-        warn!(delete_filter_path=?path);
+
         Ok(self
             .storage
             .delete_object(&RelativePathBuf::from(path))
             .await?)
     }
 
+    /// Get all correlations
     async fn get_correlations(&self) -> Result<Vec<Bytes>, MetastoreError> {
-        unimplemented!()
+        let mut correlations = Vec::new();
+
+        let users_dir = RelativePathBuf::from(USERS_ROOT_DIR);
+        for user in self.storage.list_dirs_relative(&users_dir).await? {
+            let correlations_path = users_dir.join(&user).join("correlations");
+            let correlation_bytes = self
+                .storage
+                .get_objects(
+                    Some(&correlations_path),
+                    Box::new(|file_name| file_name.ends_with(".json")),
+                )
+                .await?;
+
+            correlations.extend(correlation_bytes);
+        }
+
+        Ok(correlations)
     }
 
-    async fn put_correlation(&self, _obj: &dyn MetastoreObject) -> Result<(), MetastoreError> {
-        unimplemented!()
+    /// Save a correlation
+    async fn put_correlation(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError> {
+        let path = obj.get_object_path();
+        Ok(self
+            .storage
+            .put_object(&RelativePathBuf::from(path), to_bytes(obj))
+            .await?)
     }
 
-    async fn delete_correlation(&self, _obj: &dyn MetastoreObject) -> Result<(), MetastoreError> {
-        unimplemented!()
+    /// Delete a correlation
+    async fn delete_correlation(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError> {
+        let path = obj.get_object_path();
+
+        Ok(self
+            .storage
+            .delete_object(&RelativePathBuf::from(path))
+            .await?)
     }
 
+    /// Fetch an `ObjectStoreFormat` file
+    ///
+    /// If `get_base` is true, get the one at the base of the stream directory else depends on Mode
     async fn get_stream_json(
         &self,
         stream_name: &str,
@@ -255,6 +314,7 @@ impl Metastore for ObjectStoreMetastore {
         Ok(self.storage.get_object(&path).await?)
     }
 
+    /// Fetch all `ObjectStoreFormat` present in a stream folder
     async fn get_all_stream_jsons(
         &self,
         stream_name: &str,
@@ -291,6 +351,7 @@ impl Metastore for ObjectStoreMetastore {
         }
     }
 
+    /// Save an `ObjectStoreFormat` file
     async fn put_stream_json(
         &self,
         obj: &dyn MetastoreObject,
@@ -300,5 +361,314 @@ impl Metastore for ObjectStoreMetastore {
             .storage
             .put_object(&stream_json_path(stream_name), to_bytes(obj))
             .await?)
+    }
+
+    /// Fetch all `Manifest` files
+    async fn get_all_manifest_files(
+        &self,
+        stream_name: &str,
+    ) -> Result<BTreeMap<String, Vec<Manifest>>, MetastoreError> {
+        let mut result_file_list: BTreeMap<String, Vec<Manifest>> = BTreeMap::new();
+        let resp = self
+            .storage
+            .list_with_delimiter(Some(stream_name.into()))
+            .await?;
+
+        let dates = resp
+            .common_prefixes
+            .iter()
+            .flat_map(|path| path.parts())
+            .filter(|name| name.as_ref() != stream_name && name.as_ref() != STREAM_ROOT_DIRECTORY)
+            .map(|name| name.as_ref().to_string())
+            .collect::<Vec<_>>();
+
+        for date in dates {
+            let date_path = object_store::path::Path::from(format!("{}/{}", stream_name, &date));
+            let resp = self.storage.list_with_delimiter(Some(date_path)).await?;
+
+            let manifest_paths: Vec<String> = resp
+                .objects
+                .iter()
+                .filter(|name| name.location.filename().unwrap().ends_with("manifest.json"))
+                .map(|name| name.location.to_string())
+                .collect();
+
+            for path in manifest_paths {
+                let bytes = self
+                    .storage
+                    .get_object(&RelativePathBuf::from(path))
+                    .await?;
+
+                result_file_list
+                    .entry(date.clone())
+                    .or_default()
+                    .push(serde_json::from_slice::<Manifest>(&bytes)?);
+            }
+        }
+        Ok(result_file_list)
+    }
+
+    /// Fetch a specific `Manifest` file
+    async fn get_manifest(
+        &self,
+        stream_name: &str,
+        lower_bound: DateTime<Utc>,
+        upper_bound: DateTime<Utc>,
+    ) -> Result<Option<Manifest>, MetastoreError> {
+        let path = partition_path(stream_name, lower_bound, upper_bound);
+        let path = manifest_path(path.as_str());
+        match self.storage.get_object(&path).await {
+            Ok(bytes) => {
+                let manifest = serde_json::from_slice(&bytes)?;
+                Ok(Some(manifest))
+            }
+            Err(ObjectStorageError::NoSuchKey(_)) => Ok(None),
+            Err(err) => Err(MetastoreError::ObjectStorageError(err)),
+        }
+    }
+
+    /// Get the path for a specific `Manifest` file
+    async fn get_manifest_path(
+        &self,
+        stream_name: &str,
+        lower_bound: DateTime<Utc>,
+        upper_bound: DateTime<Utc>,
+    ) -> Result<String, MetastoreError> {
+        let path = partition_path(stream_name, lower_bound, upper_bound);
+        Ok(self
+            .storage
+            .absolute_url(&manifest_path(path.as_str()))
+            .to_string())
+    }
+
+    async fn put_manifest(
+        &self,
+        obj: &dyn MetastoreObject,
+        stream_name: &str,
+        lower_bound: DateTime<Utc>,
+        upper_bound: DateTime<Utc>,
+    ) -> Result<(), MetastoreError> {
+        let manifest_file_name = manifest_path("").to_string();
+        let path = partition_path(stream_name, lower_bound, upper_bound).join(&manifest_file_name);
+        Ok(self.storage.put_object(&path, to_bytes(obj)).await?)
+    }
+
+    async fn delete_manifest(
+        &self,
+        stream_name: &str,
+        lower_bound: DateTime<Utc>,
+        upper_bound: DateTime<Utc>,
+    ) -> Result<(), MetastoreError> {
+        let manifest_file_name = manifest_path("").to_string();
+        let path = partition_path(stream_name, lower_bound, upper_bound).join(&manifest_file_name);
+        Ok(self.storage.delete_object(&path).await?)
+    }
+
+    /// targets
+    async fn get_targets(&self) -> Result<Vec<Target>, MetastoreError> {
+        let targets_path =
+            RelativePathBuf::from_iter([SETTINGS_ROOT_DIRECTORY, TARGETS_ROOT_DIRECTORY]);
+        let targets = self
+            .storage
+            .get_objects(
+                Some(&targets_path),
+                Box::new(|file_name| file_name.ends_with(".json")),
+            )
+            .await?
+            .iter()
+            .filter_map(|bytes| {
+                serde_json::from_slice(bytes)
+                    .inspect_err(|err| warn!("Expected compatible json, error = {err}"))
+                    .ok()
+            })
+            .collect();
+
+        Ok(targets)
+    }
+
+    async fn put_target(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError> {
+        // we need the path to store in obj store
+        let path = obj.get_object_path();
+
+        Ok(self
+            .storage
+            .put_object(&RelativePathBuf::from(path), to_bytes(obj))
+            .await?)
+    }
+
+    async fn delete_target(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError> {
+        // we need the path to store in obj store
+        let path = obj.get_object_path();
+
+        Ok(self
+            .storage
+            .delete_object(&RelativePathBuf::from(path))
+            .await?)
+    }
+
+    async fn get_all_schemas(&self, stream_name: &str) -> Result<Vec<Schema>, MetastoreError> {
+        let path_prefix =
+            relative_path::RelativePathBuf::from(format!("{stream_name}/{STREAM_ROOT_DIRECTORY}"));
+        Ok(self
+            .storage
+            .get_objects(
+                Some(&path_prefix),
+                Box::new(|file_name: String| file_name.contains(".schema")),
+            )
+            .await?
+            .iter()
+            // we should be able to unwrap as we know the data is valid schema
+            .map(|byte_obj| serde_json::from_slice(byte_obj).expect("data is valid json"))
+            .collect())
+    }
+
+    async fn get_schema(&self, stream_name: &str) -> Result<Bytes, MetastoreError> {
+        Ok(self.storage.get_object(&schema_path(stream_name)).await?)
+    }
+
+    async fn put_schema(&self, obj: Schema, stream_name: &str) -> Result<(), MetastoreError> {
+        let path = schema_path(stream_name);
+        Ok(self.storage.put_object(&path, to_bytes(&obj)).await?)
+    }
+
+    async fn get_parseable_metadata(&self) -> Result<Option<Bytes>, MetastoreError> {
+        let parseable_metadata: Option<Bytes> =
+            match self.storage.get_object(&parseable_json_path()).await {
+                Ok(bytes) => Some(bytes),
+                Err(err) => {
+                    if matches!(err, ObjectStorageError::NoSuchKey(_)) {
+                        None
+                    } else {
+                        return Err(MetastoreError::ObjectStorageError(err));
+                    }
+                }
+            };
+
+        Ok(parseable_metadata)
+    }
+
+    async fn get_ingestor_metadata(&self) -> Result<Vec<Bytes>, MetastoreError> {
+        let base_path = RelativePathBuf::from(PARSEABLE_ROOT_DIRECTORY);
+        Ok(self
+            .storage
+            .get_objects(
+                Some(&base_path),
+                Box::new(|file_name| file_name.starts_with("ingestor")),
+            )
+            .await?)
+    }
+
+    async fn put_parseable_metadata(
+        &self,
+        obj: &dyn MetastoreObject,
+    ) -> Result<(), MetastoreError> {
+        self.storage
+            .put_object(&parseable_json_path(), to_bytes(obj))
+            .await
+            .map_err(MetastoreError::ObjectStorageError)
+    }
+
+    async fn get_node_metadata(&self, node_type: NodeType) -> Result<Vec<Bytes>, MetastoreError> {
+        let root_path = RelativePathBuf::from(PARSEABLE_ROOT_DIRECTORY);
+        let prefix_owned = node_type.to_string();
+
+        let metadata = self
+            .storage
+            .get_objects(
+                Some(&root_path),
+                Box::new(move |file_name| file_name.starts_with(&prefix_owned)), // Use the owned copy
+            )
+            .await?
+            .into_iter()
+            .collect();
+
+        Ok(metadata)
+    }
+
+    async fn put_node_metadata(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError> {
+        let path = obj.get_object_path();
+        self.storage
+            .put_object(&RelativePathBuf::from(path), to_bytes(obj))
+            .await?;
+        Ok(())
+    }
+
+    async fn delete_node_metadata(
+        &self,
+        domain_name: &str,
+        node_type: NodeType,
+    ) -> Result<bool, MetastoreError> {
+        let metadatas = self
+            .storage
+            .get_objects(
+                Some(&RelativePathBuf::from(PARSEABLE_ROOT_DIRECTORY)),
+                Box::new(move |file_name| file_name.starts_with(&node_type.to_string())),
+            )
+            .await?;
+
+        let node_metadatas = metadatas
+            .iter()
+            .filter_map(|elem| match serde_json::from_slice::<NodeMetadata>(elem) {
+                Ok(meta) if meta.domain_name() == domain_name => Some(meta),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        if node_metadatas.is_empty() {
+            return Ok(false);
+        }
+
+        let node_meta_filename = node_metadatas[0].file_path().to_string();
+        let file = RelativePathBuf::from(&node_meta_filename);
+
+        match self.storage.delete_object(&file).await {
+            Ok(_) => Ok(true),
+            Err(err) => {
+                if matches!(err, ObjectStorageError::IoError(_)) {
+                    Ok(false)
+                } else {
+                    Err(MetastoreError::ObjectStorageError(err))
+                }
+            }
+        }
+    }
+
+    async fn list_streams(&self) -> Result<HashSet<String>, MetastoreError> {
+        // using LocalFS list_streams because it doesn't implement list_with_delimiter
+        if PARSEABLE.get_storage_mode_string() == "drive" {
+            PARSEABLE
+                .storage
+                .get_object_store()
+                .list_streams()
+                .await
+                .map_err(MetastoreError::ObjectStorageError)
+        } else {
+            let mut result_file_list = HashSet::new();
+            let resp = self.storage.list_with_delimiter(None).await?;
+
+            let streams = resp
+                .common_prefixes
+                .iter()
+                .flat_map(|path| path.parts())
+                .map(|name| name.as_ref().to_string())
+                .filter(|name| name != PARSEABLE_ROOT_DIRECTORY && name != USERS_ROOT_DIR)
+                .collect::<Vec<_>>();
+
+            for stream in streams {
+                let stream_path = object_store::path::Path::from(format!(
+                    "{}/{}",
+                    &stream, STREAM_ROOT_DIRECTORY
+                ));
+                let resp = self.storage.list_with_delimiter(Some(stream_path)).await?;
+                if resp
+                    .objects
+                    .iter()
+                    .any(|name| name.location.filename().unwrap().ends_with("stream.json"))
+                {
+                    result_file_list.insert(stream);
+                }
+            }
+            Ok(result_file_list)
+        }
     }
 }

--- a/src/metastore/metastores/object_store_metastore.rs
+++ b/src/metastore/metastores/object_store_metastore.rs
@@ -1,0 +1,101 @@
+/*
+ * Parseable Server (C) 2022 - 2024 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use relative_path::RelativePathBuf;
+use tonic::async_trait;
+use ulid::Ulid;
+
+use crate::{
+    metastore::{
+        MetastoreError,
+        metastore_traits::{Metastore, MetastoreObject},
+    },
+    storage::{
+        ObjectStorage,
+        object_storage::{alert_json_path, to_bytes},
+    },
+};
+
+/// Using PARSEABLE's storage as a metastore (default)
+#[derive(Debug)]
+pub struct ObjectStoreMetastore {
+    pub storage: Arc<dyn ObjectStorage>,
+}
+
+#[async_trait]
+impl Metastore for ObjectStoreMetastore {
+    async fn initiate_connection(&self) -> Result<(), MetastoreError> {
+        unimplemented!()
+    }
+    async fn list_objects(&self) -> Result<(), MetastoreError> {
+        unimplemented!()
+    }
+    async fn get_object(&self) -> Result<(), MetastoreError> {
+        unimplemented!()
+    }
+
+    async fn get_objects(&self, parent_path: &str) -> Result<Vec<Bytes>, MetastoreError> {
+        Ok(self
+            .storage
+            .get_objects(
+                Some(&RelativePathBuf::from(parent_path)),
+                Box::new(|file_name| file_name.ends_with(".json")),
+            )
+            .await?)
+    }
+
+    async fn create_object(
+        &self,
+        obj: &dyn MetastoreObject,
+        path: &str,
+    ) -> Result<(), MetastoreError> {
+        // use the path provided
+        // pass it to storage
+        // write the object
+
+        Ok(self
+            .storage
+            .put_object(
+                &alert_json_path(Ulid::from_string(path).unwrap()),
+                to_bytes(obj),
+            )
+            .await?)
+    }
+    async fn update_object(
+        &self,
+        obj: &dyn MetastoreObject,
+        path: &str,
+    ) -> Result<(), MetastoreError> {
+        Ok(self
+            .storage
+            .put_object(
+                &alert_json_path(Ulid::from_string(path).unwrap()),
+                to_bytes(obj),
+            )
+            .await?)
+    }
+    async fn delete_object(&self, path: &str) -> Result<(), MetastoreError> {
+        Ok(self
+            .storage
+            .delete_object(&RelativePathBuf::from(path))
+            .await?)
+    }
+}

--- a/src/metastore/mod.rs
+++ b/src/metastore/mod.rs
@@ -148,25 +148,13 @@ impl MetastoreError {
 
     pub fn status_code(&self) -> StatusCode {
         match self {
-            MetastoreError::ObjectStorageError(_object_storage_error) => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-            MetastoreError::JsonParseError(_error) => StatusCode::INTERNAL_SERVER_ERROR,
-            MetastoreError::JsonSchemaError { message: _ } => StatusCode::INTERNAL_SERVER_ERROR,
-            MetastoreError::InvalidJsonStructure {
-                expected: _,
-                found: _,
-            } => StatusCode::INTERNAL_SERVER_ERROR,
-            MetastoreError::MissingJsonField { field: _ } => StatusCode::INTERNAL_SERVER_ERROR,
-            MetastoreError::InvalidJsonValue {
-                field: _,
-                reason: _,
-            } => StatusCode::INTERNAL_SERVER_ERROR,
-            MetastoreError::Error {
-                status_code,
-                message: _,
-                flow: _,
-            } => *status_code,
+            MetastoreError::ObjectStorageError(..) => StatusCode::INTERNAL_SERVER_ERROR,
+            MetastoreError::JsonParseError(..) => StatusCode::INTERNAL_SERVER_ERROR,
+            MetastoreError::JsonSchemaError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            MetastoreError::InvalidJsonStructure { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            MetastoreError::MissingJsonField { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            MetastoreError::InvalidJsonValue { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            MetastoreError::Error { status_code, .. } => *status_code,
         }
     }
 }

--- a/src/metastore/mod.rs
+++ b/src/metastore/mod.rs
@@ -95,7 +95,7 @@ impl MetastoreError {
                 file_path: None,
                 timestamp: Some(chrono::Utc::now()),
                 metadata: std::collections::HashMap::new(),
-                status_code: 500,
+                status_code: 400,
             },
             MetastoreError::JsonSchemaError { message } => MetastoreErrorDetail {
                 operation: "JsonSchemaError".to_string(),
@@ -104,7 +104,7 @@ impl MetastoreError {
                 file_path: None,
                 timestamp: Some(chrono::Utc::now()),
                 metadata: std::collections::HashMap::new(),
-                status_code: 500,
+                status_code: 400,
             },
             MetastoreError::InvalidJsonStructure { expected, found } => MetastoreErrorDetail {
                 operation: "InvalidJsonStructure".to_string(),
@@ -118,7 +118,7 @@ impl MetastoreError {
                 ]
                 .into_iter()
                 .collect(),
-                status_code: 500,
+                status_code: 400,
             },
             MetastoreError::MissingJsonField { field } => MetastoreErrorDetail {
                 operation: "MissingJsonField".to_string(),
@@ -127,7 +127,7 @@ impl MetastoreError {
                 file_path: None,
                 timestamp: Some(chrono::Utc::now()),
                 metadata: [("field".to_string(), field.clone())].into_iter().collect(),
-                status_code: 500,
+                status_code: 400,
             },
             MetastoreError::InvalidJsonValue { field, reason } => MetastoreErrorDetail {
                 operation: "InvalidJsonValue".to_string(),
@@ -141,7 +141,7 @@ impl MetastoreError {
                 ]
                 .into_iter()
                 .collect(),
-                status_code: 500,
+                status_code: 400,
             },
         }
     }

--- a/src/metastore/mod.rs
+++ b/src/metastore/mod.rs
@@ -1,0 +1,125 @@
+/*
+ * Parseable Server (C) 2022 - 2024 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use crate::storage::ObjectStorageError;
+
+pub mod metastore_traits;
+pub mod metastores;
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct MetastoreErrorDetail {
+    pub error_type: String,
+    pub message: String,
+    pub operation: Option<String>,
+    pub stream_name: Option<String>,
+    pub file_path: Option<String>,
+    pub timestamp: Option<chrono::DateTime<chrono::Utc>>,
+    pub metadata: std::collections::HashMap<String, String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum MetastoreError {
+    #[error("ObjectStorageError: {0}")]
+    ObjectStorageError(#[from] ObjectStorageError),
+
+    #[error("JSON parsing error: {0}")]
+    JsonParseError(#[from] serde_json::Error),
+
+    #[error("JSON schema validation error: {message}")]
+    JsonSchemaError { message: String },
+
+    #[error("Invalid JSON structure: expected {expected}, found {found}")]
+    InvalidJsonStructure { expected: String, found: String },
+
+    #[error("Missing required JSON field: {field}")]
+    MissingJsonField { field: String },
+
+    #[error("Invalid JSON value for field '{field}': {reason}")]
+    InvalidJsonValue { field: String, reason: String },
+}
+
+impl MetastoreError {
+    pub fn to_detail(&self) -> MetastoreErrorDetail {
+        match self {
+            MetastoreError::ObjectStorageError(e) => MetastoreErrorDetail {
+                error_type: "ObjectStorageError".to_string(),
+                message: e.to_string(),
+                operation: None,
+                stream_name: None,
+                file_path: None,
+                timestamp: Some(chrono::Utc::now()),
+                metadata: std::collections::HashMap::new(),
+            },
+            MetastoreError::JsonParseError(e) => MetastoreErrorDetail {
+                error_type: "JsonParseError".to_string(),
+                message: e.to_string(),
+                operation: None,
+                stream_name: None,
+                file_path: None,
+                timestamp: Some(chrono::Utc::now()),
+                metadata: std::collections::HashMap::new(),
+            },
+            MetastoreError::JsonSchemaError { message } => MetastoreErrorDetail {
+                error_type: "JsonSchemaError".to_string(),
+                message: message.clone(),
+                operation: None,
+                stream_name: None,
+                file_path: None,
+                timestamp: Some(chrono::Utc::now()),
+                metadata: std::collections::HashMap::new(),
+            },
+            MetastoreError::InvalidJsonStructure { expected, found } => MetastoreErrorDetail {
+                error_type: "InvalidJsonStructure".to_string(),
+                message: format!("Expected {}, found {}", expected, found),
+                operation: None,
+                stream_name: None,
+                file_path: None,
+                timestamp: Some(chrono::Utc::now()),
+                metadata: [
+                    ("expected".to_string(), expected.clone()),
+                    ("found".to_string(), found.clone()),
+                ]
+                .into_iter()
+                .collect(),
+            },
+            MetastoreError::MissingJsonField { field } => MetastoreErrorDetail {
+                error_type: "MissingJsonField".to_string(),
+                message: format!("Missing required field: {}", field),
+                operation: None,
+                stream_name: None,
+                file_path: None,
+                timestamp: Some(chrono::Utc::now()),
+                metadata: [("field".to_string(), field.clone())].into_iter().collect(),
+            },
+            MetastoreError::InvalidJsonValue { field, reason } => MetastoreErrorDetail {
+                error_type: "InvalidJsonValue".to_string(),
+                message: format!("Invalid value for field '{}': {}", field, reason),
+                operation: None,
+                stream_name: None,
+                file_path: None,
+                timestamp: Some(chrono::Utc::now()),
+                metadata: [
+                    ("field".to_string(), field.clone()),
+                    ("reason".to_string(), reason.clone()),
+                ]
+                .into_iter()
+                .collect(),
+            },
+        }
+    }
+}

--- a/src/metastore/mod.rs
+++ b/src/metastore/mod.rs
@@ -25,9 +25,8 @@ pub mod metastores;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MetastoreErrorDetail {
-    pub flow: String,
+    pub operation: String,
     pub message: String,
-    pub operation: Option<String>,
     pub stream_name: Option<String>,
     pub file_path: Option<String>,
     pub timestamp: Option<chrono::DateTime<chrono::Utc>>,
@@ -39,6 +38,21 @@ pub struct MetastoreErrorDetail {
 pub enum MetastoreError {
     #[error("ObjectStorageError: {0}")]
     ObjectStorageError(#[from] ObjectStorageError),
+
+    #[error("JSON parsing error: {0}")]
+    JsonParseError(#[from] serde_json::Error),
+
+    #[error("JSON schema validation error: {message}")]
+    JsonSchemaError { message: String },
+
+    #[error("Invalid JSON structure: expected {expected}, found {found}")]
+    InvalidJsonStructure { expected: String, found: String },
+
+    #[error("Missing required JSON field: {field}")]
+    MissingJsonField { field: String },
+
+    #[error("Invalid JSON value for field '{field}': {reason}")]
+    InvalidJsonValue { field: String, reason: String },
 
     #[error("{self:?}")]
     ObjectStoreError {
@@ -56,9 +70,8 @@ impl MetastoreError {
                 message,
                 flow,
             } => MetastoreErrorDetail {
-                flow,
+                operation: flow,
                 message,
-                operation: None,
                 stream_name: None,
                 file_path: None,
                 timestamp: Some(chrono::Utc::now()),
@@ -66,13 +79,67 @@ impl MetastoreError {
                 status_code,
             },
             MetastoreError::ObjectStorageError(e) => MetastoreErrorDetail {
-                flow: "ObjectStorageError".to_string(),
+                operation: "ObjectStorageError".to_string(),
                 message: e.to_string(),
-                operation: None,
                 stream_name: None,
                 file_path: None,
                 timestamp: Some(chrono::Utc::now()),
                 metadata: std::collections::HashMap::new(),
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+            },
+            MetastoreError::JsonParseError(e) => MetastoreErrorDetail {
+                operation: "JsonParseError".to_string(),
+                message: e.to_string(),
+                stream_name: None,
+                file_path: None,
+                timestamp: Some(chrono::Utc::now()),
+                metadata: std::collections::HashMap::new(),
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+            },
+            MetastoreError::JsonSchemaError { message } => MetastoreErrorDetail {
+                operation: "JsonSchemaError".to_string(),
+                message: message.clone(),
+                stream_name: None,
+                file_path: None,
+                timestamp: Some(chrono::Utc::now()),
+                metadata: std::collections::HashMap::new(),
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+            },
+            MetastoreError::InvalidJsonStructure { expected, found } => MetastoreErrorDetail {
+                operation: "InvalidJsonStructure".to_string(),
+                message: format!("Expected {}, found {}", expected, found),
+                stream_name: None,
+                file_path: None,
+                timestamp: Some(chrono::Utc::now()),
+                metadata: [
+                    ("expected".to_string(), expected.clone()),
+                    ("found".to_string(), found.clone()),
+                ]
+                .into_iter()
+                .collect(),
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+            },
+            MetastoreError::MissingJsonField { field } => MetastoreErrorDetail {
+                operation: "MissingJsonField".to_string(),
+                message: format!("Missing required field: {}", field),
+                stream_name: None,
+                file_path: None,
+                timestamp: Some(chrono::Utc::now()),
+                metadata: [("field".to_string(), field.clone())].into_iter().collect(),
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+            },
+            MetastoreError::InvalidJsonValue { field, reason } => MetastoreErrorDetail {
+                operation: "InvalidJsonValue".to_string(),
+                message: format!("Invalid value for field '{}': {}", field, reason),
+                stream_name: None,
+                file_path: None,
+                timestamp: Some(chrono::Utc::now()),
+                metadata: [
+                    ("field".to_string(), field.clone()),
+                    ("reason".to_string(), reason.clone()),
+                ]
+                .into_iter()
+                .collect(),
                 status_code: StatusCode::INTERNAL_SERVER_ERROR,
             },
         }
@@ -83,6 +150,17 @@ impl MetastoreError {
             MetastoreError::ObjectStorageError(_object_storage_error) => {
                 StatusCode::INTERNAL_SERVER_ERROR
             }
+            MetastoreError::JsonParseError(_error) => StatusCode::INTERNAL_SERVER_ERROR,
+            MetastoreError::JsonSchemaError { message: _ } => StatusCode::INTERNAL_SERVER_ERROR,
+            MetastoreError::InvalidJsonStructure {
+                expected: _,
+                found: _,
+            } => StatusCode::INTERNAL_SERVER_ERROR,
+            MetastoreError::MissingJsonField { field: _ } => StatusCode::INTERNAL_SERVER_ERROR,
+            MetastoreError::InvalidJsonValue {
+                field: _,
+                reason: _,
+            } => StatusCode::INTERNAL_SERVER_ERROR,
             MetastoreError::ObjectStoreError {
                 status_code,
                 message: _,

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -35,10 +35,7 @@ use crate::{
     metrics::fetch_stats_from_storage,
     option::Mode,
     parseable::{PARSEABLE, Parseable},
-    storage::{
-        ObjectStorage, ObjectStoreFormat, PARSEABLE_METADATA_FILE_NAME,
-        object_storage::{parseable_json_path, schema_path, stream_json_path},
-    },
+    storage::{ObjectStorage, ObjectStoreFormat, PARSEABLE_METADATA_FILE_NAME, StorageMetadata},
 };
 
 fn get_version(metadata: &serde_json::Value) -> Option<&str> {
@@ -54,7 +51,6 @@ pub async fn run_metadata_migration(
     config: &Parseable,
     parseable_json: &mut Option<Bytes>,
 ) -> anyhow::Result<()> {
-    let object_store = config.storage.get_object_store();
     let mut storage_metadata: Option<Value> = None;
     if parseable_json.is_some() {
         storage_metadata = serde_json::from_slice(parseable_json.as_ref().unwrap())
@@ -73,7 +69,7 @@ pub async fn run_metadata_migration(
                 metadata = metadata_migration::remove_querier_metadata(metadata);
                 let _metadata: Bytes = serde_json::to_vec(&metadata)?.into();
                 *parseable_json = Some(_metadata);
-                put_remote_metadata(&*object_store, &metadata).await?;
+                put_remote_metadata(metadata).await?;
             }
             Some("v2") => {
                 let mut metadata = metadata_migration::v2_v3(storage_metadata);
@@ -83,7 +79,7 @@ pub async fn run_metadata_migration(
                 metadata = metadata_migration::remove_querier_metadata(metadata);
                 let _metadata: Bytes = serde_json::to_vec(&metadata)?.into();
                 *parseable_json = Some(_metadata);
-                put_remote_metadata(&*object_store, &metadata).await?;
+                put_remote_metadata(metadata).await?;
             }
             Some("v3") => {
                 let mut metadata = metadata_migration::v3_v4(storage_metadata);
@@ -92,7 +88,7 @@ pub async fn run_metadata_migration(
                 metadata = metadata_migration::remove_querier_metadata(metadata);
                 let _metadata: Bytes = serde_json::to_vec(&metadata)?.into();
                 *parseable_json = Some(_metadata);
-                put_remote_metadata(&*object_store, &metadata).await?;
+                put_remote_metadata(metadata).await?;
             }
             Some("v4") => {
                 let mut metadata = metadata_migration::v4_v5(storage_metadata);
@@ -100,17 +96,17 @@ pub async fn run_metadata_migration(
                 metadata = metadata_migration::remove_querier_metadata(metadata);
                 let _metadata: Bytes = serde_json::to_vec(&metadata)?.into();
                 *parseable_json = Some(_metadata);
-                put_remote_metadata(&*object_store, &metadata).await?;
+                put_remote_metadata(metadata).await?;
             }
             Some("v5") => {
                 let metadata = metadata_migration::v5_v6(storage_metadata);
                 let _metadata: Bytes = serde_json::to_vec(&metadata)?.into();
                 *parseable_json = Some(_metadata);
-                put_remote_metadata(&*object_store, &metadata).await?;
+                put_remote_metadata(metadata).await?;
             }
             _ => {
                 let metadata = metadata_migration::remove_querier_metadata(storage_metadata);
-                put_remote_metadata(&*object_store, &metadata).await?;
+                put_remote_metadata(metadata).await?;
             }
         }
     }
@@ -158,7 +154,7 @@ pub async fn run_migration(config: &Parseable) -> anyhow::Result<()> {
     let storage = config.storage.get_object_store();
 
     // Get all stream names
-    let stream_names = storage.list_streams().await?;
+    let stream_names = PARSEABLE.metastore.list_streams().await?;
 
     // Create futures for each stream migration
     let futures = stream_names.into_iter().map(|stream_name| {
@@ -206,7 +202,7 @@ async fn migration_stream(
 ) -> anyhow::Result<Option<LogStreamMetadata>> {
     let mut arrow_schema: Schema = Schema::empty();
 
-    let schema = storage.create_schema_from_storage(stream).await?;
+    let schema = storage.create_schema_from_metastore(stream).await?;
     let stream_metadata = fetch_or_create_stream_metadata(stream, storage).await?;
 
     let mut stream_meta_found = true;
@@ -222,7 +218,7 @@ async fn migration_stream(
         stream_metadata_value =
             serde_json::from_slice(&stream_metadata).expect("stream.json is valid json");
         stream_metadata_value =
-            migrate_stream_metadata(stream_metadata_value, stream, storage, &schema).await?;
+            migrate_stream_metadata(stream_metadata_value, stream, &schema).await?;
     }
 
     if arrow_schema.fields().is_empty() {
@@ -259,12 +255,8 @@ async fn fetch_or_create_stream_metadata(
 async fn migrate_stream_metadata(
     mut stream_metadata_value: Value,
     stream: &str,
-    storage: &dyn ObjectStorage,
     schema: &Bytes,
 ) -> anyhow::Result<Value> {
-    let path = stream_json_path(stream);
-    let schema_path = schema_path(stream);
-
     let version = stream_metadata_value
         .as_object()
         .and_then(|meta| meta.get("version"))
@@ -277,14 +269,16 @@ async fn migrate_stream_metadata(
             stream_metadata_value = stream_metadata_migration::v5_v6(stream_metadata_value);
             stream_metadata_value = stream_metadata_migration::v6_v7(stream_metadata_value);
 
-            storage
-                .put_object(&path, to_bytes(&stream_metadata_value))
+            let stream_json: ObjectStoreFormat =
+                serde_json::from_value(stream_metadata_value.clone())?;
+            PARSEABLE
+                .metastore
+                .put_stream_json(&stream_json, stream)
                 .await?;
+
             let schema = serde_json::from_slice(schema).ok();
             let arrow_schema = schema_migration::v1_v4(schema)?;
-            storage
-                .put_object(&schema_path, to_bytes(&arrow_schema))
-                .await?;
+            PARSEABLE.metastore.put_schema(arrow_schema, stream).await?;
         }
         Some("v2") => {
             stream_metadata_value = stream_metadata_migration::v2_v4(stream_metadata_value);
@@ -292,14 +286,16 @@ async fn migrate_stream_metadata(
             stream_metadata_value = stream_metadata_migration::v5_v6(stream_metadata_value);
             stream_metadata_value = stream_metadata_migration::v6_v7(stream_metadata_value);
 
-            storage
-                .put_object(&path, to_bytes(&stream_metadata_value))
+            let stream_json: ObjectStoreFormat =
+                serde_json::from_value(stream_metadata_value.clone())?;
+            PARSEABLE
+                .metastore
+                .put_stream_json(&stream_json, stream)
                 .await?;
+
             let schema = serde_json::from_slice(schema)?;
             let arrow_schema = schema_migration::v2_v4(schema)?;
-            storage
-                .put_object(&schema_path, to_bytes(&arrow_schema))
-                .await?;
+            PARSEABLE.metastore.put_schema(arrow_schema, stream).await?;
         }
         Some("v3") => {
             stream_metadata_value = stream_metadata_migration::v3_v4(stream_metadata_value);
@@ -307,8 +303,11 @@ async fn migrate_stream_metadata(
             stream_metadata_value = stream_metadata_migration::v5_v6(stream_metadata_value);
             stream_metadata_value = stream_metadata_migration::v6_v7(stream_metadata_value);
 
-            storage
-                .put_object(&path, to_bytes(&stream_metadata_value))
+            let stream_json: ObjectStoreFormat =
+                serde_json::from_value(stream_metadata_value.clone())?;
+            PARSEABLE
+                .metastore
+                .put_stream_json(&stream_json, stream)
                 .await?;
         }
         Some("v4") => {
@@ -316,21 +315,30 @@ async fn migrate_stream_metadata(
             stream_metadata_value = stream_metadata_migration::v5_v6(stream_metadata_value);
             stream_metadata_value = stream_metadata_migration::v6_v7(stream_metadata_value);
 
-            storage
-                .put_object(&path, to_bytes(&stream_metadata_value))
+            let stream_json: ObjectStoreFormat =
+                serde_json::from_value(stream_metadata_value.clone())?;
+            PARSEABLE
+                .metastore
+                .put_stream_json(&stream_json, stream)
                 .await?;
         }
         Some("v5") => {
             stream_metadata_value = stream_metadata_migration::v5_v6(stream_metadata_value);
             stream_metadata_value = stream_metadata_migration::v6_v7(stream_metadata_value);
-            storage
-                .put_object(&path, to_bytes(&stream_metadata_value))
+            let stream_json: ObjectStoreFormat =
+                serde_json::from_value(stream_metadata_value.clone())?;
+            PARSEABLE
+                .metastore
+                .put_stream_json(&stream_json, stream)
                 .await?;
         }
         Some("v6") => {
             stream_metadata_value = stream_metadata_migration::v6_v7(stream_metadata_value);
-            storage
-                .put_object(&path, to_bytes(&stream_metadata_value))
+            let stream_json: ObjectStoreFormat =
+                serde_json::from_value(stream_metadata_value.clone())?;
+            PARSEABLE
+                .metastore
+                .put_stream_json(&stream_json, stream)
                 .await?;
         }
         _ => {
@@ -365,10 +373,11 @@ async fn setup_logstream_metadata(
         ..
     } = serde_json::from_value(stream_metadata_value).unwrap_or_default();
 
-    let storage = PARSEABLE.storage().get_object_store();
-
     update_data_type_time_partition(arrow_schema, time_partition.as_ref()).await?;
-    storage.put_schema(stream, arrow_schema).await?;
+    PARSEABLE
+        .metastore
+        .put_schema(arrow_schema.clone(), stream)
+        .await?;
     fetch_stats_from_storage(stream, stats).await;
     load_daily_metrics(&snapshot.manifest_list, stream);
 
@@ -423,13 +432,13 @@ pub fn get_staging_metadata(config: &Parseable) -> anyhow::Result<Option<serde_j
     Ok(Some(meta))
 }
 
-pub async fn put_remote_metadata(
-    storage: &dyn ObjectStorage,
-    metadata: &serde_json::Value,
-) -> anyhow::Result<()> {
-    let path = parseable_json_path();
-    let metadata = serde_json::to_vec(metadata)?.into();
-    Ok(storage.put_object(&path, metadata).await?)
+pub async fn put_remote_metadata(metadata: serde_json::Value) -> anyhow::Result<()> {
+    let metadata: StorageMetadata = serde_json::from_value(metadata)?;
+    PARSEABLE
+        .metastore
+        .put_parseable_metadata(&metadata)
+        .await?;
+    Ok(())
 }
 
 pub fn put_staging_metadata(

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -238,8 +238,7 @@ async fn fetch_or_create_stream_metadata(
     stream: &str,
     storage: &dyn ObjectStorage,
 ) -> anyhow::Result<Bytes> {
-    let path = stream_json_path(stream);
-    if let Ok(stream_metadata) = storage.get_object(&path).await {
+    if let Ok(stream_metadata) = PARSEABLE.metastore.get_stream_json(stream, false).await {
         Ok(stream_metadata)
     } else {
         let querier_stream = storage

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -660,7 +660,7 @@ impl Stream {
             return Ok(None);
         }
 
-        Ok(Some(Schema::try_merge(schemas).unwrap()))
+        Ok(Some(Schema::try_merge(schemas)?))
     }
 
     fn write_parquet_part_file(

--- a/src/prism/home/mod.rs
+++ b/src/prism/home/mod.rs
@@ -336,8 +336,7 @@ pub async fn generate_home_search_response(
 // Helper functions to split the work
 async fn get_stream_titles(key: &SessionKey) -> Result<Vec<String>, PrismHomeError> {
     let stream_titles: Vec<String> = PARSEABLE
-        .storage
-        .get_object_store()
+        .metastore
         .list_streams()
         .await
         .map_err(|e| PrismHomeError::Anyhow(anyhow::Error::new(e)))?
@@ -477,7 +476,7 @@ pub enum PrismHomeError {
     ObjectStorageError(#[from] ObjectStorageError),
     #[error("Invalid query parameter: {0}")]
     InvalidQueryParameter(String),
-    #[error("{0:?}")]
+    #[error(transparent)]
     MetastoreError(#[from] MetastoreError),
 }
 

--- a/src/prism/home/mod.rs
+++ b/src/prism/home/mod.rs
@@ -22,7 +22,6 @@ use actix_web::http::header::ContentType;
 use chrono::Utc;
 use http::StatusCode;
 use itertools::Itertools;
-use relative_path::RelativePathBuf;
 use serde::Serialize;
 use tracing::error;
 
@@ -33,10 +32,11 @@ use crate::{
         TelemetryType,
         http::{cluster::fetch_daily_stats, logstream::error::StreamError},
     },
+    metastore::MetastoreError,
     parseable::PARSEABLE,
     rbac::{Users, map::SessionKey, role::Action},
     stats::Stats,
-    storage::{ObjectStorageError, ObjectStoreFormat, STREAM_ROOT_DIRECTORY, StreamType},
+    storage::{ObjectStorageError, ObjectStoreFormat, StreamType},
     users::{dashboards::DASHBOARDS, filters::FILTERS},
 };
 
@@ -225,14 +225,9 @@ async fn get_stream_metadata(
     ),
     PrismHomeError,
 > {
-    let path = RelativePathBuf::from_iter([&stream, STREAM_ROOT_DIRECTORY]);
     let obs = PARSEABLE
-        .storage
-        .get_object_store()
-        .get_objects(
-            Some(&path),
-            Box::new(|file_name| file_name.ends_with("stream.json")),
-        )
+        .metastore
+        .get_all_stream_jsons(&stream, None)
         .await?;
 
     let mut stream_jsons = Vec::new();
@@ -482,6 +477,8 @@ pub enum PrismHomeError {
     ObjectStorageError(#[from] ObjectStorageError),
     #[error("Invalid query parameter: {0}")]
     InvalidQueryParameter(String),
+    #[error("{0:?}")]
+    MetastoreError(#[from] MetastoreError),
 }
 
 impl actix_web::ResponseError for PrismHomeError {
@@ -493,12 +490,18 @@ impl actix_web::ResponseError for PrismHomeError {
             PrismHomeError::StreamError(e) => e.status_code(),
             PrismHomeError::ObjectStorageError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             PrismHomeError::InvalidQueryParameter(_) => StatusCode::BAD_REQUEST,
+            PrismHomeError::MetastoreError(e) => e.status_code(),
         }
     }
 
     fn error_response(&self) -> actix_web::HttpResponse<actix_web::body::BoxBody> {
-        actix_web::HttpResponse::build(self.status_code())
-            .insert_header(ContentType::plaintext())
-            .body(self.to_string())
+        match self {
+            PrismHomeError::MetastoreError(e) => actix_web::HttpResponse::build(e.status_code())
+                .insert_header(ContentType::json())
+                .json(e.to_detail()),
+            _ => actix_web::HttpResponse::build(self.status_code())
+                .insert_header(ContentType::plaintext())
+                .body(self.to_string()),
+        }
     }
 }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -43,6 +43,7 @@ use std::ops::Bound;
 use std::sync::Arc;
 use sysinfo::System;
 use tokio::runtime::Runtime;
+use tracing::warn;
 
 use self::error::ExecuteError;
 use self::stream_schema_provider::GlobalSchemaProvider;
@@ -571,8 +572,12 @@ pub async fn get_manifest_list(
         PartialTimeFilter::High(Bound::Included(time_range.end.naive_utc())),
     ];
 
+    warn!(merged_snapshot=?merged_snapshot);
+    warn!(time_filter=?time_filter);
+
     let mut all_manifest_files = Vec::new();
     for manifest_item in merged_snapshot.manifests(&time_filter) {
+        warn!(manifest_item=?manifest_item);
         all_manifest_files.push(
             PARSEABLE
                 .metastore
@@ -580,6 +585,7 @@ pub async fn get_manifest_list(
                     stream_name,
                     manifest_item.time_lower_bound,
                     manifest_item.time_upper_bound,
+                    Some(manifest_item.manifest_path),
                 )
                 .await?
                 .expect("Data is invalid for Manifest"),

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -579,13 +579,15 @@ pub async fn get_manifest_list(
                 stream_name,
                 manifest_item.time_lower_bound,
                 manifest_item.time_upper_bound,
-                Some(manifest_item.manifest_path),
+                Some(manifest_item.manifest_path.clone()),
             )
             .await?;
         let manifest = manifest_opt.ok_or_else(|| {
             QueryError::CustomError(format!(
-                "Manifest not found for {stream_name} [{} - {}]",
-                manifest_item.time_lower_bound, manifest_item.time_upper_bound
+                "Manifest not found for {stream_name} [{} - {}], path- {}",
+                manifest_item.time_lower_bound,
+                manifest_item.time_upper_bound,
+                manifest_item.manifest_path
             ))
         })?;
         all_manifest_files.push(manifest);

--- a/src/query/stream_schema_provider.rs
+++ b/src/query/stream_schema_provider.rs
@@ -421,6 +421,7 @@ async fn collect_from_snapshot(
                     stream_name,
                     manifest_item.time_lower_bound,
                     manifest_item.time_upper_bound,
+                    Some(manifest_item.manifest_path),
                 )
                 .await
                 .map_err(|e| DataFusionError::Plan(e.to_string()))?

--- a/src/storage/azure_blob.rs
+++ b/src/storage/azure_blob.rs
@@ -53,7 +53,7 @@ use crate::{
 
 use super::{
     CONNECT_TIMEOUT_SECS, MIN_MULTIPART_UPLOAD_SIZE, ObjectStorage, ObjectStorageError,
-    ObjectStorageProvider, PARSEABLE_ROOT_DIRECTORY, REQUEST_TIMEOUT_SECS, SCHEMA_FILE_NAME,
+    ObjectStorageProvider, PARSEABLE_ROOT_DIRECTORY, REQUEST_TIMEOUT_SECS,
     STREAM_METADATA_FILE_NAME, STREAM_ROOT_DIRECTORY, metrics_layer::MetricLayer,
     object_storage::parseable_json_path, to_object_store_path,
 };
@@ -568,37 +568,6 @@ impl ObjectStorage for BlobStore {
                 path_arr.push(RelativePathBuf::from(meta.location.as_ref()));
             }
         }
-
-        let time = time.elapsed().as_secs_f64();
-        REQUEST_RESPONSE_TIME
-            .with_label_values(&["GET", "200"])
-            .observe(time);
-
-        Ok(path_arr)
-    }
-
-    async fn get_stream_file_paths(
-        &self,
-        stream_name: &str,
-    ) -> Result<Vec<RelativePathBuf>, ObjectStorageError> {
-        let time = Instant::now();
-        let mut path_arr = vec![];
-        let path = to_object_store_path(&RelativePathBuf::from(stream_name));
-        let mut object_stream = self.client.list(Some(&path));
-
-        while let Some(meta) = object_stream.next().await.transpose()? {
-            let flag = meta.location.filename().unwrap().starts_with(".ingestor");
-
-            if flag {
-                path_arr.push(RelativePathBuf::from(meta.location.as_ref()));
-            }
-        }
-
-        path_arr.push(RelativePathBuf::from_iter([
-            stream_name,
-            STREAM_METADATA_FILE_NAME,
-        ]));
-        path_arr.push(RelativePathBuf::from_iter([stream_name, SCHEMA_FILE_NAME]));
 
         let time = time.elapsed().as_secs_f64();
         REQUEST_RESPONSE_TIME

--- a/src/storage/gcs.rs
+++ b/src/storage/gcs.rs
@@ -51,7 +51,7 @@ use tracing::{error, info};
 
 use super::{
     CONNECT_TIMEOUT_SECS, MIN_MULTIPART_UPLOAD_SIZE, ObjectStorage, ObjectStorageError,
-    ObjectStorageProvider, PARSEABLE_ROOT_DIRECTORY, REQUEST_TIMEOUT_SECS, SCHEMA_FILE_NAME,
+    ObjectStorageProvider, PARSEABLE_ROOT_DIRECTORY, REQUEST_TIMEOUT_SECS,
     STREAM_METADATA_FILE_NAME, STREAM_ROOT_DIRECTORY, metrics_layer::MetricLayer,
     object_storage::parseable_json_path, to_object_store_path,
 };
@@ -475,37 +475,6 @@ impl ObjectStorage for Gcs {
                 path_arr.push(RelativePathBuf::from(meta.location.as_ref()));
             }
         }
-
-        let time = time.elapsed().as_secs_f64();
-        REQUEST_RESPONSE_TIME
-            .with_label_values(&["GET", "200"])
-            .observe(time);
-
-        Ok(path_arr)
-    }
-
-    async fn get_stream_file_paths(
-        &self,
-        stream_name: &str,
-    ) -> Result<Vec<RelativePathBuf>, ObjectStorageError> {
-        let time = Instant::now();
-        let mut path_arr = vec![];
-        let path = to_object_store_path(&RelativePathBuf::from(stream_name));
-        let mut object_stream = self.client.list(Some(&path));
-
-        while let Some(meta) = object_stream.next().await.transpose()? {
-            let flag = meta.location.filename().unwrap().starts_with(".ingestor");
-
-            if flag {
-                path_arr.push(RelativePathBuf::from(meta.location.as_ref()));
-            }
-        }
-
-        path_arr.push(RelativePathBuf::from_iter([
-            stream_name,
-            STREAM_METADATA_FILE_NAME,
-        ]));
-        path_arr.push(RelativePathBuf::from_iter([stream_name, SCHEMA_FILE_NAME]));
 
         let time = time.elapsed().as_secs_f64();
         REQUEST_RESPONSE_TIME

--- a/src/storage/gcs.rs
+++ b/src/storage/gcs.rs
@@ -17,14 +17,13 @@
  */
 
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::HashSet,
     path::Path,
     sync::Arc,
     time::{Duration, Instant},
 };
 
 use crate::{
-    handlers::http::users::USERS_ROOT_DIR,
     metrics::storage::{StorageMetrics, gcs::REQUEST_RESPONSE_TIME},
     parseable::LogStream,
 };
@@ -39,7 +38,7 @@ use datafusion::{
 };
 use futures::{StreamExt, TryStreamExt, stream::FuturesUnordered};
 use object_store::{
-    BackoffConfig, ClientOptions, ObjectMeta, ObjectStore, PutPayload, RetryConfig,
+    BackoffConfig, ClientOptions, ListResult, ObjectMeta, ObjectStore, PutPayload, RetryConfig,
     buffered::BufReader,
     gcp::{GoogleCloudStorage, GoogleCloudStorageBuilder},
     limit::LimitStore,
@@ -52,8 +51,8 @@ use tracing::{error, info};
 use super::{
     CONNECT_TIMEOUT_SECS, MIN_MULTIPART_UPLOAD_SIZE, ObjectStorage, ObjectStorageError,
     ObjectStorageProvider, PARSEABLE_ROOT_DIRECTORY, REQUEST_TIMEOUT_SECS,
-    STREAM_METADATA_FILE_NAME, STREAM_ROOT_DIRECTORY, metrics_layer::MetricLayer,
-    object_storage::parseable_json_path, to_object_store_path,
+    STREAM_METADATA_FILE_NAME, metrics_layer::MetricLayer, object_storage::parseable_json_path,
+    to_object_store_path,
 };
 
 #[derive(Debug, Clone, clap::Args)]
@@ -244,33 +243,33 @@ impl Gcs {
         Ok(())
     }
 
-    async fn _list_streams(&self) -> Result<HashSet<LogStream>, ObjectStorageError> {
-        let mut result_file_list = HashSet::new();
-        let resp = self.client.list_with_delimiter(None).await?;
+    // async fn _list_streams(&self) -> Result<HashSet<LogStream>, ObjectStorageError> {
+    //     let mut result_file_list = HashSet::new();
+    //     let resp = self.client.list_with_delimiter(None).await?;
 
-        let streams = resp
-            .common_prefixes
-            .iter()
-            .flat_map(|path| path.parts())
-            .map(|name| name.as_ref().to_string())
-            .filter(|name| name != PARSEABLE_ROOT_DIRECTORY && name != USERS_ROOT_DIR)
-            .collect::<Vec<_>>();
+    //     let streams = resp
+    //         .common_prefixes
+    //         .iter()
+    //         .flat_map(|path| path.parts())
+    //         .map(|name| name.as_ref().to_string())
+    //         .filter(|name| name != PARSEABLE_ROOT_DIRECTORY && name != USERS_ROOT_DIR)
+    //         .collect::<Vec<_>>();
 
-        for stream in streams {
-            let stream_path =
-                object_store::path::Path::from(format!("{}/{}", &stream, STREAM_ROOT_DIRECTORY));
-            let resp = self.client.list_with_delimiter(Some(&stream_path)).await?;
-            if resp
-                .objects
-                .iter()
-                .any(|name| name.location.filename().unwrap().ends_with("stream.json"))
-            {
-                result_file_list.insert(stream);
-            }
-        }
+    //     for stream in streams {
+    //         let stream_path =
+    //             object_store::path::Path::from(format!("{}/{}", &stream, STREAM_ROOT_DIRECTORY));
+    //         let resp = self.client.list_with_delimiter(Some(&stream_path)).await?;
+    //         if resp
+    //             .objects
+    //             .iter()
+    //             .any(|name| name.location.filename().unwrap().ends_with("stream.json"))
+    //         {
+    //             result_file_list.insert(stream);
+    //         }
+    //     }
 
-        Ok(result_file_list)
-    }
+    //     Ok(result_file_list)
+    // }
 
     async fn _list_dates(&self, stream: &str) -> Result<Vec<String>, ObjectStorageError> {
         let resp = self
@@ -288,37 +287,6 @@ impl Gcs {
             .collect();
 
         Ok(dates)
-    }
-
-    async fn _list_manifest_files(
-        &self,
-        stream: &str,
-    ) -> Result<BTreeMap<String, Vec<String>>, ObjectStorageError> {
-        let mut result_file_list: BTreeMap<String, Vec<String>> = BTreeMap::new();
-        let resp = self
-            .client
-            .list_with_delimiter(Some(&(stream.into())))
-            .await?;
-
-        let dates = resp
-            .common_prefixes
-            .iter()
-            .flat_map(|path| path.parts())
-            .filter(|name| name.as_ref() != stream && name.as_ref() != STREAM_ROOT_DIRECTORY)
-            .map(|name| name.as_ref().to_string())
-            .collect::<Vec<_>>();
-        for date in dates {
-            let date_path = object_store::path::Path::from(format!("{}/{}", stream, &date));
-            let resp = self.client.list_with_delimiter(Some(&date_path)).await?;
-            let manifests: Vec<String> = resp
-                .objects
-                .iter()
-                .filter(|name| name.location.filename().unwrap().ends_with("manifest.json"))
-                .map(|name| name.location.to_string())
-                .collect();
-            result_file_list.entry(date).or_default().extend(manifests);
-        }
-        Ok(result_file_list)
     }
     async fn _upload_file(&self, key: &str, path: &Path) -> Result<(), ObjectStorageError> {
         let instant = Instant::now();
@@ -539,7 +507,10 @@ impl ObjectStorage for Gcs {
     }
 
     async fn list_streams(&self) -> Result<HashSet<LogStream>, ObjectStorageError> {
-        self._list_streams().await
+        // self._list_streams().await
+        Err(ObjectStorageError::Custom(
+            "GCS doesn't implement list_streams".into(),
+        ))
     }
 
     async fn list_old_streams(&self) -> Result<HashSet<LogStream>, ObjectStorageError> {
@@ -632,15 +603,6 @@ impl ObjectStorage for Gcs {
         Ok(minutes)
     }
 
-    async fn list_manifest_files(
-        &self,
-        stream_name: &str,
-    ) -> Result<BTreeMap<String, Vec<String>>, ObjectStorageError> {
-        let files = self._list_manifest_files(stream_name).await?;
-
-        Ok(files)
-    }
-
     async fn upload_file(&self, key: &str, path: &Path) -> Result<(), ObjectStorageError> {
         self._upload_file(key, path).await?;
 
@@ -690,6 +652,13 @@ impl ObjectStorage for Gcs {
             .flat_map(|path| path.parts())
             .map(|name| name.as_ref().to_string())
             .collect::<Vec<_>>())
+    }
+
+    async fn list_with_delimiter(
+        &self,
+        prefix: Option<object_store::path::Path>,
+    ) -> Result<ListResult, ObjectStorageError> {
+        Ok(self.client.list_with_delimiter(prefix.as_ref()).await?)
     }
 
     fn get_bucket_name(&self) -> String {

--- a/src/storage/localfs.rs
+++ b/src/storage/localfs.rs
@@ -17,7 +17,7 @@
  */
 
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::HashSet,
     path::{Path, PathBuf},
     sync::Arc,
     time::Instant,
@@ -28,7 +28,7 @@ use bytes::Bytes;
 use datafusion::{datasource::listing::ListingTableUrl, execution::runtime_env::RuntimeEnvBuilder};
 use fs_extra::file::CopyOptions;
 use futures::{TryStreamExt, stream::FuturesUnordered};
-use object_store::{ObjectMeta, buffered::BufReader};
+use object_store::{ListResult, ObjectMeta, buffered::BufReader};
 use relative_path::{RelativePath, RelativePathBuf};
 use tokio::{
     fs::{self, DirEntry, OpenOptions},
@@ -415,14 +415,6 @@ impl ObjectStorage for LocalFS {
             .collect())
     }
 
-    async fn list_manifest_files(
-        &self,
-        _stream_name: &str,
-    ) -> Result<BTreeMap<String, Vec<String>>, ObjectStorageError> {
-        //unimplemented
-        Ok(BTreeMap::new())
-    }
-
     async fn upload_file(&self, key: &str, path: &Path) -> Result<(), ObjectStorageError> {
         let op = CopyOptions {
             overwrite: true,
@@ -454,6 +446,18 @@ impl ObjectStorage for LocalFS {
 
     fn store_url(&self) -> url::Url {
         url::Url::parse("file:///").unwrap()
+    }
+
+    async fn list_with_delimiter(
+        &self,
+        _prefix: Option<object_store::path::Path>,
+    ) -> Result<ListResult, ObjectStorageError> {
+        Err(ObjectStorageError::UnhandledError(Box::new(
+            std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "list_with_delimiter is not implemented for LocalFS",
+            ),
+        )))
     }
 
     fn get_bucket_name(&self) -> String {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -26,6 +26,7 @@ use crate::{
     event::format::LogSourceEntry,
     handlers::TelemetryType,
     metadata::SchemaVersion,
+    metastore::{MetastoreErrorDetail, metastore_traits::MetastoreObject},
     option::StandaloneWithDistributed,
     parseable::StreamNotFound,
     stats::FullStats,
@@ -127,6 +128,16 @@ pub struct ObjectStoreFormat {
     pub log_source: Vec<LogSourceEntry>,
     #[serde(default)]
     pub telemetry_type: TelemetryType,
+}
+
+impl MetastoreObject for ObjectStoreFormat {
+    fn get_object_path(&self) -> String {
+        unimplemented!()
+    }
+
+    fn get_object_id(&self) -> String {
+        unimplemented!()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -274,6 +285,9 @@ pub enum ObjectStorageError {
 
     #[error("JoinError: {0}")]
     JoinError(#[from] JoinError),
+
+    #[error("MetastoerError: {0:?}")]
+    MetastoreError(Box<MetastoreErrorDetail>),
 }
 
 pub fn to_object_store_path(path: &RelativePath) -> Path {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -286,7 +286,7 @@ pub enum ObjectStorageError {
     #[error("JoinError: {0}")]
     JoinError(#[from] JoinError),
 
-    #[error("MetastoerError: {0:?}")]
+    #[error("MetastoreError: {0:?}")]
     MetastoreError(Box<MetastoreErrorDetail>),
 }
 

--- a/src/storage/object_storage.rs
+++ b/src/storage/object_storage.rs
@@ -274,17 +274,6 @@ pub trait ObjectStorage: Debug + Send + Sync + 'static {
         prefix: Option<object_store::path::Path>,
     ) -> Result<ListResult, ObjectStorageError>;
 
-    // async fn put_schema(
-    //     &self,
-    //     stream_name: &str,
-    //     schema: &Schema,
-    // ) -> Result<(), ObjectStorageError> {
-    //     self.put_object(&schema_path(stream_name), to_bytes(schema))
-    //         .await?;
-
-    //     Ok(())
-    // }
-
     async fn create_stream(
         &self,
         stream_name: &str,

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -54,7 +54,7 @@ use crate::{
 
 use super::{
     CONNECT_TIMEOUT_SECS, MIN_MULTIPART_UPLOAD_SIZE, ObjectStorage, ObjectStorageError,
-    ObjectStorageProvider, PARSEABLE_ROOT_DIRECTORY, REQUEST_TIMEOUT_SECS, SCHEMA_FILE_NAME,
+    ObjectStorageProvider, PARSEABLE_ROOT_DIRECTORY, REQUEST_TIMEOUT_SECS,
     STREAM_METADATA_FILE_NAME, STREAM_ROOT_DIRECTORY, metrics_layer::MetricLayer,
     object_storage::parseable_json_path, to_object_store_path,
 };
@@ -651,37 +651,6 @@ impl ObjectStorage for S3 {
                 path_arr.push(RelativePathBuf::from(meta.location.as_ref()));
             }
         }
-
-        let time = time.elapsed().as_secs_f64();
-        REQUEST_RESPONSE_TIME
-            .with_label_values(&["GET", "200"])
-            .observe(time);
-
-        Ok(path_arr)
-    }
-
-    async fn get_stream_file_paths(
-        &self,
-        stream_name: &str,
-    ) -> Result<Vec<RelativePathBuf>, ObjectStorageError> {
-        let time = Instant::now();
-        let mut path_arr = vec![];
-        let path = to_object_store_path(&RelativePathBuf::from(stream_name));
-        let mut object_stream = self.client.list(Some(&path));
-
-        while let Some(meta) = object_stream.next().await.transpose()? {
-            let flag = meta.location.filename().unwrap().starts_with(".ingestor");
-
-            if flag {
-                path_arr.push(RelativePathBuf::from(meta.location.as_ref()));
-            }
-        }
-
-        path_arr.push(RelativePathBuf::from_iter([
-            stream_name,
-            STREAM_METADATA_FILE_NAME,
-        ]));
-        path_arr.push(RelativePathBuf::from_iter([stream_name, SCHEMA_FILE_NAME]));
 
         let time = time.elapsed().as_secs_f64();
         REQUEST_RESPONSE_TIME

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -346,7 +346,7 @@ impl S3 {
                 REQUEST_RESPONSE_TIME
                     .with_label_values(&["GET", "200"])
                     .observe(time);
-                let body = resp.bytes().await.unwrap();
+                let body = resp.bytes().await?;
                 Ok(body)
             }
             Err(err) => {

--- a/src/users/dashboards.rs
+++ b/src/users/dashboards.rs
@@ -25,7 +25,8 @@ use tokio::sync::RwLock;
 use ulid::Ulid;
 
 use crate::{
-    handlers::http::users::dashboards::DashboardError, parseable::PARSEABLE,
+    handlers::http::users::dashboards::DashboardError,
+    metastore::metastore_traits::MetastoreObject, parseable::PARSEABLE,
     storage::object_storage::dashboard_path,
 };
 
@@ -65,6 +66,8 @@ pub struct Dashboard {
     dashboard_type: Option<DashboardType>,
     pub tiles: Option<Vec<Tile>>,
 }
+
+impl MetastoreObject for Dashboard {}
 
 impl Dashboard {
     /// set metadata for the dashboard

--- a/src/users/dashboards.rs
+++ b/src/users/dashboards.rs
@@ -296,12 +296,11 @@ impl Dashboards {
         user_id: &str,
         dashboard_id: Ulid,
     ) -> Result<(), DashboardError> {
-        self.ensure_dashboard_ownership(dashboard_id, user_id)
+        let obj = self.ensure_dashboard_ownership(dashboard_id, user_id)
             .await?;
 
         {
             // validation has happened, dashboard exists and can be deleted by the user
-            let obj = self.get_dashboard(dashboard_id).await.unwrap();
             PARSEABLE.metastore.delete_dashboard(&obj).await?;
         }
 

--- a/src/users/dashboards.rs
+++ b/src/users/dashboards.rs
@@ -68,7 +68,7 @@ pub struct Dashboard {
 }
 
 impl MetastoreObject for Dashboard {
-    fn get_path(&self) -> String {
+    fn get_object_path(&self) -> String {
         RelativePathBuf::from_iter([
             USERS_ROOT_DIR,
             self.author.as_ref().unwrap(),
@@ -78,7 +78,7 @@ impl MetastoreObject for Dashboard {
         .to_string()
     }
 
-    fn get_id(&self) -> String {
+    fn get_object_id(&self) -> String {
         self.dashboard_id.unwrap().to_string()
     }
 }

--- a/src/users/dashboards.rs
+++ b/src/users/dashboards.rs
@@ -16,18 +16,18 @@
  *
  */
 
-use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use once_cell::sync::Lazy;
+use relative_path::RelativePathBuf;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::sync::RwLock;
 use ulid::Ulid;
 
 use crate::{
-    handlers::http::users::dashboards::DashboardError,
-    metastore::metastore_traits::MetastoreObject, parseable::PARSEABLE,
-    storage::object_storage::dashboard_path,
+    handlers::http::users::{DASHBOARDS_DIR, USERS_ROOT_DIR, dashboards::DashboardError},
+    metastore::metastore_traits::MetastoreObject,
+    parseable::PARSEABLE,
 };
 
 pub static DASHBOARDS: Lazy<Dashboards> = Lazy::new(Dashboards::default);
@@ -67,7 +67,21 @@ pub struct Dashboard {
     pub tiles: Option<Vec<Tile>>,
 }
 
-impl MetastoreObject for Dashboard {}
+impl MetastoreObject for Dashboard {
+    fn get_path(&self) -> String {
+        RelativePathBuf::from_iter([
+            USERS_ROOT_DIR,
+            self.author.as_ref().unwrap(),
+            DASHBOARDS_DIR,
+            &format!("{}.json", self.dashboard_id.unwrap()),
+        ])
+        .to_string()
+    }
+
+    fn get_id(&self) -> String {
+        self.dashboard_id.unwrap().to_string()
+    }
+}
 
 impl Dashboard {
     /// set metadata for the dashboard
@@ -164,31 +178,27 @@ impl Dashboards {
     /// This function is called on server start
     pub async fn load(&self) -> anyhow::Result<()> {
         let mut this = vec![];
-        let store = PARSEABLE.storage.get_object_store();
-        let all_dashboards = store.get_all_dashboards().await.unwrap_or_default();
 
-        for (_, dashboards) in all_dashboards {
-            for dashboard in dashboards {
-                if dashboard.is_empty() {
+        let all_dashboards = PARSEABLE.metastore.get_dashboards().await?;
+
+        for dashboard in all_dashboards {
+            if dashboard.is_empty() {
+                continue;
+            }
+
+            let dashboard_value = match serde_json::from_slice::<serde_json::Value>(&dashboard) {
+                Ok(value) => value,
+                Err(err) => {
+                    tracing::warn!("Failed to parse dashboard JSON: {}", err);
                     continue;
                 }
+            };
 
-                let dashboard_value = match serde_json::from_slice::<serde_json::Value>(&dashboard)
-                {
-                    Ok(value) => value,
-                    Err(err) => {
-                        tracing::warn!("Failed to parse dashboard JSON: {}", err);
-                        continue;
-                    }
-                };
-
-                if let Ok(dashboard) = serde_json::from_value::<Dashboard>(dashboard_value.clone())
-                {
-                    this.retain(|d: &Dashboard| d.dashboard_id != dashboard.dashboard_id);
-                    this.push(dashboard);
-                } else {
-                    tracing::warn!("Failed to deserialize dashboard: {:?}", dashboard_value);
-                }
+            if let Ok(dashboard) = serde_json::from_value::<Dashboard>(dashboard_value.clone()) {
+                this.retain(|d: &Dashboard| d.dashboard_id != dashboard.dashboard_id);
+                this.push(dashboard);
+            } else {
+                tracing::warn!("Failed to deserialize dashboard: {:?}", dashboard_value);
             }
         }
 
@@ -202,19 +212,10 @@ impl Dashboards {
     /// This function is called when creating or updating a dashboard
     async fn save_dashboard(
         &self,
-        user_id: &str,
+        // user_id: &str,
         dashboard: &Dashboard,
     ) -> Result<(), DashboardError> {
-        let dashboard_id = dashboard
-            .dashboard_id
-            .ok_or(DashboardError::Metadata("Dashboard ID must be provided"))?;
-
-        let path = dashboard_path(user_id, &format!("{dashboard_id}.json"));
-        let store = PARSEABLE.storage.get_object_store();
-        let dashboard_bytes = serde_json::to_vec(&dashboard)?;
-        store
-            .put_object(&path, Bytes::from(dashboard_bytes))
-            .await?;
+        PARSEABLE.metastore.put_dashboard(dashboard).await?;
 
         Ok(())
     }
@@ -240,7 +241,7 @@ impl Dashboards {
             return Err(DashboardError::Metadata("Dashboard title must be unique"));
         }
 
-        self.save_dashboard(user_id, dashboard).await?;
+        self.save_dashboard(dashboard).await?;
 
         dashboards.push(dashboard.clone());
 
@@ -279,7 +280,7 @@ impl Dashboards {
             return Err(DashboardError::Metadata("Dashboard title must be unique"));
         }
 
-        self.save_dashboard(user_id, dashboard).await?;
+        self.save_dashboard(dashboard).await?;
 
         dashboards.retain(|d| d.dashboard_id != Some(dashboard_id));
         dashboards.push(dashboard.clone());
@@ -298,10 +299,13 @@ impl Dashboards {
         self.ensure_dashboard_ownership(dashboard_id, user_id)
             .await?;
 
-        let path = dashboard_path(user_id, &format!("{dashboard_id}.json"));
-        let store = PARSEABLE.storage.get_object_store();
-        store.delete_object(&path).await?;
+        {
+            // validation has happened, dashboard exists and can be deleted by the user
+            let obj = self.get_dashboard(dashboard_id).await.unwrap();
+            PARSEABLE.metastore.delete_dashboard(&obj).await?;
+        }
 
+        // delete from in-memory
         self.0
             .write()
             .await

--- a/src/users/filters.rs
+++ b/src/users/filters.rs
@@ -47,7 +47,7 @@ pub struct Filter {
 }
 
 impl MetastoreObject for Filter {
-    fn get_path(&self) -> String {
+    fn get_object_path(&self) -> String {
         filter_path(
             self.user_id.as_ref().unwrap(),
             &self.stream_name,
@@ -56,7 +56,7 @@ impl MetastoreObject for Filter {
         .to_string()
     }
 
-    fn get_id(&self) -> String {
+    fn get_object_id(&self) -> String {
         self.filter_id.as_ref().unwrap().clone()
     }
 }

--- a/src/users/filters.rs
+++ b/src/users/filters.rs
@@ -23,7 +23,7 @@ use tokio::sync::RwLock;
 
 use super::TimeFilter;
 use crate::{
-    migration::to_bytes,
+    metastore::metastore_traits::MetastoreObject,
     parseable::PARSEABLE,
     rbac::{Users, map::SessionKey},
     storage::object_storage::filter_path,
@@ -44,6 +44,21 @@ pub struct Filter {
     /// all other fields are variable and can be added as needed
     #[serde(flatten)]
     pub other_fields: Option<serde_json::Map<String, Value>>,
+}
+
+impl MetastoreObject for Filter {
+    fn get_path(&self) -> String {
+        filter_path(
+            self.user_id.as_ref().unwrap(),
+            &self.stream_name,
+            &format!("{}.json", self.filter_id.as_ref().unwrap()),
+        )
+        .to_string()
+    }
+
+    fn get_id(&self) -> String {
+        self.filter_id.as_ref().unwrap().clone()
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -98,58 +113,10 @@ pub struct Filters(RwLock<Vec<Filter>>);
 
 impl Filters {
     pub async fn load(&self) -> anyhow::Result<()> {
-        let mut this = vec![];
-        let store = PARSEABLE.storage.get_object_store();
-        let all_filters = store.get_all_saved_filters().await.unwrap_or_default();
-        for (filter_relative_path, filters) in all_filters {
-            for filter in filters {
-                if filter.is_empty() {
-                    continue;
-                }
-                let mut filter_value = serde_json::from_slice::<serde_json::Value>(&filter)?;
-                if let Some(meta) = filter_value.clone().as_object() {
-                    let version = meta.get("version").and_then(|version| version.as_str());
-
-                    if version == Some("v1") {
-                        //delete older version of the filter
-                        store.delete_object(&filter_relative_path).await?;
-
-                        filter_value = migrate_v1_v2(filter_value);
-                        let user_id = filter_value
-                            .as_object()
-                            .unwrap()
-                            .get("user_id")
-                            .and_then(|user_id| user_id.as_str());
-                        let filter_id = filter_value
-                            .as_object()
-                            .unwrap()
-                            .get("filter_id")
-                            .and_then(|filter_id| filter_id.as_str());
-                        let stream_name = filter_value
-                            .as_object()
-                            .unwrap()
-                            .get("stream_name")
-                            .and_then(|stream_name| stream_name.as_str());
-                        if let (Some(user_id), Some(stream_name), Some(filter_id)) =
-                            (user_id, stream_name, filter_id)
-                        {
-                            let path =
-                                filter_path(user_id, stream_name, &format!("{filter_id}.json"));
-                            let filter_bytes = to_bytes(&filter_value);
-                            store.put_object(&path, filter_bytes.clone()).await?;
-                        }
-                    }
-
-                    if let Ok(filter) = serde_json::from_value::<Filter>(filter_value) {
-                        this.retain(|f: &Filter| f.filter_id != filter.filter_id);
-                        this.push(filter);
-                    }
-                }
-            }
-        }
+        let all_filters = PARSEABLE.metastore.get_filters().await.unwrap_or_default();
 
         let mut s = self.0.write().await;
-        s.append(&mut this);
+        s.extend(all_filters);
 
         Ok(())
     }
@@ -205,7 +172,7 @@ impl Filters {
     }
 }
 
-fn migrate_v1_v2(mut filter_meta: Value) -> Value {
+pub fn migrate_v1_v2(mut filter_meta: Value) -> Value {
     let filter_meta_map = filter_meta.as_object_mut().unwrap();
     let user_id = filter_meta_map.get("user_id").unwrap().clone();
     let str_user_id = user_id.as_str().unwrap();


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

This PR introduces Metastore to Parseable. Anything that is not parquet can be considered as metadata. Up till now, all metadata was stored as objects in object-storage. The new traits `Metastore` and `MetastoreObject` allow users to implement their own metastores. By default, Parseable uses Object store as metastore.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Central Metastore added and exposed as a public capability.

- **Refactor**
  - Platform-wide migration: metadata reads/writes moved from object-store files to the Metastore across alerts, streams, manifests, schemas, dashboards, filters, targets, correlations, chats, nodes, and tooling.

- **User-visible behavior**
  - Listings, metadata endpoints, and persistence now use Metastore-backed data; Metastore failures surface as structured JSON error details.

- **Chores**
  - Two new dependencies added to the build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->