### PR TITLE
Refactor date binning logic and SQL query formatting

### DIFF
--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -167,7 +167,6 @@ async fn handle_count_query(
         stream: table_name.to_string(),
         start_time: query_request.start_time.clone(),
         end_time: query_request.end_time.clone(),
-        num_bins: 1,
         conditions: None,
     };
     let count_records = counts_req.get_bin_density().await?;

--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -167,6 +167,7 @@ async fn handle_count_query(
         stream: table_name.to_string(),
         start_time: query_request.start_time.clone(),
         end_time: query_request.end_time.clone(),
+        num_bins: Some(1),
         conditions: None,
     };
     let count_records = counts_req.get_bin_density().await?;

--- a/src/prism/logstream/mod.rs
+++ b/src/prism/logstream/mod.rs
@@ -351,6 +351,7 @@ impl PrismDatasetRequest {
             stream: stream.to_owned(),
             start_time: "1h".to_owned(),
             end_time: "now".to_owned(),
+            num_bins: Some(10),
             conditions: None,
         };
 

--- a/src/prism/logstream/mod.rs
+++ b/src/prism/logstream/mod.rs
@@ -351,7 +351,6 @@ impl PrismDatasetRequest {
             stream: stream.to_owned(),
             start_time: "1h".to_owned(),
             end_time: "now".to_owned(),
-            num_bins: 10,
             conditions: None,
         };
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Adaptive, tiered time-binning for count queries (1 minute → 1 day) for more relevant aggregations.
  * Query results grouped and ordered consistently by bin end/start for clearer timelines.

* **API**
  * Responses provide start_time and end_time; legacy bin start/end keys are accepted and mapped automatically.

* **Breaking Changes**
  * num_bins is now optional — bin counts are auto-computed when omitted; supplying num_bins is still supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->