### PR TITLE
chore: build and release updates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -136,3 +136,57 @@ jobs:
           CXX: g++-11
           LIBRDKAFKA_SSL_VENDORED: "1"
         run: cargo build --target x86_64-unknown-linux-gnu --features kafka --release
+
+  # Kafka build for aarch64 macOS
+  build-kafka-mac:
+    name: Build Kafka aarch64-apple-darwin
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install macOS dependencies
+        run: |
+          brew install \
+            llvm \
+            pkg-config \
+            zstd \
+            lz4 \
+            openssl@3.0 \
+            cyrus-sasl \
+            python3
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: aarch64-apple-darwin
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-aarch64-apple-darwin-kafka-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Find and fix librdkafka CMakeLists.txt
+        run: |
+          cargo fetch
+          RDKAFKA_SYS_DIR=$(find ~/.cargo/registry/src -name "rdkafka-sys-*" -type d | head -n 1)
+          echo "Found rdkafka-sys at: $RDKAFKA_SYS_DIR"
+          CMAKE_FILE="$RDKAFKA_SYS_DIR/librdkafka/CMakeLists.txt"
+          if [ -f "$CMAKE_FILE" ]; then
+            echo "Found CMakeLists.txt at: $CMAKE_FILE"
+            cp "$CMAKE_FILE" "$CMAKE_FILE.bak"
+            sed -i '' 's/cmake_minimum_required(VERSION 3.2)/cmake_minimum_required(VERSION 3.5)/' "$CMAKE_FILE"
+            echo "Modified CMakeLists.txt - before and after comparison:"
+            diff "$CMAKE_FILE.bak" "$CMAKE_FILE" || true
+          else
+            echo "Could not find librdkafka CMakeLists.txt file!"
+            exit 1
+          fi
+
+      - name: Build with Kafka
+        env:
+          LIBRDKAFKA_SSL_VENDORED: "1"
+        run: cargo build --target aarch64-apple-darwin --features kafka --release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           - aarch64-unknown-linux-gnu # linux(arm)
           - x86_64-unknown-linux-gnu # linux(64 bit)
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -78,7 +78,7 @@ jobs:
       attestations: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Install latest rust toolchain
         uses: actions-rs/toolchain@v1
@@ -128,7 +128,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Install latest rust toolchain
         uses: actions-rs/toolchain@v1
@@ -176,7 +176,7 @@ jobs:
       contents: write
       attestations: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install Linux dependencies
         run: |
@@ -255,7 +255,7 @@ jobs:
       attestations: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Install macOS dependencies
         run: |


### PR DESCRIPTION
1. remove default build for x86_64 apple
2. remove aarch64 kafka build for linux
3. add x86_64 kafka binary for linux
4. add aarch64 kafka binary for apple
5. remove default binary for x86_64 apple



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated Kafka CI into two targeted builds: Linux x86_64 and macOS aarch64 (Apple Silicon).
  * Simplified cross-build logic and dependency setup, reducing platform-specific branching.
  * Added dedicated Kafka-enabled release artifacts and integrated Kafka builds into the checksum/release flow for more reliable publishing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->