### PR TITLE
Upgrade df version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -94,6 +94,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
+      - name: Set up QEMU for cross-arch builds
+        if: matrix.use_cross
+        uses: docker/setup-qemu-action@v3
+      
       # Linux-specific dependencies for native x86_64 build
       - name: Install Linux dependencies (x86_64)
         if: runner.os == 'Linux' && matrix.target == 'x86_64-unknown-linux-gnu'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,35 +15,42 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Linux builds
+          # Linux builds - x86_64 native, aarch64 cross-compile
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            use_cross: false
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-          # macOS builds  
+            use_cross: true
+          # macOS builds - both native on macos-latest (M1)
           - os: macos-latest
             target: x86_64-apple-darwin
+            use_cross: false
           - os: macos-latest
             target: aarch64-apple-darwin
+            use_cross: false
           # Windows build
           - os: windows-latest
             target: x86_64-pc-windows-msvc
+            use_cross: false
     steps:
       - uses: actions/checkout@v4
+      
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+      
       - name: Install GCC 11 on Linux
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-11 g++-11
-      - name: Set CC and CXX to gcc-11
-        if: runner.os == 'Linux'
-        run: |
-          echo "CC=gcc-11" >> $GITHUB_ENV
-          echo "CXX=g++-11" >> $GITHUB_ENV
+      
+      - name: Install cross
+        if: matrix.use_cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+      
       - name: Cache dependencies
         uses: actions/cache@v4
         with:
@@ -52,12 +59,18 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ matrix.target }}-default-${{ hashFiles('**/Cargo.lock') }}
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: ${{ runner.os == 'Linux' }}
-          command: build
-          args: --target ${{ matrix.target }} --release
+      
+      - name: Build with cross
+        if: matrix.use_cross
+        run: cross build --target ${{ matrix.target }} --release
+      
+      - name: Build native
+        if: ${{ !matrix.use_cross }}
+        env:
+          CC: ${{ runner.os == 'Linux' && 'gcc-11' || '' }}
+          CXX: ${{ runner.os == 'Linux' && 'g++-11' || '' }}
+        run: cargo build --target ${{ matrix.target }} --release
+
   # Kafka build for supported platforms
   build-kafka:
     name: Build Kafka ${{matrix.target}}
@@ -66,19 +79,29 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Linux builds
+          # Linux x86_64 - native build
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            use_cross: false
+          # Linux aarch64 - cross-compile
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            use_cross: true
+          # macOS aarch64 - native on M1
           - os: macos-latest
             target: aarch64-apple-darwin
+            use_cross: false
     steps:
       - uses: actions/checkout@v4
-      # Linux-specific dependencies
-      - name: Install Linux dependencies
-        if: runner.os == 'Linux'
+      
+      # Linux-specific dependencies for native x86_64 build
+      - name: Install Linux dependencies (x86_64)
+        if: runner.os == 'Linux' && matrix.target == 'x86_64-unknown-linux-gnu'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
+            gcc-11 \
+            g++-11 \
             build-essential \
             pkg-config \
             cmake \
@@ -88,29 +111,23 @@ jobs:
             liblz4-dev \
             libssl-dev \
             libsasl2-dev \
-            python3 \
-            gcc-aarch64-linux-gnu \
-            g++-aarch64-linux-gnu
-          # Install cross-compilation specific packages
-          if [ "${{ matrix.target }}" = "aarch64-unknown-linux-gnu" ]; then
-            sudo apt-get install -y \
-              gcc-aarch64-linux-gnu \
-              g++-aarch64-linux-gnu \
-              libc6-dev-arm64-cross \
-              libsasl2-dev:arm64 \
-              libssl-dev:arm64 \
-              pkg-config-aarch64-linux-gnu
-          fi
-      - name: Install GCC 11 on Linux
-        if: runner.os == 'Linux'
+            python3
+      
+      # Linux dependencies for aarch64 cross-compilation
+      - name: Install Linux dependencies (aarch64 cross)
+        if: runner.os == 'Linux' && matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-11 g++-11
-      - name: Set CC and CXX to gcc-11
-        if: runner.os == 'Linux'
-        run: |
-          echo "CC=gcc-11" >> $GITHUB_ENV
-          echo "CXX=g++-11" >> $GITHUB_ENV
+          sudo apt-get install -y \
+            gcc-11 \
+            g++-11 \
+            build-essential \
+            pkg-config \
+            cmake \
+            clang \
+            gcc-aarch64-linux-gnu \
+            g++-aarch64-linux-gnu
+      
       # macOS-specific dependencies
       - name: Install macOS dependencies
         if: runner.os == 'macOS'
@@ -123,10 +140,16 @@ jobs:
             openssl@3.0 \
             cyrus-sasl \
             python3
+      
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+      
+      - name: Install cross
+        if: matrix.use_cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+      
       - name: Cache dependencies
         uses: actions/cache@v4
         with:
@@ -135,8 +158,9 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ matrix.target }}-kafka-${{ hashFiles('**/Cargo.lock') }}
+      
       - name: Find and fix librdkafka CMakeLists.txt for Linux
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && !matrix.use_cross
         run: |
           cargo fetch
           # Find the rdkafka-sys package directory
@@ -156,6 +180,7 @@ jobs:
             echo "Could not find librdkafka CMakeLists.txt file!"
             exit 1
           fi
+      
       - name: Find and fix librdkafka CMakeLists.txt for macOS
         if: runner.os == 'macOS'
         run: |
@@ -177,18 +202,15 @@ jobs:
             echo "Could not find librdkafka CMakeLists.txt file!"
             exit 1
           fi
-      - name: Build with Kafka
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: ${{ runner.os == 'Linux' }}
-          command: build
-          args: --target ${{ matrix.target }} --features kafka --release
+      
+      - name: Build with Kafka (cross)
+        if: matrix.use_cross
+        run: cross build --target ${{ matrix.target }} --features kafka --release
+      
+      - name: Build with Kafka (native)
+        if: ${{ !matrix.use_cross }}
         env:
+          CC: ${{ runner.os == 'Linux' && 'gcc-11' || '' }}
+          CXX: ${{ runner.os == 'Linux' && 'g++-11' || '' }}
           LIBRDKAFKA_SSL_VENDORED: 1
-          PKG_CONFIG_ALLOW_CROSS: "1"
-          PKG_CONFIG_PATH: /usr/lib/aarch64-linux-gnu/pkgconfig
-          SASL2_DIR: /usr/lib/aarch64-linux-gnu
-          OPENSSL_DIR: /usr/lib/aarch64-linux-gnu
-          OPENSSL_ROOT_DIR: /usr/lib/aarch64-linux-gnu
-          OPENSSL_STATIC: "1"
-          SASL2_STATIC: "0"
+        run: cargo build --target ${{ matrix.target }} --features kafka --release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -206,6 +206,7 @@ jobs:
             exit 1
           fi
 
+      - name: Build with Kafka (cross) - FIXED
         if: matrix.use_cross
         env:
           LIBRDKAFKA_SSL_VENDORED: "1"
@@ -228,3 +229,11 @@ jobs:
           env | grep -E 'ZLIB_|OPENSSL_|PKG_CONFIG|LIBRDKAFKA'
           echo "=== NOW RUNNING CROSS BUILD (pre-build will show zlib paths) ==="
           cross build --target ${{ matrix.target }} --features kafka --release --verbose
+
+      - name: Build with Kafka (native)
+        if: ${{ !matrix.use_cross }}
+        env:
+          CC: ${{ runner.os == 'Linux' && 'gcc-11' || '' }}
+          CXX: ${{ runner.os == 'Linux' && 'g++-11' || '' }}
+          LIBRDKAFKA_SSL_VENDORED: "1"
+        run: cargo build --target ${{ matrix.target }} --features kafka --release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -94,6 +94,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
+      - name: Set up Docker Buildx
+        if: matrix.use_cross
+        uses: docker/setup-buildx-action@v3
+      
       - name: Set up QEMU for cross-arch builds
         if: matrix.use_cross
         uses: docker/setup-qemu-action@v3
@@ -138,36 +142,6 @@ jobs:
       - name: Install cross for aarch64
         if: matrix.use_cross
         run: cargo install cross --git https://github.com/cross-rs/cross
-      
-      - name: Create Cross.toml for aarch64 Kafka build
-        if: matrix.use_cross && matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          cat > Cross.toml << 'EOF'
-          [target.aarch64-unknown-linux-gnu]
-          pre-build = [
-              "dpkg --add-architecture arm64",
-              "sed -i 's/deb http/deb [arch=amd64] http/g' /etc/apt/sources.list",
-              "echo 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ focal main restricted universe multiverse' >> /etc/apt/sources.list",
-              "echo 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ focal-updates main restricted universe multiverse' >> /etc/apt/sources.list",
-              "apt-get update || true",
-              "apt-get install -y pkg-config:arm64 || true",
-              "apt-get install -y zlib1g-dev:arm64 || true",
-              "apt-get install -y libssl-dev:arm64 || true", 
-              "apt-get install -y libsasl2-dev:arm64 || true",
-              "apt-get install -y libzstd-dev:arm64 || true",
-              "apt-get install -y liblz4-dev:arm64 || true",
-          ]
-          
-          [build.env]
-          passthrough = [
-              "LIBRDKAFKA_SSL_VENDORED",
-              "PKG_CONFIG_ALLOW_CROSS",
-          ]
-          volumes = [
-              "/usr/lib/aarch64-linux-gnu:/usr/lib/aarch64-linux-gnu",
-          ]
-          EOF
-          cat Cross.toml
       
       - name: Cache dependencies
         uses: actions/cache@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -101,16 +101,16 @@ jobs:
               libssl-dev:arm64 \
               pkg-config-aarch64-linux-gnu
           fi
-        - name: Install GCC 11 on Linux
-          if: runner.os == 'Linux'
-          run: |
-            sudo apt-get update
-            sudo apt-get install -y gcc-11 g++-11
-        - name: Set CC and CXX to gcc-11
-          if: runner.os == 'Linux'
-          run: |
-            echo "CC=gcc-11" >> $GITHUB_ENV
-            echo "CXX=g++-11" >> $GITHUB_ENV
+      - name: Install GCC 11 on Linux
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-11 g++-11
+      - name: Set CC and CXX to gcc-11
+        if: runner.os == 'Linux'
+        run: |
+          echo "CC=gcc-11" >> $GITHUB_ENV
+          echo "CXX=g++-11" >> $GITHUB_ENV
       # macOS-specific dependencies
       - name: Install macOS dependencies
         if: runner.os == 'macOS'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -205,8 +205,13 @@ jobs:
           PKG_CONFIG_ALLOW_CROSS: "1"
           CROSS_NO_WARNINGS: "0"
           RUST_BACKTRACE: "1"
+
+          # Zlib hints for CMake
+          ZLIB_ROOT: "/usr"
           ZLIB_INCLUDE_DIR: "/usr/include/aarch64-linux-gnu"
           ZLIB_LIBRARY: "/usr/lib/aarch64-linux-gnu/libz.so"
+
+          # OpenSSL hints
           OPENSSL_ROOT_DIR: "/usr"
           OPENSSL_INCLUDE_DIR: "/usr/include/aarch64-linux-gnu"
           OPENSSL_CRYPTO_LIBRARY: "/usr/lib/aarch64-linux-gnu/libcrypto.so"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,5 @@
 name: Ensure parseable builds on all release targets
+
 on:
   pull_request:
     paths-ignore:
@@ -6,6 +7,7 @@ on:
       - helm/**
       - assets/**
       - "**.md"
+
 jobs:
   # Default build without Kafka
   build-default:
@@ -22,6 +24,7 @@ jobs:
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             use_cross: true
+
           # macOS builds - both native on macos-latest (M1)
           - os: macos-latest
             target: x86_64-apple-darwin
@@ -29,28 +32,30 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             use_cross: false
+
           # Windows build
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             use_cross: false
+
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
           targets: ${{ matrix.target }}
-      
+
       - name: Install GCC 11 on Linux
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-11 g++-11
-      
+
       - name: Install cross
         if: matrix.use_cross
         run: cargo install cross --git https://github.com/cross-rs/cross
-      
+
       - name: Cache dependencies
         uses: actions/cache@v4
         with:
@@ -59,13 +64,13 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ matrix.target }}-default-${{ hashFiles('**/Cargo.lock') }}
-      
+
       - name: Build with cross
         if: matrix.use_cross
         env:
           CROSS_NO_WARNINGS: "0"
         run: cross build --target ${{ matrix.target }} --release
-      
+
       - name: Build native
         if: ${{ !matrix.use_cross }}
         env:
@@ -85,25 +90,28 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             use_cross: false
+
           # Linux aarch64 - cross-compile
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             use_cross: true
+
           # macOS aarch64 - native on M1
           - os: macos-latest
             target: aarch64-apple-darwin
             use_cross: false
+
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Docker Buildx
         if: matrix.use_cross
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Set up QEMU for cross-arch builds
         if: matrix.use_cross
         uses: docker/setup-qemu-action@v3
-      
+
       # Linux-specific dependencies for native x86_64 build
       - name: Install Linux dependencies (x86_64)
         if: runner.os == 'Linux' && matrix.target == 'x86_64-unknown-linux-gnu'
@@ -122,7 +130,7 @@ jobs:
             libssl-dev \
             libsasl2-dev \
             python3
-      
+
       # macOS-specific dependencies
       - name: Install macOS dependencies
         if: runner.os == 'macOS'
@@ -135,16 +143,16 @@ jobs:
             openssl@3.0 \
             cyrus-sasl \
             python3
-      
+
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
           targets: ${{ matrix.target }}
-      
+
       - name: Install cross for aarch64
         if: matrix.use_cross
         run: cargo install cross --git https://github.com/cross-rs/cross
-      
+
       - name: Cache dependencies
         uses: actions/cache@v4
         with:
@@ -153,7 +161,7 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ matrix.target }}-kafka-${{ hashFiles('**/Cargo.lock') }}
-      
+
       - name: Find and fix librdkafka CMakeLists.txt for Linux
         if: runner.os == 'Linux' && !matrix.use_cross
         run: |
@@ -175,7 +183,7 @@ jobs:
             echo "Could not find librdkafka CMakeLists.txt file!"
             exit 1
           fi
-      
+
       - name: Find and fix librdkafka CMakeLists.txt for macOS
         if: runner.os == 'macOS'
         run: |
@@ -197,7 +205,7 @@ jobs:
             echo "Could not find librdkafka CMakeLists.txt file!"
             exit 1
           fi
-      
+
       - name: Build with Kafka (cross)
         if: matrix.use_cross
         env:
@@ -206,8 +214,7 @@ jobs:
           CROSS_NO_WARNINGS: "0"
           RUST_BACKTRACE: "1"
 
-          # Zlib hints for CMake
-          ZLIB_ROOT: "/usr"
+          # Zlib hints for CMake (explicit include/lib, no ZLIB_ROOT)
           ZLIB_INCLUDE_DIR: "/usr/include/aarch64-linux-gnu"
           ZLIB_LIBRARY: "/usr/lib/aarch64-linux-gnu/libz.so"
 
@@ -216,9 +223,15 @@ jobs:
           OPENSSL_INCLUDE_DIR: "/usr/include/aarch64-linux-gnu"
           OPENSSL_CRYPTO_LIBRARY: "/usr/lib/aarch64-linux-gnu/libcrypto.so"
           OPENSSL_SSL_LIBRARY: "/usr/lib/aarch64-linux-gnu/libssl.so"
+
           PKG_CONFIG_PATH: "/usr/lib/aarch64-linux-gnu/pkgconfig"
-        run: cross build --target ${{ matrix.target }} --features kafka --release --verbose
-      
+        run: |
+          echo "ZLIB_INCLUDE_DIR=$ZLIB_INCLUDE_DIR"
+          echo "ZLIB_LIBRARY=$ZLIB_LIBRARY"
+          ls -l /usr/include/aarch64-linux-gnu || true
+          ls -l /usr/lib/aarch64-linux-gnu/libz* || true
+          cross build --target ${{ matrix.target }} --features kafka --release --verbose
+
       - name: Build with Kafka (native)
         if: ${{ !matrix.use_cross }}
         env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,16 +34,16 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-        - name: Install GCC 11 on Linux
-          if: runner.os == 'Linux'
-          run: |
-            sudo apt-get update
-            sudo apt-get install -y gcc-11 g++-11
-        - name: Set CC and CXX to gcc-11
-          if: runner.os == 'Linux'
-          run: |
-            echo "CC=gcc-11" >> $GITHUB_ENV
-            echo "CXX=g++-11" >> $GITHUB_ENV
+      - name: Install GCC 11 on Linux
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-11 g++-11
+      - name: Set CC and CXX to gcc-11
+        if: runner.os == 'Linux'
+        run: |
+          echo "CC=gcc-11" >> $GITHUB_ENV
+          echo "CXX=g++-11" >> $GITHUB_ENV
       - name: Cache dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@nightly
         with:
           targets: ${{ matrix.target }}
       
@@ -135,7 +135,7 @@ jobs:
             python3
       
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@nightly
         with:
           targets: ${{ matrix.target }}
       
@@ -201,7 +201,14 @@ jobs:
         env:
           LIBRDKAFKA_SSL_VENDORED: "1"
           PKG_CONFIG_ALLOW_CROSS: "1"
-        run: cross build --target ${{ matrix.target }} --features kafka --release
+          ZLIB_INCLUDE_DIR: "/usr/include/aarch64-linux-gnu"
+          ZLIB_LIBRARY: "/usr/lib/aarch64-linux-gnu/libz.so"
+          OPENSSL_DIR: "/usr"
+          OPENSSL_LIB_DIR: "/usr/lib/aarch64-linux-gnu"
+          OPENSSL_INCLUDE_DIR: "/usr/include/aarch64-linux-gnu"
+          CROSS_NO_WARNINGS: "0"
+          RUST_BACKTRACE: "1"
+        run: cross build --target ${{ matrix.target }} --features kafka --release --verbose
       
       - name: Build with Kafka (native)
         if: ${{ !matrix.use_cross }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -206,7 +206,7 @@ jobs:
             exit 1
           fi
 
-      - name: Build with Kafka (cross)
+      - name: Build with Kafka (cross) - DEBUG
         if: matrix.use_cross
         env:
           LIBRDKAFKA_SSL_VENDORED: "1"
@@ -214,28 +214,21 @@ jobs:
           CROSS_NO_WARNINGS: "0"
           RUST_BACKTRACE: "1"
 
-          # Zlib hints for CMake (explicit include/lib, no ZLIB_ROOT)
-          ZLIB_INCLUDE_DIR: "/usr/include/aarch64-linux-gnu"
+          # Will be updated based on Cross.toml pre-build output
+          ZLIB_INCLUDE_DIR: "/usr/include"
           ZLIB_LIBRARY: "/usr/lib/aarch64-linux-gnu/libz.so"
 
-          # OpenSSL hints
           OPENSSL_ROOT_DIR: "/usr"
-          OPENSSL_INCLUDE_DIR: "/usr/include/aarch64-linux-gnu"
+          OPENSSL_INCLUDE_DIR: "/usr/include"
           OPENSSL_CRYPTO_LIBRARY: "/usr/lib/aarch64-linux-gnu/libcrypto.so"
           OPENSSL_SSL_LIBRARY: "/usr/lib/aarch64-linux-gnu/libssl.so"
 
           PKG_CONFIG_PATH: "/usr/lib/aarch64-linux-gnu/pkgconfig"
         run: |
-          echo "ZLIB_INCLUDE_DIR=$ZLIB_INCLUDE_DIR"
-          echo "ZLIB_LIBRARY=$ZLIB_LIBRARY"
-          ls -l /usr/include/aarch64-linux-gnu || true
-          ls -l /usr/lib/aarch64-linux-gnu/libz* || true
+          echo "=== HOST ENV DEBUG ==="
+          env | grep -E 'ZLIB_|OPENSSL_|PKG_CONFIG|LIBRDKAFKA'
+          echo "=== HOST PATHS DEBUG ==="
+          ls -la /usr/include/aarch64-linux-gnu 2>/dev/null || echo "No host /usr/include/aarch64-linux-gnu"
+          ls -la /usr/lib/aarch64-linux-gnu 2>/dev/null || echo "No host /usr/lib/aarch64-linux-gnu"
+          echo "=== CROSS BUILD START ==="
           cross build --target ${{ matrix.target }} --features kafka --release --verbose
-
-      - name: Build with Kafka (native)
-        if: ${{ !matrix.use_cross }}
-        env:
-          CC: ${{ runner.os == 'Linux' && 'gcc-11' || '' }}
-          CXX: ${{ runner.os == 'Linux' && 'g++-11' || '' }}
-          LIBRDKAFKA_SSL_VENDORED: "1"
-        run: cargo build --target ${{ matrix.target }} --features kafka --release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -113,21 +113,6 @@ jobs:
             libsasl2-dev \
             python3
       
-      # Linux dependencies for aarch64 cross-compilation
-      - name: Install Linux dependencies (aarch64 cross)
-        if: runner.os == 'Linux' && matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            gcc-11 \
-            g++-11 \
-            build-essential \
-            pkg-config \
-            cmake \
-            clang \
-            gcc-aarch64-linux-gnu \
-            g++-aarch64-linux-gnu
-      
       # macOS-specific dependencies
       - name: Install macOS dependencies
         if: runner.os == 'macOS'
@@ -146,9 +131,39 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       
-      - name: Install cross
+      - name: Install cross for aarch64
         if: matrix.use_cross
         run: cargo install cross --git https://github.com/cross-rs/cross
+      
+      - name: Create Cross.toml for aarch64 Kafka build
+        if: matrix.use_cross && matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          cat > Cross.toml << 'EOF'
+          [target.aarch64-unknown-linux-gnu]
+          pre-build = [
+              "dpkg --add-architecture arm64",
+              "sed -i 's/deb http/deb [arch=amd64] http/g' /etc/apt/sources.list",
+              "echo 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ focal main restricted universe multiverse' >> /etc/apt/sources.list",
+              "echo 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ focal-updates main restricted universe multiverse' >> /etc/apt/sources.list",
+              "apt-get update || true",
+              "apt-get install -y pkg-config:arm64 || true",
+              "apt-get install -y zlib1g-dev:arm64 || true",
+              "apt-get install -y libssl-dev:arm64 || true", 
+              "apt-get install -y libsasl2-dev:arm64 || true",
+              "apt-get install -y libzstd-dev:arm64 || true",
+              "apt-get install -y liblz4-dev:arm64 || true",
+          ]
+          
+          [build.env]
+          passthrough = [
+              "LIBRDKAFKA_SSL_VENDORED",
+              "PKG_CONFIG_ALLOW_CROSS",
+          ]
+          volumes = [
+              "/usr/lib/aarch64-linux-gnu:/usr/lib/aarch64-linux-gnu",
+          ]
+          EOF
+          cat Cross.toml
       
       - name: Cache dependencies
         uses: actions/cache@v4
@@ -205,6 +220,9 @@ jobs:
       
       - name: Build with Kafka (cross)
         if: matrix.use_cross
+        env:
+          LIBRDKAFKA_SSL_VENDORED: "1"
+          PKG_CONFIG_ALLOW_CROSS: "1"
         run: cross build --target ${{ matrix.target }} --features kafka --release
       
       - name: Build with Kafka (native)
@@ -212,5 +230,5 @@ jobs:
         env:
           CC: ${{ runner.os == 'Linux' && 'gcc-11' || '' }}
           CXX: ${{ runner.os == 'Linux' && 'g++-11' || '' }}
-          LIBRDKAFKA_SSL_VENDORED: 1
+          LIBRDKAFKA_SSL_VENDORED: "1"
         run: cargo build --target ${{ matrix.target }} --features kafka --release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -206,7 +206,6 @@ jobs:
             exit 1
           fi
 
-      - name: Build with Kafka (cross) - DEBUG
         if: matrix.use_cross
         env:
           LIBRDKAFKA_SSL_VENDORED: "1"
@@ -214,7 +213,7 @@ jobs:
           CROSS_NO_WARNINGS: "0"
           RUST_BACKTRACE: "1"
 
-          # Will be updated based on Cross.toml pre-build output
+          # Standard Debian multiarch paths for aarch64
           ZLIB_INCLUDE_DIR: "/usr/include"
           ZLIB_LIBRARY: "/usr/lib/aarch64-linux-gnu/libz.so"
 
@@ -223,12 +222,9 @@ jobs:
           OPENSSL_CRYPTO_LIBRARY: "/usr/lib/aarch64-linux-gnu/libcrypto.so"
           OPENSSL_SSL_LIBRARY: "/usr/lib/aarch64-linux-gnu/libssl.so"
 
-          PKG_CONFIG_PATH: "/usr/lib/aarch64-linux-gnu/pkgconfig"
+          PKG_CONFIG_PATH: "/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/share/pkgconfig"
         run: |
           echo "=== HOST ENV DEBUG ==="
           env | grep -E 'ZLIB_|OPENSSL_|PKG_CONFIG|LIBRDKAFKA'
-          echo "=== HOST PATHS DEBUG ==="
-          ls -la /usr/include/aarch64-linux-gnu 2>/dev/null || echo "No host /usr/include/aarch64-linux-gnu"
-          ls -la /usr/lib/aarch64-linux-gnu 2>/dev/null || echo "No host /usr/lib/aarch64-linux-gnu"
-          echo "=== CROSS BUILD START ==="
+          echo "=== NOW RUNNING CROSS BUILD (pre-build will show zlib paths) ==="
           cross build --target ${{ matrix.target }} --features kafka --release --verbose

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,6 +34,16 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+        - name: Install GCC 11 on Linux
+          if: runner.os == 'Linux'
+          run: |
+            sudo apt-get update
+            sudo apt-get install -y gcc-11 g++-11
+        - name: Set CC and CXX to gcc-11
+          if: runner.os == 'Linux'
+          run: |
+            echo "CC=gcc-11" >> $GITHUB_ENV
+            echo "CXX=g++-11" >> $GITHUB_ENV
       - name: Cache dependencies
         uses: actions/cache@v4
         with:
@@ -91,6 +101,16 @@ jobs:
               libssl-dev:arm64 \
               pkg-config-aarch64-linux-gnu
           fi
+        - name: Install GCC 11 on Linux
+          if: runner.os == 'Linux'
+          run: |
+            sudo apt-get update
+            sudo apt-get install -y gcc-11 g++-11
+        - name: Set CC and CXX to gcc-11
+          if: runner.os == 'Linux'
+          run: |
+            echo "CC=gcc-11" >> $GITHUB_ENV
+            echo "CXX=g++-11" >> $GITHUB_ENV
       # macOS-specific dependencies
       - name: Install macOS dependencies
         if: runner.os == 'macOS'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,6 +62,8 @@ jobs:
       
       - name: Build with cross
         if: matrix.use_cross
+        env:
+          CROSS_NO_WARNINGS: "0"
         run: cross build --target ${{ matrix.target }} --release
       
       - name: Build native
@@ -201,13 +203,15 @@ jobs:
         env:
           LIBRDKAFKA_SSL_VENDORED: "1"
           PKG_CONFIG_ALLOW_CROSS: "1"
-          ZLIB_INCLUDE_DIR: "/usr/include/aarch64-linux-gnu"
-          ZLIB_LIBRARY: "/usr/lib/aarch64-linux-gnu/libz.so"
-          OPENSSL_DIR: "/usr"
-          OPENSSL_LIB_DIR: "/usr/lib/aarch64-linux-gnu"
-          OPENSSL_INCLUDE_DIR: "/usr/include/aarch64-linux-gnu"
           CROSS_NO_WARNINGS: "0"
           RUST_BACKTRACE: "1"
+          ZLIB_INCLUDE_DIR: "/usr/include/aarch64-linux-gnu"
+          ZLIB_LIBRARY: "/usr/lib/aarch64-linux-gnu/libz.so"
+          OPENSSL_ROOT_DIR: "/usr"
+          OPENSSL_INCLUDE_DIR: "/usr/include/aarch64-linux-gnu"
+          OPENSSL_CRYPTO_LIBRARY: "/usr/lib/aarch64-linux-gnu/libcrypto.so"
+          OPENSSL_SSL_LIBRARY: "/usr/lib/aarch64-linux-gnu/libssl.so"
+          PKG_CONFIG_PATH: "/usr/lib/aarch64-linux-gnu/pkgconfig"
         run: cross build --target ${{ matrix.target }} --features kafka --release --verbose
       
       - name: Build with Kafka (native)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,58 +425,23 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc208515aa0151028e464cc94a692156e945ce5126abd3537bb7fd6ba2143ed1"
-dependencies = [
- "arrow-arith 54.3.1",
- "arrow-array 54.3.1",
- "arrow-buffer 54.3.1",
- "arrow-cast 54.3.1",
- "arrow-csv 54.3.1",
- "arrow-data 54.3.1",
- "arrow-ipc 54.2.1",
- "arrow-json 54.3.1",
- "arrow-ord 54.2.1",
- "arrow-row 54.2.1",
- "arrow-schema 54.3.1",
- "arrow-select 54.3.1",
- "arrow-string 54.2.1",
-]
-
-[[package]]
-name = "arrow"
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb372a7cbcac02a35d3fb7b3fc1f969ec078e871f9bb899bf00a2e1809bec8a3"
 dependencies = [
- "arrow-arith 57.1.0",
- "arrow-array 57.1.0",
- "arrow-buffer 57.1.0",
- "arrow-cast 57.1.0",
- "arrow-csv 57.1.0",
- "arrow-data 57.1.0",
- "arrow-ipc 57.1.0",
- "arrow-json 57.1.0",
- "arrow-ord 57.1.0",
- "arrow-row 57.1.0",
- "arrow-schema 57.1.0",
- "arrow-select 57.1.0",
- "arrow-string 57.1.0",
-]
-
-[[package]]
-name = "arrow-arith"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc766fdacaf804cb10c7c70580254fcdb5d55cdfda2bc57b02baf5223a3af9e"
-dependencies = [
- "arrow-array 54.3.1",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "chrono",
- "num",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
 ]
 
 [[package]]
@@ -485,28 +450,12 @@ version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f377dcd19e440174596d83deb49cd724886d91060c07fec4f67014ef9d54049"
 dependencies = [
- "arrow-array 57.1.0",
- "arrow-buffer 57.1.0",
- "arrow-data 57.1.0",
- "arrow-schema 57.1.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "num-traits",
-]
-
-[[package]]
-name = "arrow-array"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12fcdb3f1d03f69d3ec26ac67645a8fe3f878d77b5ebb0b15d64a116c212985"
-dependencies = [
- "ahash",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "chrono",
- "half",
- "hashbrown 0.15.2",
- "num",
 ]
 
 [[package]]
@@ -516,9 +465,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eaff85a44e9fa914660fb0d0bb00b79c4a3d888b5334adb3ea4330c84f002"
 dependencies = [
  "ahash",
- "arrow-buffer 57.1.0",
- "arrow-data 57.1.0",
- "arrow-schema 57.1.0",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "chrono-tz",
  "half",
@@ -526,17 +475,6 @@ dependencies = [
  "num-complex",
  "num-integer",
  "num-traits",
-]
-
-[[package]]
-name = "arrow-buffer"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "263f4801ff1839ef53ebd06f99a56cecd1dbaf314ec893d93168e2e860e0291c"
-dependencies = [
- "bytes",
- "half",
- "num",
 ]
 
 [[package]]
@@ -553,36 +491,16 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede6175fbc039dfc946a61c1b6d42fd682fcecf5ab5d148fbe7667705798cac9"
-dependencies = [
- "arrow-array 54.3.1",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "arrow-select 54.3.1",
- "atoi",
- "base64 0.22.1",
- "chrono",
- "half",
- "lexical-core",
- "num",
- "ryu",
-]
-
-[[package]]
-name = "arrow-cast"
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d131abb183f80c450d4591dc784f8d7750c50c6e2bc3fcaad148afc8361271"
 dependencies = [
- "arrow-array 57.1.0",
- "arrow-buffer 57.1.0",
- "arrow-data 57.1.0",
- "arrow-ord 57.1.0",
- "arrow-schema 57.1.0",
- "arrow-select 57.1.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
  "atoi",
  "base64 0.22.1",
  "chrono",
@@ -595,45 +513,17 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1644877d8bc9a0ef022d9153dc29375c2bda244c39aec05a91d0e87ccf77995f"
-dependencies = [
- "arrow-array 54.3.1",
- "arrow-cast 54.3.1",
- "arrow-schema 54.3.1",
- "chrono",
- "csv",
- "csv-core",
- "lazy_static",
- "regex",
-]
-
-[[package]]
-name = "arrow-csv"
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2275877a0e5e7e7c76954669366c2aa1a829e340ab1f612e647507860906fb6b"
 dependencies = [
- "arrow-array 57.1.0",
- "arrow-cast 57.1.0",
- "arrow-schema 57.1.0",
+ "arrow-array",
+ "arrow-cast",
+ "arrow-schema",
  "chrono",
  "csv",
  "csv-core",
  "regex",
-]
-
-[[package]]
-name = "arrow-data"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfdd7d99b4ff618f167e548b2411e5dd2c98c0ddebedd7df433d34c20a4429"
-dependencies = [
- "arrow-buffer 54.3.1",
- "arrow-schema 54.3.1",
- "half",
- "num",
 ]
 
 [[package]]
@@ -642,8 +532,8 @@ version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05738f3d42cb922b9096f7786f606fcb8669260c2640df8490533bb2fa38c9d3"
 dependencies = [
- "arrow-buffer 57.1.0",
- "arrow-schema 57.1.0",
+ "arrow-buffer",
+ "arrow-schema",
  "half",
  "num-integer",
  "num-traits",
@@ -655,11 +545,11 @@ version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b5f57c3d39d1b1b7c1376a772ea86a131e7da310aed54ebea9363124bb885e3"
 dependencies = [
- "arrow-array 57.1.0",
- "arrow-buffer 57.1.0",
- "arrow-cast 57.1.0",
- "arrow-ipc 57.1.0",
- "arrow-schema 57.1.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-ipc",
+ "arrow-schema",
  "base64 0.22.1",
  "bytes",
  "futures",
@@ -671,53 +561,18 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddecdeab02491b1ce88885986e25002a3da34dd349f682c7cfe67bab7cc17b86"
-dependencies = [
- "arrow-array 54.3.1",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "flatbuffers 24.12.23",
-]
-
-[[package]]
-name = "arrow-ipc"
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d09446e8076c4b3f235603d9ea7c5494e73d441b01cd61fb33d7254c11964b3"
 dependencies = [
- "arrow-array 57.1.0",
- "arrow-buffer 57.1.0",
- "arrow-data 57.1.0",
- "arrow-schema 57.1.0",
- "arrow-select 57.1.0",
- "flatbuffers 25.9.23",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
  "lz4_flex",
  "zstd",
-]
-
-[[package]]
-name = "arrow-json"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee5b4ca98a7fb2efb9ab3309a5d1c88b5116997ff93f3147efdc1062a6158e9"
-dependencies = [
- "arrow-array 54.3.1",
- "arrow-buffer 54.3.1",
- "arrow-cast 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "chrono",
- "half",
- "indexmap",
- "lexical-core",
- "memchr",
- "num",
- "serde",
- "serde_json",
- "simdutf8",
 ]
 
 [[package]]
@@ -726,11 +581,11 @@ version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "371ffd66fa77f71d7628c63f209c9ca5341081051aa32f9c8020feb0def787c0"
 dependencies = [
- "arrow-array 57.1.0",
- "arrow-buffer 57.1.0",
- "arrow-cast 57.1.0",
- "arrow-data 57.1.0",
- "arrow-schema 57.1.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "half",
  "indexmap",
@@ -746,41 +601,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f841bfcc1997ef6ac48ee0305c4dfceb1f7c786fe31e67c1186edf775e1f1160"
-dependencies = [
- "arrow-array 54.3.1",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "arrow-select 54.3.1",
-]
-
-[[package]]
-name = "arrow-ord"
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc94fc7adec5d1ba9e8cd1b1e8d6f72423b33fe978bf1f46d970fafab787521"
 dependencies = [
- "arrow-array 57.1.0",
- "arrow-buffer 57.1.0",
- "arrow-data 57.1.0",
- "arrow-schema 57.1.0",
- "arrow-select 57.1.0",
-]
-
-[[package]]
-name = "arrow-row"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eeb55b0a0a83851aa01f2ca5ee5648f607e8506ba6802577afdda9d75cdedcd"
-dependencies = [
- "arrow-array 54.3.1",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "half",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
 ]
 
 [[package]]
@@ -789,18 +618,12 @@ version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "169676f317157dc079cc5def6354d16db63d8861d61046d2f3883268ced6f99f"
 dependencies = [
- "arrow-array 57.1.0",
- "arrow-buffer 57.1.0",
- "arrow-data 57.1.0",
- "arrow-schema 57.1.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "half",
 ]
-
-[[package]]
-name = "arrow-schema"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cfaf5e440be44db5413b75b72c2a87c1f8f0627117d110264048f2969b99e9"
 
 [[package]]
 name = "arrow-schema"
@@ -815,47 +638,16 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69efcd706420e52cd44f5c4358d279801993846d1c2a8e52111853d61d55a619"
-dependencies = [
- "ahash",
- "arrow-array 54.3.1",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "num",
-]
-
-[[package]]
-name = "arrow-select"
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae980d021879ea119dd6e2a13912d81e64abed372d53163e804dfe84639d8010"
 dependencies = [
  "ahash",
- "arrow-array 57.1.0",
- "arrow-buffer 57.1.0",
- "arrow-data 57.1.0",
- "arrow-schema 57.1.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "num-traits",
-]
-
-[[package]]
-name = "arrow-string"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "912e38bd6a7a7714c1d9b61df80315685553b7455e8a6045c27531d8ecd5b458"
-dependencies = [
- "arrow-array 54.3.1",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "arrow-select 54.3.1",
- "memchr",
- "num",
- "regex",
- "regex-syntax",
 ]
 
 [[package]]
@@ -864,11 +656,11 @@ version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf35e8ef49dcf0c5f6d175edee6b8af7b45611805333129c541a8b89a0fc0534"
 dependencies = [
- "arrow-array 57.1.0",
- "arrow-buffer 57.1.0",
- "arrow-data 57.1.0",
- "arrow-schema 57.1.0",
- "arrow-select 57.1.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
  "memchr",
  "num-traits",
  "regex",
@@ -1694,8 +1486,8 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba7cb113e9c0bedf9e9765926031e132fa05a1b09ba6e93a6d1a4d7044457b8"
 dependencies = [
- "arrow 57.1.0",
- "arrow-schema 57.1.0",
+ "arrow",
+ "arrow-schema",
  "async-trait",
  "bytes",
  "bzip2 0.6.1",
@@ -1750,7 +1542,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66a3a799f914a59b1ea343906a0486f17061f39509af74e874a866428951130d"
 dependencies = [
- "arrow 57.1.0",
+ "arrow",
  "async-trait",
  "dashmap",
  "datafusion-common",
@@ -1775,7 +1567,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db1b113c80d7a0febcd901476a57aef378e717c54517a163ed51417d87621b0"
 dependencies = [
- "arrow 57.1.0",
+ "arrow",
  "async-trait",
  "datafusion-catalog",
  "datafusion-common",
@@ -1800,8 +1592,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c10f7659e96127d25e8366be7c8be4109595d6a2c3eac70421f380a7006a1b0"
 dependencies = [
  "ahash",
- "arrow 57.1.0",
- "arrow-ipc 57.1.0",
+ "arrow",
+ "arrow-ipc",
  "chrono",
  "half",
  "hashbrown 0.14.5",
@@ -1834,7 +1626,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde13794244bc7581cd82f6fff217068ed79cdc344cafe4ab2c3a1c3510b38d6"
 dependencies = [
- "arrow 57.1.0",
+ "arrow",
  "async-compression",
  "async-trait",
  "bytes",
@@ -1869,8 +1661,8 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804fa9b4ecf3157982021770617200ef7c1b2979d57bec9044748314775a9aea"
 dependencies = [
- "arrow 57.1.0",
- "arrow-ipc 57.1.0",
+ "arrow",
+ "arrow-ipc",
  "async-trait",
  "bytes",
  "datafusion-common",
@@ -1893,7 +1685,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61a1641a40b259bab38131c5e6f48fac0717bedb7dc93690e604142a849e0568"
 dependencies = [
- "arrow 57.1.0",
+ "arrow",
  "async-trait",
  "bytes",
  "datafusion-common",
@@ -1916,7 +1708,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adeacdb00c1d37271176f8fb6a1d8ce096baba16ea7a4b2671840c5c9c64fe85"
 dependencies = [
- "arrow 57.1.0",
+ "arrow",
  "async-trait",
  "bytes",
  "datafusion-common",
@@ -1938,7 +1730,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d0b60ffd66f28bfb026565d62b0a6cbc416da09814766a3797bba7d85a3cd9"
 dependencies = [
- "arrow 57.1.0",
+ "arrow",
  "async-trait",
  "bytes",
  "datafusion-common",
@@ -1974,7 +1766,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63695643190679037bc946ad46a263b62016931547bf119859c511f7ff2f5178"
 dependencies = [
- "arrow 57.1.0",
+ "arrow",
  "async-trait",
  "dashmap",
  "datafusion-common",
@@ -1994,7 +1786,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9a4787cbf5feb1ab351f789063398f67654a6df75c4d37d7f637dc96f951a91"
 dependencies = [
- "arrow 57.1.0",
+ "arrow",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -2017,7 +1809,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ce2fb1b8c15c9ac45b0863c30b268c69dc9ee7a1ee13ecf5d067738338173dc"
 dependencies = [
- "arrow 57.1.0",
+ "arrow",
  "datafusion-common",
  "indexmap",
  "itertools 0.14.0",
@@ -2030,8 +1822,8 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "794a9db7f7b96b3346fc007ff25e994f09b8f0511b4cf7dff651fadfe3ebb28f"
 dependencies = [
- "arrow 57.1.0",
- "arrow-buffer 57.1.0",
+ "arrow",
+ "arrow-buffer",
  "base64 0.22.1",
  "blake2",
  "blake3",
@@ -2061,7 +1853,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c25210520a9dcf9c2b2cbbce31ebd4131ef5af7fc60ee92b266dc7d159cb305"
 dependencies = [
  "ahash",
- "arrow 57.1.0",
+ "arrow",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-execution",
@@ -2082,7 +1874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f4a66f3b87300bb70f4124b55434d2ae3fe80455f3574701d0348da040b55d"
 dependencies = [
  "ahash",
- "arrow 57.1.0",
+ "arrow",
  "datafusion-common",
  "datafusion-expr-common",
  "datafusion-physical-expr-common",
@@ -2094,8 +1886,8 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae5c06eed03918dc7fe7a9f082a284050f0e9ecf95d72f57712d1496da03b8c4"
 dependencies = [
- "arrow 57.1.0",
- "arrow-ord 57.1.0",
+ "arrow",
+ "arrow-ord",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-execution",
@@ -2117,7 +1909,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db4fed1d71738fbe22e2712d71396db04c25de4111f1ec252b8f4c6d3b25d7f5"
 dependencies = [
- "arrow 57.1.0",
+ "arrow",
  "async-trait",
  "datafusion-catalog",
  "datafusion-common",
@@ -2133,7 +1925,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d92206aa5ae21892f1552b4d61758a862a70956e6fd7a95cb85db1de74bc6d1"
 dependencies = [
- "arrow 57.1.0",
+ "arrow",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-expr",
@@ -2172,7 +1964,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f35f9ec5d08b87fd1893a30c2929f2559c2f9806ca072d8fefca5009dc0f06a"
 dependencies = [
- "arrow 57.1.0",
+ "arrow",
  "chrono",
  "datafusion-common",
  "datafusion-expr",
@@ -2193,7 +1985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c30cc8012e9eedcb48bbe112c6eff4ae5ed19cf3003cb0f505662e88b7014c5d"
 dependencies = [
  "ahash",
- "arrow 57.1.0",
+ "arrow",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-expr-common",
@@ -2214,7 +2006,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f9ff2dbd476221b1f67337699eff432781c4e6e1713d2aefdaa517dfbf79768"
 dependencies = [
- "arrow 57.1.0",
+ "arrow",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-functions",
@@ -2230,7 +2022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90da43e1ec550b172f34c87ec68161986ced70fd05c8d2a2add66eef9c276f03"
 dependencies = [
  "ahash",
- "arrow 57.1.0",
+ "arrow",
  "datafusion-common",
  "datafusion-expr-common",
  "hashbrown 0.14.5",
@@ -2243,7 +2035,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce9804f799acd7daef3be7aaffe77c0033768ed8fdbf5fb82fc4c5f2e6bc14e6"
 dependencies = [
- "arrow 57.1.0",
+ "arrow",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
@@ -2263,9 +2055,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0acf0ad6b6924c6b1aa7d213b181e012e2d3ec0a64ff5b10ee6282ab0f8532ac"
 dependencies = [
  "ahash",
- "arrow 57.1.0",
- "arrow-ord 57.1.0",
- "arrow-schema 57.1.0",
+ "arrow",
+ "arrow-ord",
+ "arrow-schema",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -2293,7 +2085,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2c2498a1f134a9e11a9f5ed202a2a7d7e9774bd9249295593053ea3be999db"
 dependencies = [
- "arrow 57.1.0",
+ "arrow",
  "datafusion-common",
  "datafusion-datasource",
  "datafusion-expr-common",
@@ -2324,7 +2116,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fc195fe60634b2c6ccfd131b487de46dc30eccae8a3c35a13f136e7f440414f"
 dependencies = [
- "arrow 57.1.0",
+ "arrow",
  "bigdecimal",
  "chrono",
  "datafusion-common",
@@ -2528,16 +2320,6 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
-
-[[package]]
-name = "flatbuffers"
-version = "24.12.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1baf0dbf96932ec9a3038d57900329c015b0bfb7b63d904f3bc27e2b02a096"
-dependencies = [
- "bitflags 1.3.2",
- "rustc_version",
-]
 
 [[package]]
 name = "flatbuffers"
@@ -3645,20 +3427,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3689,28 +3457,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
  "num-traits",
 ]
 
@@ -3964,13 +3710,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be3e4f6d320dd92bfa7d612e265d7d08bba0a240bab86af3425e1d255a511d89"
 dependencies = [
  "ahash",
- "arrow-array 57.1.0",
- "arrow-buffer 57.1.0",
- "arrow-cast 57.1.0",
- "arrow-data 57.1.0",
- "arrow-ipc 57.1.0",
- "arrow-schema 57.1.0",
- "arrow-select 57.1.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
  "base64 0.22.1",
  "brotli 8.0.2",
  "bytes",
@@ -4014,14 +3760,13 @@ dependencies = [
  "actix-web-static-files",
  "anyhow",
  "argon2",
- "arrow 54.2.1",
- "arrow 57.1.0",
- "arrow-array 57.1.0",
+ "arrow",
+ "arrow-array",
  "arrow-flight",
- "arrow-ipc 57.1.0",
- "arrow-json 57.1.0",
- "arrow-schema 57.1.0",
- "arrow-select 57.1.0",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-schema",
+ "arrow-select",
  "async-trait",
  "base64 0.22.1",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,23 +446,23 @@ dependencies = [
 
 [[package]]
 name = "arrow"
-version = "57.0.0"
+version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df8bb5b0bd64c0b9bc61317fcc480bad0f00e56d3bc32c69a4c8dada4786bae"
+checksum = "cb372a7cbcac02a35d3fb7b3fc1f969ec078e871f9bb899bf00a2e1809bec8a3"
 dependencies = [
- "arrow-arith 57.0.0",
- "arrow-array 57.0.0",
- "arrow-buffer 57.0.0",
- "arrow-cast 57.0.0",
- "arrow-csv 57.0.0",
- "arrow-data 57.0.0",
- "arrow-ipc 57.0.0",
- "arrow-json 57.0.0",
- "arrow-ord 57.0.0",
- "arrow-row 57.0.0",
- "arrow-schema 57.0.0",
- "arrow-select 57.0.0",
- "arrow-string 57.0.0",
+ "arrow-arith 57.1.0",
+ "arrow-array 57.1.0",
+ "arrow-buffer 57.1.0",
+ "arrow-cast 57.1.0",
+ "arrow-csv 57.1.0",
+ "arrow-data 57.1.0",
+ "arrow-ipc 57.1.0",
+ "arrow-json 57.1.0",
+ "arrow-ord 57.1.0",
+ "arrow-row 57.1.0",
+ "arrow-schema 57.1.0",
+ "arrow-select 57.1.0",
+ "arrow-string 57.1.0",
 ]
 
 [[package]]
@@ -481,14 +481,14 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "57.0.0"
+version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a640186d3bd30a24cb42264c2dafb30e236a6f50d510e56d40b708c9582491"
+checksum = "0f377dcd19e440174596d83deb49cd724886d91060c07fec4f67014ef9d54049"
 dependencies = [
- "arrow-array 57.0.0",
- "arrow-buffer 57.0.0",
- "arrow-data 57.0.0",
- "arrow-schema 57.0.0",
+ "arrow-array 57.1.0",
+ "arrow-buffer 57.1.0",
+ "arrow-data 57.1.0",
+ "arrow-schema 57.1.0",
  "chrono",
  "num-traits",
 ]
@@ -511,14 +511,14 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "57.0.0"
+version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219fe420e6800979744c8393b687afb0252b3f8a89b91027d27887b72aa36d31"
+checksum = "a23eaff85a44e9fa914660fb0d0bb00b79c4a3d888b5334adb3ea4330c84f002"
 dependencies = [
  "ahash",
- "arrow-buffer 57.0.0",
- "arrow-data 57.0.0",
- "arrow-schema 57.0.0",
+ "arrow-buffer 57.1.0",
+ "arrow-data 57.1.0",
+ "arrow-schema 57.1.0",
  "chrono",
  "chrono-tz",
  "half",
@@ -541,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "57.0.0"
+version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76885a2697a7edf6b59577f568b456afc94ce0e2edc15b784ce3685b6c3c5c27"
+checksum = "a2819d893750cb3380ab31ebdc8c68874dd4429f90fd09180f3c93538bd21626"
 dependencies = [
  "bytes",
  "half",
@@ -573,15 +573,16 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "57.0.0"
+version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9ebb4c987e6b3b236fb4a14b20b34835abfdd80acead3ccf1f9bf399e1f168"
+checksum = "e3d131abb183f80c450d4591dc784f8d7750c50c6e2bc3fcaad148afc8361271"
 dependencies = [
- "arrow-array 57.0.0",
- "arrow-buffer 57.0.0",
- "arrow-data 57.0.0",
- "arrow-schema 57.0.0",
- "arrow-select 57.0.0",
+ "arrow-array 57.1.0",
+ "arrow-buffer 57.1.0",
+ "arrow-data 57.1.0",
+ "arrow-ord 57.1.0",
+ "arrow-schema 57.1.0",
+ "arrow-select 57.1.0",
  "atoi",
  "base64 0.22.1",
  "chrono",
@@ -610,13 +611,13 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "57.0.0"
+version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92386159c8d4bce96f8bd396b0642a0d544d471bdc2ef34d631aec80db40a09c"
+checksum = "2275877a0e5e7e7c76954669366c2aa1a829e340ab1f612e647507860906fb6b"
 dependencies = [
- "arrow-array 57.0.0",
- "arrow-cast 57.0.0",
- "arrow-schema 57.0.0",
+ "arrow-array 57.1.0",
+ "arrow-cast 57.1.0",
+ "arrow-schema 57.1.0",
  "chrono",
  "csv",
  "csv-core",
@@ -637,12 +638,12 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "57.0.0"
+version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727681b95de313b600eddc2a37e736dcb21980a40f640314dcf360e2f36bc89b"
+checksum = "05738f3d42cb922b9096f7786f606fcb8669260c2640df8490533bb2fa38c9d3"
 dependencies = [
- "arrow-buffer 57.0.0",
- "arrow-schema 57.0.0",
+ "arrow-buffer 57.1.0",
+ "arrow-schema 57.1.0",
  "half",
  "num-integer",
  "num-traits",
@@ -650,15 +651,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-flight"
-version = "57.0.0"
+version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f70bb56412a007b0cfc116d15f24dda6adeed9611a213852a004cda20085a3b9"
+checksum = "8b5f57c3d39d1b1b7c1376a772ea86a131e7da310aed54ebea9363124bb885e3"
 dependencies = [
- "arrow-array 57.0.0",
- "arrow-buffer 57.0.0",
- "arrow-cast 57.0.0",
- "arrow-ipc 57.0.0",
- "arrow-schema 57.0.0",
+ "arrow-array 57.1.0",
+ "arrow-buffer 57.1.0",
+ "arrow-cast 57.1.0",
+ "arrow-ipc 57.1.0",
+ "arrow-schema 57.1.0",
  "base64 0.22.1",
  "bytes",
  "futures",
@@ -683,15 +684,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "57.0.0"
+version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9ba92e3de170295c98a84e5af22e2b037f0c7b32449445e6c493b5fca27f27"
+checksum = "3d09446e8076c4b3f235603d9ea7c5494e73d441b01cd61fb33d7254c11964b3"
 dependencies = [
- "arrow-array 57.0.0",
- "arrow-buffer 57.0.0",
- "arrow-data 57.0.0",
- "arrow-schema 57.0.0",
- "arrow-select 57.0.0",
+ "arrow-array 57.1.0",
+ "arrow-buffer 57.1.0",
+ "arrow-data 57.1.0",
+ "arrow-schema 57.1.0",
+ "arrow-select 57.1.0",
  "flatbuffers 25.9.23",
  "lz4_flex",
  "zstd",
@@ -721,15 +722,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "57.0.0"
+version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b969b4a421ae83828591c6bf5450bd52e6d489584142845ad6a861f42fe35df8"
+checksum = "371ffd66fa77f71d7628c63f209c9ca5341081051aa32f9c8020feb0def787c0"
 dependencies = [
- "arrow-array 57.0.0",
- "arrow-buffer 57.0.0",
- "arrow-cast 57.0.0",
- "arrow-data 57.0.0",
- "arrow-schema 57.0.0",
+ "arrow-array 57.1.0",
+ "arrow-buffer 57.1.0",
+ "arrow-cast 57.1.0",
+ "arrow-data 57.1.0",
+ "arrow-schema 57.1.0",
  "chrono",
  "half",
  "indexmap",
@@ -758,15 +759,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "57.0.0"
+version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "141c05298b21d03e88062317a1f1a73f5ba7b6eb041b350015b1cd6aabc0519b"
+checksum = "cbc94fc7adec5d1ba9e8cd1b1e8d6f72423b33fe978bf1f46d970fafab787521"
 dependencies = [
- "arrow-array 57.0.0",
- "arrow-buffer 57.0.0",
- "arrow-data 57.0.0",
- "arrow-schema 57.0.0",
- "arrow-select 57.0.0",
+ "arrow-array 57.1.0",
+ "arrow-buffer 57.1.0",
+ "arrow-data 57.1.0",
+ "arrow-schema 57.1.0",
+ "arrow-select 57.1.0",
 ]
 
 [[package]]
@@ -784,14 +785,14 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "57.0.0"
+version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f3c06a6abad6164508ed283c7a02151515cef3de4b4ff2cebbcaeb85533db2"
+checksum = "169676f317157dc079cc5def6354d16db63d8861d61046d2f3883268ced6f99f"
 dependencies = [
- "arrow-array 57.0.0",
- "arrow-buffer 57.0.0",
- "arrow-data 57.0.0",
- "arrow-schema 57.0.0",
+ "arrow-array 57.1.0",
+ "arrow-buffer 57.1.0",
+ "arrow-data 57.1.0",
+ "arrow-schema 57.1.0",
  "half",
 ]
 
@@ -803,9 +804,9 @@ checksum = "39cfaf5e440be44db5413b75b72c2a87c1f8f0627117d110264048f2969b99e9"
 
 [[package]]
 name = "arrow-schema"
-version = "57.0.0"
+version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cfa7a03d1eee2a4d061476e1840ad5c9867a544ca6c4c59256496af5d0a8be5"
+checksum = "d27609cd7dd45f006abae27995c2729ef6f4b9361cde1ddd019dc31a5aa017e0"
 dependencies = [
  "serde",
  "serde_core",
@@ -828,15 +829,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
-version = "57.0.0"
+version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bafa595babaad59f2455f4957d0f26448fb472722c186739f4fac0823a1bdb47"
+checksum = "ae980d021879ea119dd6e2a13912d81e64abed372d53163e804dfe84639d8010"
 dependencies = [
  "ahash",
- "arrow-array 57.0.0",
- "arrow-buffer 57.0.0",
- "arrow-data 57.0.0",
- "arrow-schema 57.0.0",
+ "arrow-array 57.1.0",
+ "arrow-buffer 57.1.0",
+ "arrow-data 57.1.0",
+ "arrow-schema 57.1.0",
  "num-traits",
 ]
 
@@ -859,15 +860,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "57.0.0"
+version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f46457dbbb99f2650ff3ac23e46a929e0ab81db809b02aa5511c258348bef2"
+checksum = "cf35e8ef49dcf0c5f6d175edee6b8af7b45611805333129c541a8b89a0fc0534"
 dependencies = [
- "arrow-array 57.0.0",
- "arrow-buffer 57.0.0",
- "arrow-data 57.0.0",
- "arrow-schema 57.0.0",
- "arrow-select 57.0.0",
+ "arrow-array 57.1.0",
+ "arrow-buffer 57.1.0",
+ "arrow-data 57.1.0",
+ "arrow-schema 57.1.0",
+ "arrow-select 57.1.0",
  "memchr",
  "num-traits",
  "regex",
@@ -1689,11 +1690,12 @@ checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
 
 [[package]]
 name = "datafusion"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ba7cb113e9c0bedf9e9765926031e132fa05a1b09ba6e93a6d1a4d7044457b8"
 dependencies = [
- "arrow 57.0.0",
- "arrow-schema 57.0.0",
+ "arrow 57.1.0",
+ "arrow-schema 57.1.0",
  "async-trait",
  "bytes",
  "bzip2 0.6.1",
@@ -1732,7 +1734,7 @@ dependencies = [
  "parquet",
  "rand 0.9.1",
  "regex",
- "rstest 0.25.0",
+ "rstest 0.26.1",
  "sqlparser",
  "tempfile",
  "tokio",
@@ -1744,10 +1746,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66a3a799f914a59b1ea343906a0486f17061f39509af74e874a866428951130d"
 dependencies = [
- "arrow 57.0.0",
+ "arrow 57.1.0",
  "async-trait",
  "dashmap",
  "datafusion-common",
@@ -1768,10 +1771,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db1b113c80d7a0febcd901476a57aef378e717c54517a163ed51417d87621b0"
 dependencies = [
- "arrow 57.0.0",
+ "arrow 57.1.0",
  "async-trait",
  "datafusion-catalog",
  "datafusion-common",
@@ -1791,12 +1795,13 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c10f7659e96127d25e8366be7c8be4109595d6a2c3eac70421f380a7006a1b0"
 dependencies = [
  "ahash",
- "arrow 57.0.0",
- "arrow-ipc 57.0.0",
+ "arrow 57.1.0",
+ "arrow-ipc 57.1.0",
  "chrono",
  "half",
  "hashbrown 0.14.5",
@@ -1814,8 +1819,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b92065bbc6532c6651e2f7dd30b55cba0c7a14f860c7e1d15f165c41a1868d95"
 dependencies = [
  "futures",
  "log",
@@ -1824,10 +1830,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde13794244bc7581cd82f6fff217068ed79cdc344cafe4ab2c3a1c3510b38d6"
 dependencies = [
- "arrow 57.0.0",
+ "arrow 57.1.0",
  "async-compression",
  "async-trait",
  "bytes",
@@ -1858,11 +1865,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-arrow"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804fa9b4ecf3157982021770617200ef7c1b2979d57bec9044748314775a9aea"
 dependencies = [
- "arrow 57.0.0",
- "arrow-ipc 57.0.0",
+ "arrow 57.1.0",
+ "arrow-ipc 57.1.0",
  "async-trait",
  "bytes",
  "datafusion-common",
@@ -1881,10 +1889,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-csv"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a1641a40b259bab38131c5e6f48fac0717bedb7dc93690e604142a849e0568"
 dependencies = [
- "arrow 57.0.0",
+ "arrow 57.1.0",
  "async-trait",
  "bytes",
  "datafusion-common",
@@ -1903,10 +1912,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adeacdb00c1d37271176f8fb6a1d8ce096baba16ea7a4b2671840c5c9c64fe85"
 dependencies = [
- "arrow 57.0.0",
+ "arrow 57.1.0",
  "async-trait",
  "bytes",
  "datafusion-common",
@@ -1924,10 +1934,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-parquet"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d0b60ffd66f28bfb026565d62b0a6cbc416da09814766a3797bba7d85a3cd9"
 dependencies = [
- "arrow 57.0.0",
+ "arrow 57.1.0",
  "async-trait",
  "bytes",
  "datafusion-common",
@@ -1953,15 +1964,17 @@ dependencies = [
 
 [[package]]
 name = "datafusion-doc"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b99e13947667b36ad713549237362afb054b2d8f8cc447751e23ec61202db07"
 
 [[package]]
 name = "datafusion-execution"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63695643190679037bc946ad46a263b62016931547bf119859c511f7ff2f5178"
 dependencies = [
- "arrow 57.0.0",
+ "arrow 57.1.0",
  "async-trait",
  "dashmap",
  "datafusion-common",
@@ -1977,10 +1990,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a4787cbf5feb1ab351f789063398f67654a6df75c4d37d7f637dc96f951a91"
 dependencies = [
- "arrow 57.0.0",
+ "arrow 57.1.0",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -1999,10 +2013,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce2fb1b8c15c9ac45b0863c30b268c69dc9ee7a1ee13ecf5d067738338173dc"
 dependencies = [
- "arrow 57.0.0",
+ "arrow 57.1.0",
  "datafusion-common",
  "indexmap",
  "itertools 0.14.0",
@@ -2011,11 +2026,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794a9db7f7b96b3346fc007ff25e994f09b8f0511b4cf7dff651fadfe3ebb28f"
 dependencies = [
- "arrow 57.0.0",
- "arrow-buffer 57.0.0",
+ "arrow 57.1.0",
+ "arrow-buffer 57.1.0",
  "base64 0.22.1",
  "blake2",
  "blake3",
@@ -2040,11 +2056,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c25210520a9dcf9c2b2cbbce31ebd4131ef5af7fc60ee92b266dc7d159cb305"
 dependencies = [
  "ahash",
- "arrow 57.0.0",
+ "arrow 57.1.0",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-execution",
@@ -2060,11 +2077,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f4a66f3b87300bb70f4124b55434d2ae3fe80455f3574701d0348da040b55d"
 dependencies = [
  "ahash",
- "arrow 57.0.0",
+ "arrow 57.1.0",
  "datafusion-common",
  "datafusion-expr-common",
  "datafusion-physical-expr-common",
@@ -2072,11 +2090,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae5c06eed03918dc7fe7a9f082a284050f0e9ecf95d72f57712d1496da03b8c4"
 dependencies = [
- "arrow 57.0.0",
- "arrow-ord 57.0.0",
+ "arrow 57.1.0",
+ "arrow-ord 57.1.0",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-execution",
@@ -2094,10 +2113,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-table"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db4fed1d71738fbe22e2712d71396db04c25de4111f1ec252b8f4c6d3b25d7f5"
 dependencies = [
- "arrow 57.0.0",
+ "arrow 57.1.0",
  "async-trait",
  "datafusion-catalog",
  "datafusion-common",
@@ -2109,10 +2129,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d92206aa5ae21892f1552b4d61758a862a70956e6fd7a95cb85db1de74bc6d1"
 dependencies = [
- "arrow 57.0.0",
+ "arrow 57.1.0",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-expr",
@@ -2126,8 +2147,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53ae9bcc39800820d53a22d758b3b8726ff84a5a3e24cecef04ef4e5fdf1c7cc"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -2135,8 +2157,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1063ad4c9e094b3f798acee16d9a47bd7372d9699be2de21b05c3bd3f34ab848"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -2145,10 +2168,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f35f9ec5d08b87fd1893a30c2929f2559c2f9806ca072d8fefca5009dc0f06a"
 dependencies = [
- "arrow 57.0.0",
+ "arrow 57.1.0",
  "chrono",
  "datafusion-common",
  "datafusion-expr",
@@ -2164,11 +2188,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c30cc8012e9eedcb48bbe112c6eff4ae5ed19cf3003cb0f505662e88b7014c5d"
 dependencies = [
  "ahash",
- "arrow 57.0.0",
+ "arrow 57.1.0",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-expr-common",
@@ -2185,10 +2210,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9ff2dbd476221b1f67337699eff432781c4e6e1713d2aefdaa517dfbf79768"
 dependencies = [
- "arrow 57.0.0",
+ "arrow 57.1.0",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-functions",
@@ -2199,11 +2225,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90da43e1ec550b172f34c87ec68161986ced70fd05c8d2a2add66eef9c276f03"
 dependencies = [
  "ahash",
- "arrow 57.0.0",
+ "arrow 57.1.0",
  "datafusion-common",
  "datafusion-expr-common",
  "hashbrown 0.14.5",
@@ -2212,10 +2239,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce9804f799acd7daef3be7aaffe77c0033768ed8fdbf5fb82fc4c5f2e6bc14e6"
 dependencies = [
- "arrow 57.0.0",
+ "arrow 57.1.0",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
@@ -2230,13 +2258,14 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0acf0ad6b6924c6b1aa7d213b181e012e2d3ec0a64ff5b10ee6282ab0f8532ac"
 dependencies = [
  "ahash",
- "arrow 57.0.0",
- "arrow-ord 57.0.0",
- "arrow-schema 57.0.0",
+ "arrow 57.1.0",
+ "arrow-ord 57.1.0",
+ "arrow-schema 57.1.0",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -2260,10 +2289,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-pruning"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2c2498a1f134a9e11a9f5ed202a2a7d7e9774bd9249295593053ea3be999db"
 dependencies = [
- "arrow 57.0.0",
+ "arrow 57.1.0",
  "datafusion-common",
  "datafusion-datasource",
  "datafusion-expr-common",
@@ -2276,8 +2306,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-session"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f96eebd17555386f459037c65ab73aae8df09f464524c709d6a3134ad4f4776"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -2289,10 +2320,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "50.3.0"
-source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fc195fe60634b2c6ccfd131b487de46dc30eccae8a3c35a13f136e7f440414f"
 dependencies = [
- "arrow 57.0.0",
+ "arrow 57.1.0",
  "bigdecimal",
  "chrono",
  "datafusion-common",
@@ -3482,11 +3514,11 @@ checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.3"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+checksum = "ab6473172471198271ff72e9379150e9dfd70d8e533e0752a27e515b48dd375e"
 dependencies = [
- "twox-hash 1.6.3",
+ "twox-hash",
 ]
 
 [[package]]
@@ -3927,18 +3959,18 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "57.0.0"
+version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0f31027ef1af7549f7cec603a9a21dce706d3f8d7c2060a68f43c1773be95a"
+checksum = "be3e4f6d320dd92bfa7d612e265d7d08bba0a240bab86af3425e1d255a511d89"
 dependencies = [
  "ahash",
- "arrow-array 57.0.0",
- "arrow-buffer 57.0.0",
- "arrow-cast 57.0.0",
- "arrow-data 57.0.0",
- "arrow-ipc 57.0.0",
- "arrow-schema 57.0.0",
- "arrow-select 57.0.0",
+ "arrow-array 57.1.0",
+ "arrow-buffer 57.1.0",
+ "arrow-cast 57.1.0",
+ "arrow-data 57.1.0",
+ "arrow-ipc 57.1.0",
+ "arrow-schema 57.1.0",
+ "arrow-select 57.1.0",
  "base64 0.22.1",
  "brotli 8.0.2",
  "bytes",
@@ -3958,7 +3990,7 @@ dependencies = [
  "snap",
  "thrift",
  "tokio",
- "twox-hash 2.1.2",
+ "twox-hash",
  "zstd",
 ]
 
@@ -3983,13 +4015,13 @@ dependencies = [
  "anyhow",
  "argon2",
  "arrow 54.2.1",
- "arrow 57.0.0",
- "arrow-array 57.0.0",
+ "arrow 57.1.0",
+ "arrow-array 57.1.0",
  "arrow-flight",
- "arrow-ipc 57.0.0",
- "arrow-json 57.0.0",
- "arrow-schema 57.0.0",
- "arrow-select 57.0.0",
+ "arrow-ipc 57.1.0",
+ "arrow-json 57.1.0",
+ "arrow-schema 57.1.0",
+ "arrow-select 57.1.0",
  "async-trait",
  "base64 0.22.1",
  "byteorder",
@@ -4789,14 +4821,13 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
 dependencies = [
  "futures-timer",
  "futures-util",
- "rstest_macros 0.25.0",
- "rustc_version",
+ "rstest_macros 0.26.1",
 ]
 
 [[package]]
@@ -4819,9 +4850,9 @@ dependencies = [
 
 [[package]]
 name = "rstest_macros"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
  "cfg-if",
  "glob",
@@ -5934,16 +5965,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "twox-hash"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "static_assertions",
-]
 
 [[package]]
 name = "twox-hash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -121,7 +121,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "socket2",
+ "socket2 0.5.8",
  "tokio",
  "tracing",
 ]
@@ -204,7 +204,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2",
+ "socket2 0.5.8",
  "time",
  "url",
 ]
@@ -218,7 +218,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -289,7 +289,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -321,12 +321,6 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -435,57 +429,110 @@ version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc208515aa0151028e464cc94a692156e945ce5126abd3537bb7fd6ba2143ed1"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-csv",
- "arrow-data",
- "arrow-ipc",
- "arrow-json",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-arith 54.3.1",
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-cast 54.3.1",
+ "arrow-csv 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-ipc 54.2.1",
+ "arrow-json 54.3.1",
+ "arrow-ord 54.2.1",
+ "arrow-row 54.2.1",
+ "arrow-schema 54.3.1",
+ "arrow-select 54.3.1",
+ "arrow-string 54.2.1",
+]
+
+[[package]]
+name = "arrow"
+version = "57.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df8bb5b0bd64c0b9bc61317fcc480bad0f00e56d3bc32c69a4c8dada4786bae"
+dependencies = [
+ "arrow-arith 57.0.0",
+ "arrow-array 57.0.0",
+ "arrow-buffer 57.0.0",
+ "arrow-cast 57.0.0",
+ "arrow-csv 57.0.0",
+ "arrow-data 57.0.0",
+ "arrow-ipc 57.0.0",
+ "arrow-json 57.0.0",
+ "arrow-ord 57.0.0",
+ "arrow-row 57.0.0",
+ "arrow-schema 57.0.0",
+ "arrow-select 57.0.0",
+ "arrow-string 57.0.0",
 ]
 
 [[package]]
 name = "arrow-arith"
-version = "54.2.1"
+version = "54.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e07e726e2b3f7816a85c6a45b6ec118eeeabf0b2a8c208122ad949437181f49a"
+checksum = "8fc766fdacaf804cb10c7c70580254fcdb5d55cdfda2bc57b02baf5223a3af9e"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
  "chrono",
  "num",
 ]
 
 [[package]]
-name = "arrow-array"
-version = "54.2.1"
+name = "arrow-arith"
+version = "57.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2262eba4f16c78496adfd559a29fe4b24df6088efc9985a873d58e92be022d5"
+checksum = "a1a640186d3bd30a24cb42264c2dafb30e236a6f50d510e56d40b708c9582491"
+dependencies = [
+ "arrow-array 57.0.0",
+ "arrow-buffer 57.0.0",
+ "arrow-data 57.0.0",
+ "arrow-schema 57.0.0",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12fcdb3f1d03f69d3ec26ac67645a8fe3f878d77b5ebb0b15d64a116c212985"
 dependencies = [
  "ahash",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
  "chrono",
- "chrono-tz",
  "half",
  "hashbrown 0.15.2",
  "num",
 ]
 
 [[package]]
-name = "arrow-buffer"
-version = "54.2.1"
+name = "arrow-array"
+version = "57.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e899dade2c3b7f5642eb8366cfd898958bcca099cde6dfea543c7e8d3ad88d4"
+checksum = "219fe420e6800979744c8393b687afb0252b3f8a89b91027d27887b72aa36d31"
+dependencies = [
+ "ahash",
+ "arrow-buffer 57.0.0",
+ "arrow-data 57.0.0",
+ "arrow-schema 57.0.0",
+ "chrono",
+ "chrono-tz",
+ "half",
+ "hashbrown 0.16.0",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "263f4801ff1839ef53ebd06f99a56cecd1dbaf314ec893d93168e2e860e0291c"
 dependencies = [
  "bytes",
  "half",
@@ -493,20 +540,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-cast"
-version = "54.2.1"
+name = "arrow-buffer"
+version = "57.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4103d88c5b441525ed4ac23153be7458494c2b0c9a11115848fdb9b81f6f886a"
+checksum = "76885a2697a7edf6b59577f568b456afc94ce0e2edc15b784ce3685b6c3c5c27"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ede6175fbc039dfc946a61c1b6d42fd682fcecf5ab5d148fbe7667705798cac9"
+dependencies = [
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "arrow-select 54.3.1",
  "atoi",
  "base64 0.22.1",
  "chrono",
- "comfy-table",
  "half",
  "lexical-core",
  "num",
@@ -514,14 +572,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-csv"
-version = "54.2.1"
+name = "arrow-cast"
+version = "57.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d3cb0914486a3cae19a5cad2598e44e225d53157926d0ada03c20521191a65"
+checksum = "9c9ebb4c987e6b3b236fb4a14b20b34835abfdd80acead3ccf1f9bf399e1f168"
 dependencies = [
- "arrow-array",
- "arrow-cast",
- "arrow-schema",
+ "arrow-array 57.0.0",
+ "arrow-buffer 57.0.0",
+ "arrow-data 57.0.0",
+ "arrow-schema 57.0.0",
+ "arrow-select 57.0.0",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "comfy-table",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1644877d8bc9a0ef022d9153dc29375c2bda244c39aec05a91d0e87ccf77995f"
+dependencies = [
+ "arrow-array 54.3.1",
+ "arrow-cast 54.3.1",
+ "arrow-schema 54.3.1",
  "chrono",
  "csv",
  "csv-core",
@@ -530,34 +609,63 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-data"
-version = "54.2.1"
+name = "arrow-csv"
+version = "57.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a329fb064477c9ec5f0870d2f5130966f91055c7c5bce2b3a084f116bc28c3b"
+checksum = "92386159c8d4bce96f8bd396b0642a0d544d471bdc2ef34d631aec80db40a09c"
 dependencies = [
- "arrow-buffer",
- "arrow-schema",
+ "arrow-array 57.0.0",
+ "arrow-cast 57.0.0",
+ "arrow-schema 57.0.0",
+ "chrono",
+ "csv",
+ "csv-core",
+ "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61cfdd7d99b4ff618f167e548b2411e5dd2c98c0ddebedd7df433d34c20a4429"
+dependencies = [
+ "arrow-buffer 54.3.1",
+ "arrow-schema 54.3.1",
  "half",
  "num",
 ]
 
 [[package]]
-name = "arrow-flight"
-version = "54.2.1"
+name = "arrow-data"
+version = "57.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7408f2bf3b978eddda272c7699f439760ebc4ac70feca25fefa82c5b8ce808d"
+checksum = "727681b95de313b600eddc2a37e736dcb21980a40f640314dcf360e2f36bc89b"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-ipc",
- "arrow-schema",
+ "arrow-buffer 57.0.0",
+ "arrow-schema 57.0.0",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-flight"
+version = "57.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70bb56412a007b0cfc116d15f24dda6adeed9611a213852a004cda20085a3b9"
+dependencies = [
+ "arrow-array 57.0.0",
+ "arrow-buffer 57.0.0",
+ "arrow-cast 57.0.0",
+ "arrow-ipc 57.0.0",
+ "arrow-schema 57.0.0",
  "base64 0.22.1",
  "bytes",
  "futures",
- "prost",
+ "prost 0.14.1",
  "prost-types",
- "tonic 0.12.3",
+ "tonic 0.14.2",
+ "tonic-prost",
 ]
 
 [[package]]
@@ -566,33 +674,73 @@ version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddecdeab02491b1ce88885986e25002a3da34dd349f682c7cfe67bab7cc17b86"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "flatbuffers",
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "flatbuffers 24.12.23",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "57.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9ba92e3de170295c98a84e5af22e2b037f0c7b32449445e6c493b5fca27f27"
+dependencies = [
+ "arrow-array 57.0.0",
+ "arrow-buffer 57.0.0",
+ "arrow-data 57.0.0",
+ "arrow-schema 57.0.0",
+ "arrow-select 57.0.0",
+ "flatbuffers 25.9.23",
  "lz4_flex",
  "zstd",
 ]
 
 [[package]]
 name = "arrow-json"
-version = "54.2.1"
+version = "54.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03b9340013413eb84868682ace00a1098c81a5ebc96d279f7ebf9a4cac3c0fd"
+checksum = "0ee5b4ca98a7fb2efb9ab3309a5d1c88b5116997ff93f3147efdc1062a6158e9"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-cast 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
  "chrono",
  "half",
- "indexmap 2.7.1",
+ "indexmap",
  "lexical-core",
+ "memchr",
  "num",
  "serde",
  "serde_json",
+ "simdutf8",
+]
+
+[[package]]
+name = "arrow-json"
+version = "57.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b969b4a421ae83828591c6bf5450bd52e6d489584142845ad6a861f42fe35df8"
+dependencies = [
+ "arrow-array 57.0.0",
+ "arrow-buffer 57.0.0",
+ "arrow-cast 57.0.0",
+ "arrow-data 57.0.0",
+ "arrow-schema 57.0.0",
+ "chrono",
+ "half",
+ "indexmap",
+ "itoa",
+ "lexical-core",
+ "memchr",
+ "num-traits",
+ "ryu",
+ "serde_core",
+ "serde_json",
+ "simdutf8",
 ]
 
 [[package]]
@@ -601,11 +749,24 @@ version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f841bfcc1997ef6ac48ee0305c4dfceb1f7c786fe31e67c1186edf775e1f1160"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "arrow-select 54.3.1",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "57.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "141c05298b21d03e88062317a1f1a73f5ba7b6eb041b350015b1cd6aabc0519b"
+dependencies = [
+ "arrow-array 57.0.0",
+ "arrow-buffer 57.0.0",
+ "arrow-data 57.0.0",
+ "arrow-schema 57.0.0",
+ "arrow-select 57.0.0",
 ]
 
 [[package]]
@@ -614,34 +775,69 @@ version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1eeb55b0a0a83851aa01f2ca5ee5648f607e8506ba6802577afdda9d75cdedcd"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "half",
+]
+
+[[package]]
+name = "arrow-row"
+version = "57.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f3c06a6abad6164508ed283c7a02151515cef3de4b4ff2cebbcaeb85533db2"
+dependencies = [
+ "arrow-array 57.0.0",
+ "arrow-buffer 57.0.0",
+ "arrow-data 57.0.0",
+ "arrow-schema 57.0.0",
  "half",
 ]
 
 [[package]]
 name = "arrow-schema"
-version = "54.2.1"
+version = "54.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85934a9d0261e0fa5d4e2a5295107d743b543a6e0484a835d4b8db2da15306f9"
+checksum = "39cfaf5e440be44db5413b75b72c2a87c1f8f0627117d110264048f2969b99e9"
+
+[[package]]
+name = "arrow-schema"
+version = "57.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cfa7a03d1eee2a4d061476e1840ad5c9867a544ca6c4c59256496af5d0a8be5"
 dependencies = [
  "serde",
+ "serde_core",
+ "serde_json",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "54.2.1"
+version = "54.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e2932aece2d0c869dd2125feb9bd1709ef5c445daa3838ac4112dcfa0fda52c"
+checksum = "69efcd706420e52cd44f5c4358d279801993846d1c2a8e52111853d61d55a619"
 dependencies = [
  "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
  "num",
+]
+
+[[package]]
+name = "arrow-select"
+version = "57.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafa595babaad59f2455f4957d0f26448fb472722c186739f4fac0823a1bdb47"
+dependencies = [
+ "ahash",
+ "arrow-array 57.0.0",
+ "arrow-buffer 57.0.0",
+ "arrow-data 57.0.0",
+ "arrow-schema 57.0.0",
+ "num-traits",
 ]
 
 [[package]]
@@ -650,11 +846,11 @@ version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "912e38bd6a7a7714c1d9b61df80315685553b7455e8a6045c27531d8ecd5b458"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "arrow-select 54.3.1",
  "memchr",
  "num",
  "regex",
@@ -662,13 +858,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-compression"
-version = "0.4.18"
+name = "arrow-string"
+version = "57.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+checksum = "32f46457dbbb99f2650ff3ac23e46a929e0ab81db809b02aa5511c258348bef2"
+dependencies = [
+ "arrow-array 57.0.0",
+ "arrow-buffer 57.0.0",
+ "arrow-data 57.0.0",
+ "arrow-schema 57.0.0",
+ "arrow-select 57.0.0",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06575e6a9673580f52661c92107baabffbf41e2141373441cbcdc47cb733003c"
 dependencies = [
  "brotli 7.0.0",
- "bzip2 0.4.4",
+ "bzip2 0.5.0",
  "flate2",
  "futures-core",
  "memchr",
@@ -680,36 +893,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
 name = "async-trait"
-version = "0.1.85"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -734,12 +925,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "axum"
-version = "0.7.9"
+name = "aws-lc-rs"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "879b6c89592deb404ba4dc0ae6b58ffd1795c78991cbb5b8bc441c48a070440d"
 dependencies = [
- "async-trait",
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "107a4e9d9cab9963e04e84bb8dee0e25f2a987f9a8bad5ed054abd439caa8f8c"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
+dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
@@ -752,29 +965,26 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "sync_wrapper 1.0.2",
- "tower 0.5.2",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
+ "futures-core",
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
@@ -815,15 +1025,35 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bigdecimal"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f31f3af01c5c65a07985c804d3366560e6fa7883d640a122819b14ec327482c"
+checksum = "560f42649de9fa436b73517378a147ec21f6c997a546581df4b4b31677828934"
 dependencies = [
  "autocfg",
  "libm",
  "num-bigint",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.8.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -865,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.5"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ee0c1824c4dea5b5f81736aff91bae041d2c07ee1192bec91054e10e3e601e"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -893,7 +1123,7 @@ checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor",
+ "brotli-decompressor 4.0.2",
 ]
 
 [[package]]
@@ -904,7 +1134,18 @@ checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor",
+ "brotli-decompressor 4.0.2",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor 5.0.0",
 ]
 
 [[package]]
@@ -912,6 +1153,16 @@ name = "brotli-decompressor"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74fa05ad7d803d413eb8380983b092cbbaf9a85f151b871360e7b00cd7060b37"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -931,9 +1182,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bytestring"
@@ -946,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "bzip2"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+checksum = "bafdbf26611df8c14810e268ddceda071c297570a5fb360ceddf617fe417ef58"
 dependencies = [
  "bzip2-sys",
  "libc",
@@ -956,12 +1207,11 @@ dependencies = [
 
 [[package]]
 name = "bzip2"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bafdbf26611df8c14810e268ddceda071c297570a5fb360ceddf617fe417ef58"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
- "bzip2-sys",
- "libc",
+ "libbz2-rs-sys",
 ]
 
 [[package]]
@@ -1019,13 +1269,23 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.10"
+version = "1.2.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+checksum = "739eb0f94557554b3ca9a86d2d37bebd49c5e6d0c1d2bda35ba5bdac830befc2"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -1052,17 +1312,16 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -1096,6 +1355,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,7 +1395,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1145,9 +1415,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.53"
+version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24a03c8b52922d68a1589ad61032f2c1aa5a8158d2aa0d93c6e9534944bbad6"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
  "cc",
 ]
@@ -1160,9 +1430,9 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "comfy-table"
-version = "7.1.3"
+version = "7.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f165e7b643266ea80cb858aed492ad9280e3e05ce24d4a99d7d7b889b6a4d9"
+checksum = "e0d05af1e006a2407bedef5af410552494ce5be9090444dbbcb57258c1af3d56"
 dependencies = [
  "strum",
  "strum_macros",
@@ -1383,7 +1653,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1394,7 +1664,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1419,24 +1689,27 @@ checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
 
 [[package]]
 name = "datafusion"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae420e7a5b0b7f1c39364cc76cbcd0f5fdc416b2514ae3847c2676bbd60702a"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
 dependencies = [
- "arrow",
- "arrow-array",
- "arrow-ipc",
- "arrow-schema",
- "async-compression",
+ "arrow 57.0.0",
+ "arrow-schema 57.0.0",
  "async-trait",
  "bytes",
- "bzip2 0.5.0",
+ "bzip2 0.6.1",
  "chrono",
  "datafusion-catalog",
+ "datafusion-catalog-listing",
  "datafusion-common",
  "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-datasource-arrow",
+ "datafusion-datasource-csv",
+ "datafusion-datasource-json",
+ "datafusion-datasource-parquet",
  "datafusion-execution",
  "datafusion-expr",
+ "datafusion-expr-common",
  "datafusion-functions",
  "datafusion-functions-aggregate",
  "datafusion-functions-nested",
@@ -1444,24 +1717,25 @@ dependencies = [
  "datafusion-functions-window",
  "datafusion-optimizer",
  "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
  "datafusion-physical-expr-common",
  "datafusion-physical-optimizer",
  "datafusion-physical-plan",
+ "datafusion-session",
  "datafusion-sql",
  "flate2",
  "futures",
- "glob",
  "itertools 0.14.0",
  "log",
  "object_store",
  "parking_lot",
  "parquet",
- "rand 0.8.5",
+ "rand 0.9.1",
  "regex",
+ "rstest 0.25.0",
  "sqlparser",
  "tempfile",
  "tokio",
- "tokio-util",
  "url",
  "uuid",
  "xz2",
@@ -1470,41 +1744,63 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f27987bc22b810939e8dfecc55571e9d50355d6ea8ec1c47af8383a76a6d0e1"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
 dependencies = [
- "arrow",
+ "arrow 57.0.0",
  "async-trait",
  "dashmap",
  "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
  "datafusion-execution",
  "datafusion-expr",
+ "datafusion-physical-expr",
  "datafusion-physical-plan",
- "datafusion-sql",
+ "datafusion-session",
  "futures",
  "itertools 0.14.0",
  "log",
+ "object_store",
  "parking_lot",
- "sqlparser",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-catalog-listing"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+dependencies = [
+ "arrow 57.0.0",
+ "async-trait",
+ "datafusion-catalog",
+ "datafusion-common",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+ "tokio",
 ]
 
 [[package]]
 name = "datafusion-common"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3f6d5b8c9408cc692f7c194b8aa0c0f9b253e065a8d960ad9cdc2a13e697602"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
 dependencies = [
  "ahash",
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-ipc",
- "arrow-schema",
- "base64 0.22.1",
+ "arrow 57.0.0",
+ "arrow-ipc 57.0.0",
+ "chrono",
  "half",
  "hashbrown 0.14.5",
- "indexmap 2.7.1",
+ "indexmap",
  "libc",
  "log",
  "object_store",
@@ -1518,27 +1814,155 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4603c8e8a4baf77660ab7074cc66fc15cc8a18f2ce9dfadb755fc6ee294e48"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
 dependencies = [
+ "futures",
  "log",
  "tokio",
 ]
 
 [[package]]
+name = "datafusion-datasource"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+dependencies = [
+ "arrow 57.0.0",
+ "async-compression",
+ "async-trait",
+ "bytes",
+ "bzip2 0.6.1",
+ "chrono",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "flate2",
+ "futures",
+ "glob",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+ "rand 0.9.1",
+ "tokio",
+ "tokio-util",
+ "url",
+ "xz2",
+ "zstd",
+]
+
+[[package]]
+name = "datafusion-datasource-arrow"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+dependencies = [
+ "arrow 57.0.0",
+ "arrow-ipc 57.0.0",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "itertools 0.14.0",
+ "object_store",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-csv"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+dependencies = [
+ "arrow 57.0.0",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "object_store",
+ "regex",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-json"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+dependencies = [
+ "arrow 57.0.0",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "object_store",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-parquet"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+dependencies = [
+ "arrow 57.0.0",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions-aggregate-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-pruning",
+ "datafusion-session",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+ "parking_lot",
+ "parquet",
+ "tokio",
+]
+
+[[package]]
 name = "datafusion-doc"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bf4bc68623a5cf231eed601ed6eb41f46a37c4d15d11a0bff24cbc8396cd66"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
 
 [[package]]
 name = "datafusion-execution"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b491c012cdf8e051053426013429a76f74ee3c2db68496c79c323ca1084d27"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
 dependencies = [
- "arrow",
+ "arrow 57.0.0",
+ "async-trait",
  "dashmap",
  "datafusion-common",
  "datafusion-expr",
@@ -1546,18 +1970,18 @@ dependencies = [
  "log",
  "object_store",
  "parking_lot",
- "rand 0.8.5",
+ "rand 0.9.1",
  "tempfile",
  "url",
 ]
 
 [[package]]
 name = "datafusion-expr"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a181408d4fc5dc22f9252781a8f39f2d0e5d1b33ec9bde242844980a2689c1"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
 dependencies = [
- "arrow",
+ "arrow 57.0.0",
+ "async-trait",
  "chrono",
  "datafusion-common",
  "datafusion-doc",
@@ -1565,7 +1989,8 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
- "indexmap 2.7.1",
+ "indexmap",
+ "itertools 0.14.0",
  "paste",
  "recursive",
  "serde_json",
@@ -1574,24 +1999,23 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1129b48e8534d8c03c6543bcdccef0b55c8ac0c1272a15a56c67068b6eb1885"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
 dependencies = [
- "arrow",
+ "arrow 57.0.0",
  "datafusion-common",
+ "indexmap",
  "itertools 0.14.0",
  "paste",
 ]
 
 [[package]]
 name = "datafusion-functions"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6125874e4856dfb09b59886784fcb74cde5cfc5930b3a80a1a728ef7a010df6b"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
 dependencies = [
- "arrow",
- "arrow-buffer",
+ "arrow 57.0.0",
+ "arrow-buffer 57.0.0",
  "base64 0.22.1",
  "blake2",
  "blake3",
@@ -1602,12 +2026,12 @@ dependencies = [
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-macros",
- "hashbrown 0.14.5",
  "hex",
  "itertools 0.14.0",
  "log",
  "md-5",
- "rand 0.8.5",
+ "num-traits",
+ "rand 0.9.1",
  "regex",
  "sha2",
  "unicode-segmentation",
@@ -1616,14 +2040,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3add7b1d3888e05e7c95f2b281af900ca69ebdcb21069ba679b33bde8b3b9d6"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
 dependencies = [
  "ahash",
- "arrow",
- "arrow-buffer",
- "arrow-schema",
+ "arrow 57.0.0",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-execution",
@@ -1639,12 +2060,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e18baa4cfc3d2f144f74148ed68a1f92337f5072b6dde204a0dbbdf3324989c"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
 dependencies = [
  "ahash",
- "arrow",
+ "arrow 57.0.0",
  "datafusion-common",
  "datafusion-expr-common",
  "datafusion-physical-expr-common",
@@ -1652,21 +2072,19 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ec5ee8cecb0dc370291279673097ddabec03a011f73f30d7f1096457127e03e"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
 dependencies = [
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-ord",
- "arrow-schema",
+ "arrow 57.0.0",
+ "arrow-ord 57.0.0",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-execution",
  "datafusion-expr",
+ "datafusion-expr-common",
  "datafusion-functions",
  "datafusion-functions-aggregate",
+ "datafusion-functions-aggregate-common",
  "datafusion-macros",
  "datafusion-physical-expr-common",
  "itertools 0.14.0",
@@ -1676,11 +2094,10 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-table"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c403ddd473bbb0952ba880008428b3c7febf0ed3ce1eec35a205db20efb2a36"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
 dependencies = [
- "arrow",
+ "arrow 57.0.0",
  "async-trait",
  "datafusion-catalog",
  "datafusion-common",
@@ -1692,10 +2109,10 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab18c2fb835614d06a75f24a9e09136d3a8c12a92d97c95a6af316a1787a9c5"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
 dependencies = [
+ "arrow 57.0.0",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-expr",
@@ -1709,9 +2126,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77b73bc15e7d1967121fdc7a55d819bfb9d6c03766a6c322247dce9094a53a4"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -1719,27 +2135,26 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09369b8d962291e808977cf94d495fd8b5b38647232d7ef562c27ac0f495b0af"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
 dependencies = [
- "datafusion-expr",
+ "datafusion-doc",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
 name = "datafusion-optimizer"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2403a7e4a84637f3de7d8d4d7a9ccc0cc4be92d89b0161ba3ee5be82f0531c54"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
 dependencies = [
- "arrow",
+ "arrow 57.0.0",
  "chrono",
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-expr-common",
  "datafusion-physical-expr",
- "indexmap 2.7.1",
+ "indexmap",
  "itertools 0.14.0",
  "log",
  "recursive",
@@ -1749,15 +2164,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ff72ac702b62dbf2650c4e1d715ebd3e4aab14e3885e72e8549e250307347c"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
 dependencies = [
  "ahash",
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow 57.0.0",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-expr-common",
@@ -1765,22 +2176,34 @@ dependencies = [
  "datafusion-physical-expr-common",
  "half",
  "hashbrown 0.14.5",
- "indexmap 2.7.1",
+ "indexmap",
  "itertools 0.14.0",
- "log",
+ "parking_lot",
  "paste",
  "petgraph",
 ]
 
 [[package]]
+name = "datafusion-physical-expr-adapter"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+dependencies = [
+ "arrow 57.0.0",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "itertools 0.14.0",
+]
+
+[[package]]
 name = "datafusion-physical-expr-common"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60982b7d684e25579ee29754b4333057ed62e2cc925383c5f0bd8cab7962f435"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
 dependencies = [
  "ahash",
- "arrow",
- "arrow-buffer",
+ "arrow 57.0.0",
  "datafusion-common",
  "datafusion-expr-common",
  "hashbrown 0.14.5",
@@ -1789,12 +2212,10 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac5e85c189d5238a5cf181a624e450c4cd4c66ac77ca551d6f3ff9080bac90bb"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
 dependencies = [
- "arrow",
- "arrow-schema",
+ "arrow 57.0.0",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
@@ -1802,38 +2223,34 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
- "futures",
+ "datafusion-pruning",
  "itertools 0.14.0",
- "log",
  "recursive",
- "url",
 ]
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c36bf163956d7e2542657c78b3383fdc78f791317ef358a359feffcdb968106f"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
 dependencies = [
  "ahash",
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-ord",
- "arrow-schema",
+ "arrow 57.0.0",
+ "arrow-ord 57.0.0",
+ "arrow-schema 57.0.0",
  "async-trait",
  "chrono",
  "datafusion-common",
  "datafusion-common-runtime",
  "datafusion-execution",
  "datafusion-expr",
+ "datafusion-functions-aggregate-common",
  "datafusion-functions-window-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "futures",
  "half",
  "hashbrown 0.14.5",
- "indexmap 2.7.1",
+ "indexmap",
  "itertools 0.14.0",
  "log",
  "parking_lot",
@@ -1842,18 +2259,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "datafusion-sql"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13caa4daede211ecec53c78b13c503b592794d125f9a3cc3afe992edf9e7f43"
+name = "datafusion-pruning"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
 dependencies = [
- "arrow",
- "arrow-array",
- "arrow-schema",
+ "arrow 57.0.0",
+ "datafusion-common",
+ "datafusion-datasource",
+ "datafusion-expr-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "itertools 0.14.0",
+ "log",
+]
+
+[[package]]
+name = "datafusion-session"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+dependencies = [
+ "async-trait",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-plan",
+ "parking_lot",
+]
+
+[[package]]
+name = "datafusion-sql"
+version = "50.3.0"
+source = "git+https://github.com/apache/datafusion#0a650a0d27cab21591eccb85d048a1907fc75f14"
+dependencies = [
+ "arrow 57.0.0",
  "bigdecimal",
+ "chrono",
  "datafusion-common",
  "datafusion-expr",
- "indexmap 2.7.1",
+ "indexmap",
  "log",
  "recursive",
  "regex",
@@ -1877,7 +2321,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1898,7 +2342,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1908,7 +2352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1921,7 +2365,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1942,7 +2386,7 @@ dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
  "unicode-xid",
 ]
 
@@ -1965,7 +2409,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1979,6 +2423,12 @@ dependencies = [
  "os_pipe",
  "shared_child",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -2036,6 +2486,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+
+[[package]]
 name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2052,12 +2508,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "flate2"
-version = "1.0.35"
+name = "flatbuffers"
+version = "25.9.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "09b6620799e7340ebd9968d2e0708eb82cf1971e9a16821e2091b6d6e475eed5"
+dependencies = [
+ "bitflags 2.8.0",
+ "rustc_version",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -2068,10 +2535,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.1"
+name = "foldhash"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -2153,7 +2626,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2251,7 +2724,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.7.1",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -2270,7 +2743,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.2.0",
- "indexmap 2.7.1",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -2279,20 +2752,15 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
+ "zerocopy 0.8.27",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -2309,6 +2777,15 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "heck"
@@ -2455,7 +2932,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -2542,7 +3019,7 @@ dependencies = [
  "http-body 1.0.1",
  "hyper 1.6.0",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -2686,7 +3163,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2707,9 +3184,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -2734,22 +3211,12 @@ checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -2908,16 +3375,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.169"
+name = "libbz2-rs-sys"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+
+[[package]]
+name = "libc"
+version = "0.2.177"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
+dependencies = [
+ "zlib-rs",
+]
 
 [[package]]
 name = "libz-sys"
@@ -2994,7 +3486,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
 dependencies = [
- "twox-hash",
+ "twox-hash 1.6.3",
 ]
 
 [[package]]
@@ -3028,9 +3520,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -3065,12 +3557,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.3"
+name = "minimal-lexical"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -3083,6 +3582,16 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -3211,7 +3720,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -3234,34 +3743,40 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.11.2"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cfccb68961a56facde1163f9319e0d15743352344e7808a11795fb99698dcaf"
+checksum = "4c1be0c6c22ec0817cdc77d3842f721a17fd30ab6965001415b5402a74e6b740"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bytes",
  "chrono",
+ "form_urlencoded",
  "futures",
+ "http 1.2.0",
+ "http-body-util",
  "httparse",
  "humantime",
  "hyper 1.6.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "md-5",
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand 0.8.5",
+ "rand 0.9.1",
  "reqwest 0.12.12",
  "ring",
  "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
- "snafu",
+ "serde_urlencoded",
+ "thiserror 2.0.11",
  "tokio",
  "tracing",
  "url",
  "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
 ]
 
 [[package]]
@@ -3341,7 +3856,7 @@ dependencies = [
  "hex",
  "opentelemetry",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.13.4",
  "serde",
  "tonic 0.13.1",
 ]
@@ -3412,29 +3927,30 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "54.2.1"
+version = "57.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88838dca3b84d41444a0341b19f347e8098a3898b0f21536654b8b799e11abd"
+checksum = "7a0f31027ef1af7549f7cec603a9a21dce706d3f8d7c2060a68f43c1773be95a"
 dependencies = [
  "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ipc",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 57.0.0",
+ "arrow-buffer 57.0.0",
+ "arrow-cast 57.0.0",
+ "arrow-data 57.0.0",
+ "arrow-ipc 57.0.0",
+ "arrow-schema 57.0.0",
+ "arrow-select 57.0.0",
  "base64 0.22.1",
- "brotli 7.0.0",
+ "brotli 8.0.2",
  "bytes",
  "chrono",
  "flate2",
  "futures",
  "half",
- "hashbrown 0.15.2",
+ "hashbrown 0.16.0",
  "lz4_flex",
- "num",
  "num-bigint",
+ "num-integer",
+ "num-traits",
  "object_store",
  "paste",
  "seq-macro",
@@ -3442,9 +3958,8 @@ dependencies = [
  "snap",
  "thrift",
  "tokio",
- "twox-hash",
+ "twox-hash 2.1.2",
  "zstd",
- "zstd-sys",
 ]
 
 [[package]]
@@ -3467,13 +3982,14 @@ dependencies = [
  "actix-web-static-files",
  "anyhow",
  "argon2",
- "arrow",
- "arrow-array",
+ "arrow 54.2.1",
+ "arrow 57.0.0",
+ "arrow-array 57.0.0",
  "arrow-flight",
- "arrow-ipc",
- "arrow-json",
- "arrow-schema",
- "arrow-select",
+ "arrow-ipc 57.0.0",
+ "arrow-json 57.0.0",
+ "arrow-schema 57.0.0",
+ "arrow-select 57.0.0",
  "async-trait",
  "base64 0.22.1",
  "byteorder",
@@ -3511,14 +4027,14 @@ dependencies = [
  "path-clean",
  "prometheus",
  "prometheus-parse",
- "prost",
+ "prost 0.13.4",
  "rand 0.8.5",
  "rayon",
  "rdkafka",
  "regex",
  "relative-path",
  "reqwest 0.11.27",
- "rstest",
+ "rstest 0.23.0",
  "rustls 0.22.4",
  "rustls-pemfile 2.2.0",
  "sasl2-sys",
@@ -3536,9 +4052,10 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic 0.12.3",
+ "tonic 0.14.2",
+ "tonic-prost",
  "tonic-web",
- "tower-http 0.6.2",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "ulid",
@@ -3590,18 +4107,20 @@ checksum = "498a099351efa4becc6a19c72aa9270598e8fd274ca47052e37455241c88b696"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
-version = "0.7.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
- "indexmap 2.7.1",
+ "hashbrown 0.15.2",
+ "indexmap",
+ "serde",
 ]
 
 [[package]]
@@ -3659,7 +4178,7 @@ checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -3692,7 +4211,17 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -3796,7 +4325,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.13.4",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.1",
 ]
 
 [[package]]
@@ -3809,16 +4348,29 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.13.4"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
+checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
 dependencies = [
- "prost",
+ "prost 0.14.1",
 ]
 
 [[package]]
@@ -3854,9 +4406,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.2"
+version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003"
+checksum = "42a232e7487fc2ef313d96dde7948e7a3c05101870d8985e4fd8d26aedd27b89"
 dependencies = [
  "memchr",
  "serde",
@@ -3874,7 +4426,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.22",
- "socket2",
+ "socket2 0.5.8",
  "thiserror 2.0.11",
  "tokio",
  "tracing",
@@ -3909,16 +4461,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.8",
  "tracing",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
@@ -4062,7 +4614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -4076,9 +4628,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4088,9 +4640,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4105,9 +4657,9 @@ checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "relative-path"
@@ -4156,6 +4708,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 0.25.4",
  "winreg",
@@ -4197,7 +4750,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.1",
  "tokio-util",
- "tower 0.5.2",
+ "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4230,7 +4783,19 @@ checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
 dependencies = [
  "futures",
  "futures-timer",
- "rstest_macros",
+ "rstest_macros 0.23.0",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros 0.25.0",
  "rustc_version",
 ]
 
@@ -4248,7 +4813,25 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.96",
+ "syn 2.0.108",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.108",
  "unicode-ident",
 ]
 
@@ -4331,6 +4914,7 @@ version = "0.23.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -4395,6 +4979,7 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -4498,22 +5083,32 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -4522,7 +5117,7 @@ version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -4537,7 +5132,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -4580,9 +5175,9 @@ checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -4678,27 +5273,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
-name = "snafu"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
-dependencies = [
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
 name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4715,12 +5289,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlparser"
-version = "0.53.0"
+name = "socket2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a528114c392209b3264855ad491fcce534b94a38771b0a0b97a79379275ce8"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4591acadbcf52f0af60eafbb2c003232b2b4cd8de5f0e9437cb8b1b59046cc0f"
 dependencies = [
  "log",
+ "recursive",
  "sqlparser_derive",
 ]
 
@@ -4732,7 +5317,7 @@ checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -4793,7 +5378,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -4814,9 +5399,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4846,7 +5431,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -4929,7 +5514,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -4940,7 +5525,7 @@ checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -5033,31 +5618,30 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.1"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "492a604e2fd7f814268a378409e6c92b5525d747d10db9a229723f55a417958c"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
- "backtrace",
  "bytes",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.1",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -5104,9 +5688,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5142,45 +5726,11 @@ version = "0.22.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
  "winnow",
-]
-
-[[package]]
-name = "tonic"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum",
- "base64 0.22.1",
- "bytes",
- "flate2",
- "h2 0.4.7",
- "http 1.2.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.6.0",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "prost",
- "rustls-pemfile 2.2.0",
- "socket2",
- "tokio",
- "tokio-rustls 0.26.1",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
- "zstd",
 ]
 
 [[package]]
@@ -5200,50 +5750,72 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.13.4",
  "tokio",
  "tokio-stream",
- "tower 0.5.2",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
 ]
 
 [[package]]
-name = "tonic-web"
-version = "0.12.3"
+name = "tonic"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5299dd20801ad736dccb4a5ea0da7376e59cd98f213bf1c3d478cf53f4834b58"
+checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "flate2",
+ "h2 0.4.7",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "rustls-native-certs",
+ "socket2 0.6.1",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-rustls 0.26.1",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "zstd",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
+dependencies = [
+ "bytes",
+ "prost 0.14.1",
+ "tonic 0.14.2",
+]
+
+[[package]]
+name = "tonic-web"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75214f6b6bd28c19aa752ac09fdf0eea546095670906c21fe3940e180a4c43f2"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "http 1.2.0",
  "http-body 1.0.1",
- "http-body-util",
  "pin-project",
  "tokio-stream",
- "tonic 0.12.3",
- "tower-http 0.5.2",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
+ "tonic 0.14.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5257,7 +5829,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.7.1",
+ "indexmap",
  "pin-project-lite",
  "slab",
  "sync_wrapper 1.0.2",
@@ -5266,22 +5838,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
-dependencies = [
- "bitflags 2.8.0",
- "bytes",
- "http 1.2.0",
- "http-body 1.0.1",
- "http-body-util",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -5330,7 +5886,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -5388,6 +5944,12 @@ dependencies = [
  "cfg-if",
  "static_assertions",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
@@ -5486,12 +6048,12 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
- "idna 1.0.3",
+ "idna 1.1.0",
  "percent-encoding",
  "serde",
 ]
@@ -5516,11 +6078,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.12.1"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.3.1",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5550,7 +6114,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -5681,7 +6245,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
  "wasm-bindgen-shared",
 ]
 
@@ -5716,7 +6280,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5858,7 +6422,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -5869,8 +6433,14 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
@@ -5939,6 +6509,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5962,11 +6550,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5982,6 +6587,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5992,6 +6603,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6006,10 +6623,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6024,6 +6653,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6034,6 +6669,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6048,6 +6689,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6058,6 +6705,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -6134,7 +6787,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
  "synstructure",
 ]
 
@@ -6145,7 +6798,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive 0.8.27",
 ]
 
 [[package]]
@@ -6156,7 +6818,18 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -6176,7 +6849,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
  "synstructure",
 ]
 
@@ -6205,7 +6878,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -6219,11 +6892,17 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.7.1",
+ "indexmap",
  "memchr",
  "thiserror 2.0.11",
  "zopfli",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f06ae92f42f5e5c42443fd094f245eb656abf56dd7cce9b8b263236565e00f2"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,21 +9,22 @@ build = "build.rs"
 
 [dependencies]
 # Arrow and DataFusion ecosystem
-arrow = "54.0.0"
-arrow-array = "54.0.0"
-arrow-flight = { version = "54.0.0", features = ["tls"] }
-arrow-ipc = { version = "54.0.0", features = ["zstd"] }
-arrow-json = "54.0.0"
-arrow-schema = { version = "54.0.0", features = ["serde"] }
-arrow-select = "54.0.0"
-datafusion = "45.0.0"
-object_store = { version = "0.11.2", features = [
+arrow = "57.0.0"
+arrow-array = "57.0.0"
+arrow-flight = { version = "57.0.0", features = ["tls-aws-lc","tls-native-roots"] }
+arrow-ipc = { version = "57.0.0", features = ["zstd"] }
+arrow-json = "57.0.0"
+arrow-schema = { version = "57.0.0", features = ["serde"] }
+arrow-select = "57.0.0"
+# datafusion = "50.3.0"
+datafusion = {git="https://github.com/apache/datafusion"}
+object_store = { version = "0.12.4", features = [
     "cloud",
     "aws",
     "azure",
     "gcp",
 ] }
-parquet = "54.0.0"
+parquet = "57.0.0"
 
 # Web server and HTTP-related
 actix-cors = "0.7.0"
@@ -33,8 +34,9 @@ actix-web-prometheus = { version = "0.1" }
 actix-web-static-files = "4.0"
 http = "0.2.7"
 http-auth-basic = "0.3.3"
-tonic = { version = "0.12.3", features = ["tls", "transport", "gzip", "zstd", "prost"] }
-tonic-web = "0.12.3"
+tonic = { version = "0.14.1", features = ["tls-aws-lc", "tls-native-roots", "transport", "gzip", "zstd"] }
+tonic-prost = "0.14.1"
+tonic-web = "0.14.1"
 tower-http = { version = "0.6.1", features = ["cors"] }
 url = "2.4.0"
 
@@ -126,12 +128,13 @@ itertools = "0.14"
 once_cell = "1.20"
 rayon = "1.8"
 rand = "0.8.5"
-regex = "1.7.3"
+regex = "1.12.2"
 reqwest = { version = "0.11.27", default-features = false, features = [
     "rustls-tls",
     "json",
     "gzip",
     "brotli",
+    "stream"
 ] } # cannot update cause rustls is not latest `see rustls`
 semver = "1.0"
 static-files = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,22 +9,21 @@ build = "build.rs"
 
 [dependencies]
 # Arrow and DataFusion ecosystem
-arrow = "57.0.0"
-arrow-array = "57.0.0"
-arrow-flight = { version = "57.0.0", features = ["tls-aws-lc","tls-native-roots"] }
-arrow-ipc = { version = "57.0.0", features = ["zstd"] }
-arrow-json = "57.0.0"
-arrow-schema = { version = "57.0.0", features = ["serde"] }
-arrow-select = "57.0.0"
-# datafusion = "50.3.0"
-datafusion = {git="https://github.com/apache/datafusion"}
+arrow = "57.1.0"
+arrow-array = "57.1.0"
+arrow-flight = { version = "57.1.0", features = ["tls-aws-lc","tls-native-roots"] }
+arrow-ipc = { version = "57.1.0", features = ["zstd"] }
+arrow-json = "57.1.0"
+arrow-schema = { version = "57.1.0", features = ["serde"] }
+arrow-select = "57.1.0"
+datafusion = "51.0.0"
 object_store = { version = "0.12.4", features = [
     "cloud",
     "aws",
     "azure",
     "gcp",
 ] }
-parquet = "57.0.0"
+parquet = "57.1.0"
 
 # Web server and HTTP-related
 actix-cors = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ anyhow = "1.0"
 
 [dev-dependencies]
 rstest = "0.23.0"
-arrow = "54.0.0"
+arrow = "57.1.0"
 temp-dir = "0.1.14"
 
 [package.metadata.parseable_ui]

--- a/Cross.toml
+++ b/Cross.toml
@@ -4,17 +4,32 @@ pre-build = [
     "dpkg --add-architecture arm64",
     "apt-get update",
     "apt-get install -y pkg-config:arm64 libc6-dev:arm64",
-    "apt-get install -y libssl-dev:arm64 libsasl2-dev:arm64",
-    "ln -sf /usr/lib/aarch64-linux-gnu/libssl.so.1.1 /usr/lib/aarch64-linux-gnu/libssl.so",
-    "ln -sf /usr/lib/aarch64-linux-gnu/libcrypto.so.1.1 /usr/lib/aarch64-linux-gnu/libcrypto.so",
+    "apt-get install -y zlib1g-dev:arm64 libssl-dev:arm64 libsasl2-dev:arm64",
+    
+    # The cross toolchain restricts cmake to search in /usr/aarch64-linux-gnu
+    # But multiarch installs to /usr/lib/aarch64-linux-gnu
+    # Create the expected directory structure with symlinks
+    "mkdir -p /usr/aarch64-linux-gnu/lib /usr/aarch64-linux-gnu/include",
+    
+    # Symlink zlib files to where cmake will find them
+    "ln -sf /usr/lib/aarch64-linux-gnu/libz.so /usr/aarch64-linux-gnu/lib/",
+    "ln -sf /usr/lib/aarch64-linux-gnu/libz.a /usr/aarch64-linux-gnu/lib/",
+    "cp /usr/include/zlib.h /usr/include/zconf.h /usr/aarch64-linux-gnu/include/",
+    
+    # Symlink SSL files
+    "ln -sf /usr/lib/aarch64-linux-gnu/libssl.so.1.1 /usr/aarch64-linux-gnu/lib/libssl.so",
+    "ln -sf /usr/lib/aarch64-linux-gnu/libcrypto.so.1.1 /usr/aarch64-linux-gnu/lib/libcrypto.so",
+    "ln -sf /usr/lib/aarch64-linux-gnu/libssl.a /usr/aarch64-linux-gnu/lib/",
+    "ln -sf /usr/lib/aarch64-linux-gnu/libcrypto.a /usr/aarch64-linux-gnu/lib/",
+    "cp -r /usr/include/openssl /usr/aarch64-linux-gnu/include/",
+    
+    # Debug - verify files are in place
+    "echo '=== ZLIB CHECK ==='",
+    "ls -la /usr/aarch64-linux-gnu/lib/libz*",
+    "ls -la /usr/aarch64-linux-gnu/include/zlib.h",
 ]
 
 [target.aarch64-unknown-linux-gnu.env]
-LIBZ_SYS_STATIC = "1"
 PKG_CONFIG_PATH = "/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/share/pkgconfig"
 PKG_CONFIG_ALLOW_CROSS = "1"
 LIBRDKAFKA_SSL_VENDORED = "1"
-OPENSSL_ROOT_DIR = "/usr"
-OPENSSL_INCLUDE_DIR = "/usr/include"
-OPENSSL_CRYPTO_LIBRARY = "/usr/lib/aarch64-linux-gnu/libcrypto.so"
-OPENSSL_SSL_LIBRARY = "/usr/lib/aarch64-linux-gnu/libssl.so"

--- a/Cross.toml
+++ b/Cross.toml
@@ -31,4 +31,4 @@ volumes = [
 ]
 
 [target.x86_64-unknown-linux-gnu]
-image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu@sha256:bf05360bb9d6d4947eed60532ac7a0d7e8fae8f214e9abb801d5941c8fe491
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu@sha256:bf05360bb9d6d4947eed60532ac7a0d7e8fae8f214e9abb801d5941c8fe4918d"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,21 @@
 [target.aarch64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu@sha256:1e2a0291f92a4372cbc22d8994e735473045383f1ce7fa44a16c234ba00187f4"
+pre-build = [
+    "dpkg --add-architecture arm64",
+    "apt-get update || true",
+    "apt-get install -y pkg-config:arm64 || true",
+    "apt-get install -y zlib1g-dev:arm64 || true",
+    "apt-get install -y libssl-dev:arm64 || true",
+    "apt-get install -y libsasl2-dev:arm64 || true",
+    "apt-get install -y libzstd-dev:arm64 || true",
+    "apt-get install -y liblz4-dev:arm64 || true",
+]
+
+[target.aarch64-unknown-linux-gnu.env]
+passthrough = [
+    "LIBRDKAFKA_SSL_VENDORED",
+    "PKG_CONFIG_ALLOW_CROSS",
+]
 
 [target.x86_64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu@sha256:bf05360bb9d6d4947eed60532ac7a0d7e8fae8f214e9abb801d5941c8fe4918d"

--- a/Cross.toml
+++ b/Cross.toml
@@ -2,11 +2,16 @@
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu@sha256:1e2a0291f92a4372cbc22d8994e735473045383f1ce7fa44a16c234ba00187f4"
 pre-build = [
     "dpkg --add-architecture arm64",
-    "apt-get update || true",
-    "apt-get install -y pkg-config:arm64 zlib1g-dev:arm64 libssl-dev:arm64 libsasl2-dev:arm64 libzstd-dev:arm64 liblz4-dev:arm64 || true",
-    # debug to confirm libs/headers are present
-    "ls -R /usr/lib/aarch64-linux-gnu || true",
-    "ls -R /usr/include/aarch64-linux-gnu || true",
+    "apt-get update",
+    "apt-get install -y pkg-config:arm64 zlib1g-dev:arm64 libssl-dev:arm64 libsasl2-dev:arm64 libzstd-dev:arm64 liblz4-dev:arm64",
+    "echo '=== DEBUG: zlib installation paths ==='",
+    "dpkg -l | grep zlib || true",
+    "find /usr -name 'zlib.h' 2>/dev/null || true",
+    "find /usr -name 'libz.so*' 2>/dev/null || true",
+    "pkg-config --cflags --libs zlib || echo 'pkg-config zlib failed'",
+    "echo '=== DEBUG: aarch64-linux-gnu paths ==='",
+    "ls -la /usr/include/aarch64-linux-gnu 2>/dev/null || echo 'No /usr/include/aarch64-linux-gnu'",
+    "ls -la /usr/lib/aarch64-linux-gnu 2>/dev/null || echo 'No /usr/lib/aarch64-linux-gnu'",
 ]
 
 [target.aarch64-unknown-linux-gnu.env]
@@ -15,19 +20,18 @@ passthrough = [
     "PKG_CONFIG_ALLOW_CROSS",
     "CROSS_NO_WARNINGS",
     "RUST_BACKTRACE",
-    # Explicit Zlib hints (used by CMake FindZLIB)
     "ZLIB_INCLUDE_DIR",
     "ZLIB_LIBRARY",
-    # OpenSSL hints
     "OPENSSL_ROOT_DIR",
     "OPENSSL_INCLUDE_DIR",
     "OPENSSL_CRYPTO_LIBRARY",
     "OPENSSL_SSL_LIBRARY",
     "PKG_CONFIG_PATH",
 ]
+# Fixed volumes syntax - mount host aarch64 paths into container
 volumes = [
-    "/usr/lib/aarch64-linux-gnu:/usr/lib/aarch64-linux-gnu:ro",
-    "/usr/include/aarch64-linux-gnu:/usr/include/aarch64-linux-gnu:ro",
+    "ZLIB_HOST_INCLUDE=/usr/include/aarch64-linux-gnu",
+    "ZLIB_HOST_LIB=/usr/lib/aarch64-linux-gnu",
 ]
 
 [target.x86_64-unknown-linux-gnu]

--- a/Cross.toml
+++ b/Cross.toml
@@ -28,11 +28,7 @@ passthrough = [
     "OPENSSL_SSL_LIBRARY",
     "PKG_CONFIG_PATH",
 ]
-# Fixed volumes syntax - mount host aarch64 paths into container
-volumes = [
-    "ZLIB_HOST_INCLUDE=/usr/include/aarch64-linux-gnu",
-    "ZLIB_HOST_LIB=/usr/lib/aarch64-linux-gnu",
-]
+# REMOVED: broken volumes causing cross to crash
 
 [target.x86_64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu@sha256:bf05360bb9d6d4947eed60532ac7a0d7e8fae8f214e9abb801d5941c8fe4918d"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,34 +1,50 @@
 [target.aarch64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu@sha256:1e2a0291f92a4372cbc22d8994e735473045383f1ce7fa44a16c234ba00187f4"
 pre-build = [
+    # Add multiarch support
     "dpkg --add-architecture arm64",
     "apt-get update",
-    "apt-get install -y pkg-config:arm64 zlib1g-dev:arm64 libssl-dev:arm64 libsasl2-dev:arm64 libzstd-dev:arm64 liblz4-dev:arm64",
-    "echo '=== DEBUG: zlib installation paths ==='",
-    "dpkg -l | grep zlib || true",
-    "find /usr -name 'zlib.h' 2>/dev/null || true",
-    "find /usr -name 'libz.so*' 2>/dev/null || true",
-    "pkg-config --cflags --libs zlib || echo 'pkg-config zlib failed'",
-    "echo '=== DEBUG: aarch64-linux-gnu paths ==='",
-    "ls -la /usr/include/aarch64-linux-gnu 2>/dev/null || echo 'No /usr/include/aarch64-linux-gnu'",
-    "ls -la /usr/lib/aarch64-linux-gnu 2>/dev/null || echo 'No /usr/lib/aarch64-linux-gnu'",
+    
+    # Install base dev packages FIRST (creates pkgconfig dir structure)
+    "apt-get install -y pkg-config:arm64 libc6-dev:arm64",
+    
+    # Install zlib and other deps
+    "apt-get install -y zlib1g-dev:arm64 libssl-dev:arm64 libsasl2-dev:arm64 libzstd-dev:arm64 liblz4-dev:arm64",
+    
+    # Verify pkg-config finds zlib
+    "pkg-config --cflags --libs --exists zlib || (echo 'ZLIB PC FAILED'; exit 1)",
+    
+    # Fix library paths (ensure symlinks)
+    "ln -sf /usr/lib/aarch64-linux-gnu/libz.so.1 /usr/lib/aarch64-linux-gnu/libz.so",
+    "ln -sf /usr/lib/aarch64-linux-gnu/libssl.so.1.1 /usr/lib/aarch64-linux-gnu/libssl.so",
+    "ln -sf /usr/lib/aarch64-linux-gnu/libcrypto.so.1.1 /usr/lib/aarch64-linux-gnu/libcrypto.so",
+    
+    # Debug verification
+    "echo '=== ZLIB DEBUG ==='",
+    "dpkg -l '*zlib*' | grep '^ii'",
+    "find /usr -name 'zlib.pc' 2>/dev/null || echo 'NO zlib.pc'",
+    "pkg-config --cflags --libs zlib",
+    "ls -la /usr/lib/aarch64-linux-gnu/libz*",
+    "echo '=== PATHS ==='",
+    "ls -la /usr/lib/aarch64-linux-gnu/pkgconfig/ 2>/dev/null || echo 'NO PKGCONFIG DIR'",
 ]
 
 [target.aarch64-unknown-linux-gnu.env]
-passthrough = [
-    "LIBRDKAFKA_SSL_VENDORED",
-    "PKG_CONFIG_ALLOW_CROSS",
-    "CROSS_NO_WARNINGS",
-    "RUST_BACKTRACE",
-    "ZLIB_INCLUDE_DIR",
-    "ZLIB_LIBRARY",
-    "OPENSSL_ROOT_DIR",
-    "OPENSSL_INCLUDE_DIR",
-    "OPENSSL_CRYPTO_LIBRARY",
-    "OPENSSL_SSL_LIBRARY",
-    "PKG_CONFIG_PATH",
-]
-# REMOVED: broken volumes causing cross to crash
+# Force pkg-config to cross paths
+PKG_CONFIG_PATH = "/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/share/pkgconfig"
+PKG_CONFIG_ALLOW_CROSS = "1"
+LIBRDKAFKA_SSL_VENDORED = "1"
 
-[target.x86_64-unknown-linux-gnu]
-image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu@sha256:bf05360bb9d6d4947eed60532ac7a0d7e8fae8f214e9abb801d5941c8fe4918d"
+# Explicit zlib paths for cmake
+ZLIB_INCLUDE_DIR = "/usr/include"
+ZLIB_LIBRARY = "/usr/lib/aarch64-linux-gnu/libz.so"
+
+# Explicit openssl paths
+OPENSSL_ROOT_DIR = "/usr"
+OPENSSL_INCLUDE_DIR = "/usr/include"
+OPENSSL_CRYPTO_LIBRARY = "/usr/lib/aarch64-linux-gnu/libcrypto.so"
+OPENSSL_SSL_LIBRARY = "/usr/lib/aarch64-linux-gnu/libssl.so"
+
+# Debug
+RUST_BACKTRACE = "1"
+CROSS_NO_WARNINGS = "0"

--- a/Cross.toml
+++ b/Cross.toml
@@ -4,7 +4,7 @@ pre-build = [
     "dpkg --add-architecture arm64",
     "apt-get update || true",
     "apt-get install -y pkg-config:arm64 zlib1g-dev:arm64 libssl-dev:arm64 libsasl2-dev:arm64 libzstd-dev:arm64 liblz4-dev:arm64 || true",
-    # debug: confirm zlib and headers exist
+    # debug to confirm libs/headers are present
     "ls -R /usr/lib/aarch64-linux-gnu || true",
     "ls -R /usr/include/aarch64-linux-gnu || true",
 ]
@@ -15,8 +15,7 @@ passthrough = [
     "PKG_CONFIG_ALLOW_CROSS",
     "CROSS_NO_WARNINGS",
     "RUST_BACKTRACE",
-    # Zlib hints for CMake
-    "ZLIB_ROOT",
+    # Explicit Zlib hints (used by CMake FindZLIB)
     "ZLIB_INCLUDE_DIR",
     "ZLIB_LIBRARY",
     # OpenSSL hints
@@ -32,4 +31,4 @@ volumes = [
 ]
 
 [target.x86_64-unknown-linux-gnu]
-image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu@sha256:bf05360bb9d6d4947eed60532ac7a0d7e8fae8f214e9abb801d5941c8fe4918d"
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu@sha256:bf05360bb9d6d4947eed60532ac7a0d7e8fae8f214e9abb801d5941c8fe491

--- a/Cross.toml
+++ b/Cross.toml
@@ -4,6 +4,9 @@ pre-build = [
     "dpkg --add-architecture arm64",
     "apt-get update || true",
     "apt-get install -y pkg-config:arm64 zlib1g-dev:arm64 libssl-dev:arm64 libsasl2-dev:arm64 libzstd-dev:arm64 liblz4-dev:arm64 || true",
+    # debug: confirm zlib and headers exist
+    "ls -R /usr/lib/aarch64-linux-gnu || true",
+    "ls -R /usr/include/aarch64-linux-gnu || true",
 ]
 
 [target.aarch64-unknown-linux-gnu.env]
@@ -12,8 +15,11 @@ passthrough = [
     "PKG_CONFIG_ALLOW_CROSS",
     "CROSS_NO_WARNINGS",
     "RUST_BACKTRACE",
+    # Zlib hints for CMake
+    "ZLIB_ROOT",
     "ZLIB_INCLUDE_DIR",
     "ZLIB_LIBRARY",
+    # OpenSSL hints
     "OPENSSL_ROOT_DIR",
     "OPENSSL_INCLUDE_DIR",
     "OPENSSL_CRYPTO_LIBRARY",

--- a/Cross.toml
+++ b/Cross.toml
@@ -21,22 +21,23 @@ pre-build = [
     "ln -sf /usr/lib/aarch64-linux-gnu/libcrypto.a /usr/aarch64-linux-gnu/lib/",
     "cp -r /usr/include/openssl /usr/aarch64-linux-gnu/include/",
     
+    # Symlink SASL2
     "ln -sf /usr/lib/aarch64-linux-gnu/libsasl2.so.2 /usr/aarch64-linux-gnu/lib/libsasl2.so",
     "ln -sf /usr/lib/aarch64-linux-gnu/libsasl2.so.2 /usr/aarch64-linux-gnu/lib/libsasl2.so.2",
-    "ln -sf /usr/lib/aarch64-linux-gnu/libsasl2.a /usr/aarch64-linux-gnu/lib/ || true",
     "cp -r /usr/include/sasl /usr/aarch64-linux-gnu/include/",
-    
-    # Debug
-    "echo '=== VERIFY CROSS SYSROOT ==='",
-    "ls -la /usr/aarch64-linux-gnu/lib/",
-    "ls -la /usr/aarch64-linux-gnu/include/",
 ]
 
 [target.aarch64-unknown-linux-gnu.env]
 PKG_CONFIG_PATH = "/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/share/pkgconfig"
-PKG_CONFIG_SYSROOT_DIR = "/usr/aarch64-linux-gnu"
+PKG_CONFIG_SYSROOT_DIR = "/"
 PKG_CONFIG_ALLOW_CROSS = "1"
 LIBRDKAFKA_SSL_VENDORED = "1"
 
-# Tell sasl2-sys to use system library, not build from source
-SASL2_STATIC = "0"
+# Force sasl2-sys to use system library via pkg-config
+SASL2_SYS_USE_PKG_CONFIG = "1"
+
+# Set cross-compiler for any C builds
+CC_aarch64_unknown_linux_gnu = "aarch64-linux-gnu-gcc"
+CXX_aarch64_unknown_linux_gnu = "aarch64-linux-gnu-g++"
+AR_aarch64_unknown_linux_gnu = "aarch64-linux-gnu-ar"
+CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER = "aarch64-linux-gnu-gcc"

--- a/Cross.toml
+++ b/Cross.toml
@@ -3,18 +3,24 @@ image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu@sha256:1e2a0291f92a4372cbc22
 pre-build = [
     "dpkg --add-architecture arm64",
     "apt-get update || true",
-    "apt-get install -y pkg-config:arm64 || true",
-    "apt-get install -y zlib1g-dev:arm64 || true",
-    "apt-get install -y libssl-dev:arm64 || true",
-    "apt-get install -y libsasl2-dev:arm64 || true",
-    "apt-get install -y libzstd-dev:arm64 || true",
-    "apt-get install -y liblz4-dev:arm64 || true",
+    "apt-get install -y pkg-config:arm64 zlib1g-dev:arm64 libssl-dev:arm64 libsasl2-dev:arm64 libzstd-dev:arm64 liblz4-dev:arm64 || true",
 ]
 
 [target.aarch64-unknown-linux-gnu.env]
 passthrough = [
     "LIBRDKAFKA_SSL_VENDORED",
     "PKG_CONFIG_ALLOW_CROSS",
+    "ZLIB_INCLUDE_DIR",
+    "ZLIB_LIBRARY",
+    "OPENSSL_DIR",
+    "OPENSSL_LIB_DIR",
+    "OPENSSL_INCLUDE_DIR",
+    "CROSS_NO_WARNINGS",
+    "RUST_BACKTRACE",
+]
+volumes = [
+    "/usr/lib/aarch64-linux-gnu:/usr/lib/aarch64-linux-gnu:ro",
+    "/usr/include/aarch64-linux-gnu:/usr/include/aarch64-linux-gnu:ro",
 ]
 
 [target.x86_64-unknown-linux-gnu]

--- a/Cross.toml
+++ b/Cross.toml
@@ -6,30 +6,37 @@ pre-build = [
     "apt-get install -y pkg-config:arm64 libc6-dev:arm64",
     "apt-get install -y zlib1g-dev:arm64 libssl-dev:arm64 libsasl2-dev:arm64",
     
-    # The cross toolchain restricts cmake to search in /usr/aarch64-linux-gnu
-    # But multiarch installs to /usr/lib/aarch64-linux-gnu
-    # Create the expected directory structure with symlinks
+    # Create cross sysroot directories
     "mkdir -p /usr/aarch64-linux-gnu/lib /usr/aarch64-linux-gnu/include",
     
-    # Symlink zlib files to where cmake will find them
+    # Symlink zlib
     "ln -sf /usr/lib/aarch64-linux-gnu/libz.so /usr/aarch64-linux-gnu/lib/",
     "ln -sf /usr/lib/aarch64-linux-gnu/libz.a /usr/aarch64-linux-gnu/lib/",
     "cp /usr/include/zlib.h /usr/include/zconf.h /usr/aarch64-linux-gnu/include/",
     
-    # Symlink SSL files
+    # Symlink SSL
     "ln -sf /usr/lib/aarch64-linux-gnu/libssl.so.1.1 /usr/aarch64-linux-gnu/lib/libssl.so",
     "ln -sf /usr/lib/aarch64-linux-gnu/libcrypto.so.1.1 /usr/aarch64-linux-gnu/lib/libcrypto.so",
     "ln -sf /usr/lib/aarch64-linux-gnu/libssl.a /usr/aarch64-linux-gnu/lib/",
     "ln -sf /usr/lib/aarch64-linux-gnu/libcrypto.a /usr/aarch64-linux-gnu/lib/",
     "cp -r /usr/include/openssl /usr/aarch64-linux-gnu/include/",
     
-    # Debug - verify files are in place
-    "echo '=== ZLIB CHECK ==='",
-    "ls -la /usr/aarch64-linux-gnu/lib/libz*",
-    "ls -la /usr/aarch64-linux-gnu/include/zlib.h",
+    "ln -sf /usr/lib/aarch64-linux-gnu/libsasl2.so.2 /usr/aarch64-linux-gnu/lib/libsasl2.so",
+    "ln -sf /usr/lib/aarch64-linux-gnu/libsasl2.so.2 /usr/aarch64-linux-gnu/lib/libsasl2.so.2",
+    "ln -sf /usr/lib/aarch64-linux-gnu/libsasl2.a /usr/aarch64-linux-gnu/lib/ || true",
+    "cp -r /usr/include/sasl /usr/aarch64-linux-gnu/include/",
+    
+    # Debug
+    "echo '=== VERIFY CROSS SYSROOT ==='",
+    "ls -la /usr/aarch64-linux-gnu/lib/",
+    "ls -la /usr/aarch64-linux-gnu/include/",
 ]
 
 [target.aarch64-unknown-linux-gnu.env]
 PKG_CONFIG_PATH = "/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/share/pkgconfig"
+PKG_CONFIG_SYSROOT_DIR = "/usr/aarch64-linux-gnu"
 PKG_CONFIG_ALLOW_CROSS = "1"
 LIBRDKAFKA_SSL_VENDORED = "1"
+
+# Tell sasl2-sys to use system library, not build from source
+SASL2_STATIC = "0"

--- a/Cross.toml
+++ b/Cross.toml
@@ -10,13 +10,15 @@ pre-build = [
 passthrough = [
     "LIBRDKAFKA_SSL_VENDORED",
     "PKG_CONFIG_ALLOW_CROSS",
-    "ZLIB_INCLUDE_DIR",
-    "ZLIB_LIBRARY",
-    "OPENSSL_DIR",
-    "OPENSSL_LIB_DIR",
-    "OPENSSL_INCLUDE_DIR",
     "CROSS_NO_WARNINGS",
     "RUST_BACKTRACE",
+    "ZLIB_INCLUDE_DIR",
+    "ZLIB_LIBRARY",
+    "OPENSSL_ROOT_DIR",
+    "OPENSSL_INCLUDE_DIR",
+    "OPENSSL_CRYPTO_LIBRARY",
+    "OPENSSL_SSL_LIBRARY",
+    "PKG_CONFIG_PATH",
 ]
 volumes = [
     "/usr/lib/aarch64-linux-gnu:/usr/lib/aarch64-linux-gnu:ro",

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,50 +1,20 @@
 [target.aarch64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu@sha256:1e2a0291f92a4372cbc22d8994e735473045383f1ce7fa44a16c234ba00187f4"
 pre-build = [
-    # Add multiarch support
     "dpkg --add-architecture arm64",
     "apt-get update",
-    
-    # Install base dev packages FIRST (creates pkgconfig dir structure)
     "apt-get install -y pkg-config:arm64 libc6-dev:arm64",
-    
-    # Install zlib and other deps
-    "apt-get install -y zlib1g-dev:arm64 libssl-dev:arm64 libsasl2-dev:arm64 libzstd-dev:arm64 liblz4-dev:arm64",
-    
-    # Verify pkg-config finds zlib
-    "pkg-config --cflags --libs --exists zlib || (echo 'ZLIB PC FAILED'; exit 1)",
-    
-    # Fix library paths (ensure symlinks)
-    "ln -sf /usr/lib/aarch64-linux-gnu/libz.so.1 /usr/lib/aarch64-linux-gnu/libz.so",
+    "apt-get install -y libssl-dev:arm64 libsasl2-dev:arm64",
     "ln -sf /usr/lib/aarch64-linux-gnu/libssl.so.1.1 /usr/lib/aarch64-linux-gnu/libssl.so",
     "ln -sf /usr/lib/aarch64-linux-gnu/libcrypto.so.1.1 /usr/lib/aarch64-linux-gnu/libcrypto.so",
-    
-    # Debug verification
-    "echo '=== ZLIB DEBUG ==='",
-    "dpkg -l '*zlib*' | grep '^ii'",
-    "find /usr -name 'zlib.pc' 2>/dev/null || echo 'NO zlib.pc'",
-    "pkg-config --cflags --libs zlib",
-    "ls -la /usr/lib/aarch64-linux-gnu/libz*",
-    "echo '=== PATHS ==='",
-    "ls -la /usr/lib/aarch64-linux-gnu/pkgconfig/ 2>/dev/null || echo 'NO PKGCONFIG DIR'",
 ]
 
 [target.aarch64-unknown-linux-gnu.env]
-# Force pkg-config to cross paths
+LIBZ_SYS_STATIC = "1"
 PKG_CONFIG_PATH = "/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/share/pkgconfig"
 PKG_CONFIG_ALLOW_CROSS = "1"
 LIBRDKAFKA_SSL_VENDORED = "1"
-
-# Explicit zlib paths for cmake
-ZLIB_INCLUDE_DIR = "/usr/include"
-ZLIB_LIBRARY = "/usr/lib/aarch64-linux-gnu/libz.so"
-
-# Explicit openssl paths
 OPENSSL_ROOT_DIR = "/usr"
 OPENSSL_INCLUDE_DIR = "/usr/include"
 OPENSSL_CRYPTO_LIBRARY = "/usr/lib/aarch64-linux-gnu/libcrypto.so"
 OPENSSL_SSL_LIBRARY = "/usr/lib/aarch64-linux-gnu/libssl.so"
-
-# Debug
-RUST_BACKTRACE = "1"
-CROSS_NO_WARNINGS = "0"

--- a/src/catalog/manifest.rs
+++ b/src/catalog/manifest.rs
@@ -19,7 +19,10 @@
 use std::collections::HashMap;
 
 use itertools::Itertools;
-use parquet::{file::reader::FileReader, format::SortingColumn};
+use parquet::file::{
+    metadata::{RowGroupMetaData, SortingColumn},
+    reader::FileReader,
+};
 
 use crate::metastore::metastore_traits::MetastoreObject;
 
@@ -170,9 +173,7 @@ fn sort_order(
     sort_orders
 }
 
-fn column_statistics(
-    row_groups: &[parquet::file::metadata::RowGroupMetaData],
-) -> HashMap<String, Column> {
+fn column_statistics(row_groups: &[RowGroupMetaData]) -> HashMap<String, Column> {
     let mut columns: HashMap<String, Column> = HashMap::new();
     for row_group in row_groups {
         for col in row_group.columns() {

--- a/src/parseable/staging/reader.rs
+++ b/src/parseable/staging/reader.rs
@@ -342,7 +342,8 @@ mod tests {
         types::Int64Type,
     };
     use arrow_ipc::writer::{
-        DictionaryTracker, IpcDataGenerator, IpcWriteOptions, StreamWriter, write_message,
+        CompressionContext, DictionaryTracker, IpcDataGenerator, IpcWriteOptions, StreamWriter,
+        write_message,
     };
     use arrow_schema::{DataType, Field, Schema};
     use chrono::Utc;
@@ -433,6 +434,7 @@ mod tests {
         let options = IpcWriteOptions::default();
         let mut dictionary_tracker = DictionaryTracker::new(error_on_replacement);
         let data_gen = IpcDataGenerator {};
+        let mut compression_context = CompressionContext::default();
 
         let mut buf = Vec::new();
         let rb1 = rb(1);
@@ -446,7 +448,12 @@ mod tests {
 
         for i in (1..=3).cycle().skip(1).take(10000) {
             let (_, encoded_message) = data_gen
-                .encoded_batch(&rb(i), &mut dictionary_tracker, &options)
+                .encode(
+                    &rb(i),
+                    &mut dictionary_tracker,
+                    &options,
+                    &mut compression_context,
+                )
                 .unwrap();
             write_message(&mut buf, encoded_message, &options).unwrap();
         }

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -35,10 +35,9 @@ use parquet::{
     arrow::ArrowWriter,
     basic::Encoding,
     file::{
-        FOOTER_SIZE, properties::WriterProperties, reader::FileReader,
+        FOOTER_SIZE, metadata::SortingColumn, properties::WriterProperties, reader::FileReader,
         serialized_reader::SerializedFileReader,
     },
-    format::SortingColumn,
     schema::types::ColumnPath,
 };
 use relative_path::RelativePathBuf;

--- a/src/storage/localfs.rs
+++ b/src/storage/localfs.rs
@@ -143,7 +143,7 @@ impl ObjectStorage for LocalFS {
                         .modified()
                         .map_err(ObjectStorageError::IoError)?
                         .into(),
-                    size: metadata.len() as usize,
+                    size: metadata.len(),
                     e_tag: None,
                     version: None,
                 };

--- a/src/storage/object_storage.rs
+++ b/src/storage/object_storage.rs
@@ -223,7 +223,7 @@ async fn validate_uploaded_parquet_file(
         .await
     {
         Ok(metadata) => {
-            if metadata.size as u64 != expected_size {
+            if metadata.size != expected_size {
                 warn!(
                     "Uploaded file size mismatch for stream {}: expected {}, got {}",
                     stream_name, expected_size, metadata.size

--- a/src/utils/arrow/flight.rs
+++ b/src/utils/arrow/flight.rs
@@ -28,6 +28,7 @@ use arrow_flight::encode::FlightDataEncoderBuilder;
 use arrow_flight::{FlightData, Ticket};
 use arrow_ipc::writer::IpcWriteOptions;
 use arrow_select::concat::concat_batches;
+use datafusion::common::Spans;
 use datafusion::logical_expr::BinaryExpr;
 use datafusion::prelude::Expr;
 use datafusion::scalar::ScalarValue;
@@ -119,6 +120,7 @@ pub fn send_to_ingester(start: i64, end: i64) -> bool {
     let expr_left = Expr::Column(datafusion::common::Column {
         relation: None,
         name: "p_timestamp".to_owned(),
+        spans: Spans::new(),
     });
 
     let ex1 = BinaryExpr::new(
@@ -138,7 +140,7 @@ pub fn send_to_ingester(start: i64, end: i64) -> bool {
 }
 
 fn lit_timestamp_milli(time: i64) -> Expr {
-    Expr::Literal(ScalarValue::TimestampMillisecond(Some(time), None))
+    Expr::Literal(ScalarValue::TimestampMillisecond(Some(time), None), None)
 }
 
 pub fn into_flight_data(records: Vec<RecordBatch>) -> Result<Response<DoGetStream>, Box<Status>> {


### PR DESCRIPTION
Upgrade df version to 50.3.0 and arrow/parquet to 57.0.0

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Arrow/DataFusion/Parquet ecosystem, object-store, tonic/reqwest/regex and related crates; CI now supports cross/native aarch64 builds and uses the nightly toolchain.

* **Refactor**
  * Modernized file-scan/source construction to a builder-based model with projection, limits, file-grouping and predicate support; updated plan assembly and literal shapes.

* **Bug Fixes**
  * Corrected legacy timestamp handling and updated tests for compression-context and new literal representations.

* **Breaking Changes**
  * Object metadata size type, several object-store method signatures, and IPC writer encode signature changed; client updates may be required.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->