### PR TITLE
Fix for otel-metrics JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,7 +555,7 @@ dependencies = [
  "futures",
  "prost 0.14.1",
  "prost-types",
- "tonic 0.14.2",
+ "tonic",
  "tonic-prost",
 ]
 
@@ -1230,6 +1230,18 @@ dependencies = [
  "strum",
  "strum_macros",
  "unicode-width",
+]
+
+[[package]]
+name = "const-hex"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "proptest",
+ "serde_core",
 ]
 
 [[package]]
@@ -3612,9 +3624,8 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
+version = "0.31.0"
+source = "git+https://github.com/parmesant/opentelemetry-rust/?branch=fix-metrics-u64-serialization#45fb828769e6ade96d56ca1f5fa14cf0986a5341"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3626,24 +3637,24 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
+version = "0.31.0"
+source = "git+https://github.com/parmesant/opentelemetry-rust/?branch=fix-metrics-u64-serialization#45fb828769e6ade96d56ca1f5fa14cf0986a5341"
 dependencies = [
  "base64 0.22.1",
- "hex",
+ "const-hex",
  "opentelemetry",
  "opentelemetry_sdk",
- "prost 0.13.4",
+ "prost 0.14.1",
  "serde",
- "tonic 0.13.1",
+ "serde_json",
+ "tonic",
+ "tonic-prost",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
+version = "0.31.0"
+source = "git+https://github.com/parmesant/opentelemetry-rust/?branch=fix-metrics-u64-serialization#45fb828769e6ade96d56ca1f5fa14cf0986a5341"
 dependencies = [
  "futures-channel",
  "futures-executor",
@@ -3651,7 +3662,6 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "rand 0.9.1",
- "serde_json",
  "thiserror 2.0.11",
 ]
 
@@ -3829,7 +3839,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic 0.14.2",
+ "tonic",
  "tonic-prost",
  "tonic-web",
  "tower-http",
@@ -4096,6 +4106,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+dependencies = [
+ "bitflags 2.8.0",
+ "lazy_static",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4309,6 +4335,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5511,32 +5546,6 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "bytes",
- "http 1.2.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.6.0",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "prost 0.13.4",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
@@ -5576,7 +5585,7 @@ checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
 dependencies = [
  "bytes",
  "prost 0.14.1",
- "tonic 0.14.2",
+ "tonic",
 ]
 
 [[package]]
@@ -5591,7 +5600,7 @@ dependencies = [
  "http-body 1.0.1",
  "pin-project",
  "tokio-stream",
- "tonic 0.14.2",
+ "tonic",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5733,6 +5742,12 @@ dependencies = [
  "serde",
  "web-time",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3625,7 +3625,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry"
 version = "0.31.0"
-source = "git+https://github.com/parmesant/opentelemetry-rust/?branch=fix-metrics-u64-serialization#45fb828769e6ade96d56ca1f5fa14cf0986a5341"
+source = "git+https://github.com/parmesant/opentelemetry-rust/?rev=45fb828769e6ade96d56ca1f5fa14cf0986a5341#45fb828769e6ade96d56ca1f5fa14cf0986a5341"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3638,7 +3638,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry-proto"
 version = "0.31.0"
-source = "git+https://github.com/parmesant/opentelemetry-rust/?branch=fix-metrics-u64-serialization#45fb828769e6ade96d56ca1f5fa14cf0986a5341"
+source = "git+https://github.com/parmesant/opentelemetry-rust/?rev=45fb828769e6ade96d56ca1f5fa14cf0986a5341#45fb828769e6ade96d56ca1f5fa14cf0986a5341"
 dependencies = [
  "base64 0.22.1",
  "const-hex",
@@ -3654,7 +3654,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry_sdk"
 version = "0.31.0"
-source = "git+https://github.com/parmesant/opentelemetry-rust/?branch=fix-metrics-u64-serialization#45fb828769e6ade96d56ca1f5fa14cf0986a5341"
+source = "git+https://github.com/parmesant/opentelemetry-rust/?rev=45fb828769e6ade96d56ca1f5fa14cf0986a5341#45fb828769e6ade96d56ca1f5fa14cf0986a5341"
 dependencies = [
  "futures-channel",
  "futures-executor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,10 @@ build = "build.rs"
 # Arrow and DataFusion ecosystem
 arrow = "57.1.0"
 arrow-array = "57.1.0"
-arrow-flight = { version = "57.1.0", features = ["tls-aws-lc","tls-native-roots"] }
+arrow-flight = { version = "57.1.0", features = [
+    "tls-aws-lc",
+    "tls-native-roots",
+] }
 arrow-ipc = { version = "57.1.0", features = ["zstd"] }
 arrow-json = "57.1.0"
 arrow-schema = { version = "57.1.0", features = ["serde"] }
@@ -33,7 +36,13 @@ actix-web-prometheus = { version = "0.1" }
 actix-web-static-files = "4.0"
 http = "0.2.7"
 http-auth-basic = "0.3.3"
-tonic = { version = "0.14.1", features = ["tls-aws-lc", "tls-native-roots", "transport", "gzip", "zstd"] }
+tonic = { version = "0.14.1", features = [
+    "tls-aws-lc",
+    "tls-native-roots",
+    "transport",
+    "gzip",
+    "zstd",
+] }
 tonic-prost = "0.14.1"
 tonic-web = "0.14.1"
 tower-http = { version = "0.6.1", features = ["cors"] }
@@ -87,13 +96,13 @@ tokio-util = { version = "0.7" }
 # ] }
 
 # add custom branch with fix until it gets merged
-opentelemetry-proto = {git = "https://github.com/parmesant/opentelemetry-rust/", branch = "fix-metrics-u64-serialization", features = [
+opentelemetry-proto = { git = "https://github.com/parmesant/opentelemetry-rust/", rev = "45fb828769e6ade96d56ca1f5fa14cf0986a5341", features = [
     "gen-tonic",
     "with-serde",
     "logs",
     "metrics",
     "trace",
-]}
+] }
 prometheus = { version = "0.13", features = ["process"] }
 prometheus-parse = "0.2.5"
 tracing = "0.1"
@@ -142,7 +151,7 @@ reqwest = { version = "0.11.27", default-features = false, features = [
     "json",
     "gzip",
     "brotli",
-    "stream"
+    "stream",
 ] } # cannot update cause rustls is not latest `see rustls`
 semver = "1.0"
 static-files = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,14 +77,23 @@ tokio = { version = "^1.43", default-features = false, features = [
 tokio-stream = { version = "0.1", features = ["fs"] }
 tokio-util = { version = "0.7" }
 
-# Logging and Metrics
-opentelemetry-proto = { version = "0.30.0", features = [
+# # Logging and Metrics
+# opentelemetry-proto = { version = "0.30.0", features = [
+#     "gen-tonic",
+#     "with-serde",
+#     "logs",
+#     "metrics",
+#     "trace",
+# ] }
+
+# add custom branch with fix until it gets merged
+opentelemetry-proto = {git = "https://github.com/parmesant/opentelemetry-rust/", branch = "fix-metrics-u64-serialization", features = [
     "gen-tonic",
     "with-serde",
     "logs",
     "metrics",
     "trace",
-] }
+]}
 prometheus = { version = "0.13", features = ["process"] }
 prometheus-parse = "0.2.5"
 tracing = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ pub mod validator;
 
 use std::time::Duration;
 
+// Public re-exports of crates being used in enterprise
 pub use datafusion;
 pub use handlers::http::modal::{
     ParseableServer, ingest_server::IngestServer, query_server::QueryServer, server::Server,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ pub use handlers::http::modal::{
     ParseableServer, ingest_server::IngestServer, query_server::QueryServer, server::Server,
 };
 use once_cell::sync::Lazy;
+pub use opentelemetry_proto;
 use parseable::PARSEABLE;
 use reqwest::{Client, ClientBuilder};
 

--- a/src/query/stream_schema_provider.rs
+++ b/src/query/stream_schema_provider.rs
@@ -146,10 +146,7 @@ impl StandardTableProvider {
         let file_format = ParquetFormat::default().with_enable_pruning(true);
 
         // create file groups from vec file partitions
-        let file_groups = partitions
-            .into_iter()
-            .map(FileGroup::new)
-            .collect_vec();
+        let file_groups = partitions.into_iter().map(FileGroup::new).collect_vec();
 
         // parquet file source, default table parquet options
         let file_source = if let Some(phyiscal_expr) = filters {


### PR DESCRIPTION
In case of content-type JSON, metric type Summary was not getting deserialized properly due to missing fields and improper type conversion

in the otel proto package

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Made opentelemetry_proto publicly accessible in the crate API.

* **Chores**
  * Switched opentelemetry-proto dependency to a git-based source (keeps prior feature set) and adjusted dependency declarations.

* **Style**
  * Minor formatting cleanups in manifest and code (spacing, trailing commas, small refactorings).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->