### PR TITLE
Add missing key 'secret' to logstream-job helm template.

### DIFF
--- a/helm/templates/logstream-job.yaml
+++ b/helm/templates/logstream-job.yaml
@@ -47,7 +47,7 @@ spec:
             {{- end }}
             {{- end }}
             {{- else}}
-            {{- range $secret := .Values.parseable.s3ModeSecret }}
+            {{- range $secret := .Values.parseable.s3ModeSecret.secrets }}
             {{- range $key := $secret.keys }}
             {{- $envPrefix := $secret.prefix | default "" | upper }}
             {{- $envKey := $key | upper | replace "." "_" | replace "-" "_" }}


### PR DESCRIPTION
Fixes #1433.

### Description

Enabling logstream currently triggers the logstream-job template, but it incorrectly iterates over .Values.parseable.s3ModeSecret instead of .Values.parseable.s3ModeSecret.secrets.
This causes the template to fail when trying to access keys because they are nested under the secrets key.

The fix updates the helm/templates/logstream-job.yaml file to correctly iterate over .Values.parseable.s3ModeSecret.secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of S3 mode secrets in the Helm chart for the logstream job, ensuring secrets defined as an array under the S3 configuration are correctly read and injected as environment variables in non-local deployments.
  * Improves reliability of environment variable population from secrets. Users may need to align values to the updated array structure if using custom configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->