### PR TITLE
feat: save alert state history

### DIFF
--- a/src/alerts/mod.rs
+++ b/src/alerts/mod.rs
@@ -49,8 +49,9 @@ pub use crate::alerts::alert_enums::{
     LogicalOperator, NotificationState, Severity, WhereConfigOperator,
 };
 pub use crate::alerts::alert_structs::{
-    AlertConfig, AlertInfo, AlertRequest, Alerts, AlertsInfo, AlertsInfoByState, AlertsSummary,
-    BasicAlertFields, Context, DeploymentInfo, RollingWindow, ThresholdConfig,
+    AlertConfig, AlertInfo, AlertRequest, AlertStateEntry, Alerts, AlertsInfo, AlertsInfoByState,
+    AlertsSummary, BasicAlertFields, Context, DeploymentInfo, RollingWindow, StateTransition,
+    ThresholdConfig,
 };
 use crate::alerts::alert_traits::{AlertManagerTrait, AlertTrait};
 use crate::alerts::alert_types::ThresholdAlert;

--- a/src/metastore/metastore_traits.rs
+++ b/src/metastore/metastore_traits.rs
@@ -24,10 +24,15 @@ use chrono::{DateTime, Utc};
 use dashmap::DashMap;
 use erased_serde::Serialize as ErasedSerialize;
 use tonic::async_trait;
+use ulid::Ulid;
 
 use crate::{
-    alerts::target::Target, catalog::manifest::Manifest, handlers::http::modal::NodeType,
-    metastore::MetastoreError, option::Mode, users::filters::Filter,
+    alerts::{alert_structs::AlertStateEntry, target::Target},
+    catalog::manifest::Manifest,
+    handlers::http::modal::NodeType,
+    metastore::MetastoreError,
+    option::Mode,
+    users::filters::Filter,
 };
 
 /// A metastore is a logically separated compartment to store metadata for Parseable.
@@ -43,6 +48,15 @@ pub trait Metastore: std::fmt::Debug + Send + Sync {
     async fn get_alerts(&self) -> Result<Vec<Bytes>, MetastoreError>;
     async fn put_alert(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError>;
     async fn delete_alert(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError>;
+
+    /// alerts state
+    async fn get_alert_states(&self) -> Result<Vec<AlertStateEntry>, MetastoreError>;
+    async fn get_alert_state_entry(
+        &self,
+        alert_id: &Ulid,
+    ) -> Result<Option<AlertStateEntry>, MetastoreError>;
+    async fn put_alert_state(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError>;
+    async fn delete_alert_state(&self, obj: &dyn MetastoreObject) -> Result<(), MetastoreError>;
 
     /// llmconfig
     async fn get_llmconfigs(&self) -> Result<Vec<Bytes>, MetastoreError>;

--- a/src/storage/object_storage.rs
+++ b/src/storage/object_storage.rs
@@ -1142,6 +1142,16 @@ pub fn target_json_path(target_id: &Ulid) -> RelativePathBuf {
     ])
 }
 
+/// Constructs the path for storing alert state JSON files
+/// Format: ".parseable/alerts/alert_state_{alert_id}.json"
+#[inline(always)]
+pub fn alert_state_json_path(alert_id: Ulid) -> RelativePathBuf {
+    RelativePathBuf::from_iter([
+        ALERTS_ROOT_DIRECTORY,
+        &format!("alert_state_{alert_id}.json"),
+    ])
+}
+
 #[inline(always)]
 pub fn manifest_path(prefix: &str) -> RelativePathBuf {
     let hostname = hostname::get()


### PR DESCRIPTION
state history for an alert is saved at path .alerts/alert_state_{alertid}.json details to save - state, last_updated_at
use to show full track of a lifecycle of an alert
not triggered -> triggered -> disabled (if disabled by user) -> not triggered (when issue is resolved)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added persistent alert state history with timestamps, enabling accurate tracking of state changes over time.
  - Alerts now create and remove corresponding state entries on add/delete, keeping stored state aligned with in-memory status.
- Bug Fixes
  - Local file storage now correctly reports object metadata, improving reliability for storage operations.
- Chores
  - Backend metastore expanded to support listing, retrieving, updating, and deleting alert state records, reducing unnecessary writes by only persisting real state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->