### PR TITLE
fix: allow @ in the username

### DIFF
--- a/src/validator.rs
+++ b/src/validator.rs
@@ -118,7 +118,7 @@ pub fn user_role_name(name: &str) -> Result<(), UsernameValidationError> {
                 prev_was_special = false;
             }
             // Allow specific special characters
-            '_' | '-' | '.' => {
+            '_' | '-' | '.' | '@' => {
                 if prev_was_special {
                     return Err(UsernameValidationError::ConsecutiveSpecialChars);
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Role names now support the “@” character, making it easier to align with common naming conventions (e.g., email-like identifiers).
  * Validation continues to allow alphanumeric characters and select special characters while still preventing consecutive special characters, preserving existing safeguards during role creation and renaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->