### PR TITLE
optimize performance of ingest path

### DIFF
--- a/src/connectors/kafka/processor.rs
+++ b/src/connectors/kafka/processor.rs
@@ -103,7 +103,7 @@ impl Processor<Vec<ConsumerRecord>, ()> for ParseableSinkProcessor {
         let len = records.len();
         debug!("Processing {len} records");
 
-        self.build_event_from_chunk(&records).await?.process()?;
+        self.build_event_from_chunk(&records).await?.process().await?;
 
         debug!("Processed {len} records");
         Ok(())

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -56,7 +56,7 @@ pub struct Event {
 
 // Events holds the schema related to a each event for a single log stream
 impl Event {
-    pub fn process(self) -> Result<(), EventError> {
+    pub async fn process(self) -> Result<(), EventError> {
         let mut key = get_schema_key(&self.rb.schema().fields);
         if self.time_partition.is_some() {
             let parsed_timestamp_to_min = self.parsed_timestamp.format("%Y%m%dT%H%M").to_string();
@@ -73,13 +73,14 @@ impl Event {
             commit_schema(&self.stream_name, self.rb.schema())?;
         }
 
+        // Await async push - memtable push is awaited, disk write is fire-and-forget
         PARSEABLE.get_or_create_stream(&self.stream_name).push(
             &key,
             &self.rb,
             self.parsed_timestamp,
             &self.custom_partition_values,
             self.stream_type,
-        )?;
+        ).await?;
 
         update_stats(
             &self.stream_name,
@@ -99,16 +100,17 @@ impl Event {
         Ok(())
     }
 
-    pub fn process_unchecked(&self) -> Result<(), EventError> {
+    pub async fn process_unchecked(&self) -> Result<(), EventError> {
         let key = get_schema_key(&self.rb.schema().fields);
 
+        // Await async push
         PARSEABLE.get_or_create_stream(&self.stream_name).push(
             &key,
             &self.rb,
             self.parsed_timestamp,
             &self.custom_partition_values,
             self.stream_type,
-        )?;
+        ).await?;
 
         Ok(())
     }

--- a/src/handlers/http/ingest.rs
+++ b/src/handlers/http/ingest.rs
@@ -150,7 +150,7 @@ pub async fn ingest_internal_stream(stream_name: String, body: Bytes) -> Result<
             StreamType::Internal,
             &p_custom_fields,
         )?
-        .process()?;
+        .process().await?;
 
     Ok(())
 }
@@ -416,7 +416,7 @@ pub async fn push_logs_unchecked(
         custom_partition_values: HashMap::new(), // should be an empty map for unchecked push
         stream_type: StreamType::UserDefined,
     };
-    unchecked_event.process_unchecked()?;
+    unchecked_event.process_unchecked().await?;
 
     Ok(unchecked_event)
 }

--- a/src/handlers/http/modal/utils/ingest_utils.rs
+++ b/src/handlers/http/modal/utils/ingest_utils.rs
@@ -170,7 +170,7 @@ pub async fn push_logs(
                 StreamType::UserDefined,
                 p_custom_fields,
             )?
-            .process()?;
+            .process().await?;
     }
     Ok(())
 }

--- a/src/storage/field_stats.rs
+++ b/src/storage/field_stats.rs
@@ -162,7 +162,7 @@ pub async fn calculate_field_stats(
             StreamType::Internal,
             &p_custom_fields,
         )?
-        .process()?;
+        .process().await?;
     }
     Ok(stats_calculated)
 }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #452

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description
Blocking I/O moved to the tokio spawn_blocking so it would not block the worker thread and move away the mem write from write path 
<!-- Describe the goal of this PR -->
To improve performance of ingest flow
<!-- Describe the possible solutions and chosen one with the rationale. -->
May be other possible solutions can be various we can discuss like may be introduce a  different lock for memtable and disk so we would have minimum contention, or introduce a channel so rather than writting directly to disk first push to channel and consumer would consume and write it to disk.
But here in this change we just move both write to memtable and disk to spawn_blocking so worker thread would not be blocked, and take memtable write from core ingest path. 
Note - for now not changed anything in memtable concats, need explore that more
<!-- Describe key changes made in the patch. -->
  Major change is in `src/parseable/streams.rs` all other changes are just to support it, now disk write and memtable write are moved to tokio::spawn_blocking and we are waiting for write on memtable anymore. 
<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Event processing and stream push flows converted to async so processing yields correctly; disk persistence is awaited for durability while in-memory updates run in background tasks.
  * Internal call sites updated to await new async flows.

* **Tests**
  * I/O and push-related tests updated to match async behavior.

* **Chores**
  * Public method signatures changed to async—callers may need to update call sites to await these methods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->