### PR TITLE
fix: read directory error on localfs

### DIFF
--- a/src/storage/localfs.rs
+++ b/src/storage/localfs.rs
@@ -471,6 +471,10 @@ impl ObjectStorage for LocalFS {
                 read_dir
             }
             Err(err) => {
+                if err.kind() == std::io::ErrorKind::NotFound {
+                    return Ok(Vec::new());
+                }
+
                 return Err(err.into());
             }
         };
@@ -501,6 +505,10 @@ impl ObjectStorage for LocalFS {
         let read_dir = match result {
             Ok(read_dir) => read_dir,
             Err(err) => {
+                if err.kind() == std::io::ErrorKind::NotFound {
+                    return Ok(Vec::new());
+                }
+
                 return Err(err.into());
             }
         };
@@ -531,6 +539,10 @@ impl ObjectStorage for LocalFS {
                 read_dir
             }
             Err(err) => {
+                if err.kind() == std::io::ErrorKind::NotFound {
+                    return Ok(Vec::new());
+                }
+
                 return Err(err.into());
             }
         };


### PR DESCRIPTION
When DataFusion tries to query a date range where no manifest exists, 
it calls into the listing table functionality
The listing table builder tries to generate prefixes and list directories for those date ranges

Previously, if those directories didn't exist,
it would return an error that propagated up as a DataFusion External error
```
Execution Error: Query Execution failed due to error in datafusion: External error: IO Error: No such file or directory (os error 2)
```

Now, it gracefully returns an empty list,
allowing the query to continue and return no results instead of failing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when accessing missing directories. File listing operations now gracefully return empty results instead of failing when directories don't exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->