### PR TITLE
new metrics endpoint

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -197,6 +197,14 @@ pub struct Options {
     )]
     pub mask_pii: bool,
 
+    #[arg(
+        long,
+        env = "P_METRICS_ENDPOINT_AUTH",
+        default_value = "true",
+        help = "Enable/Disable authentication for /v1/metrics endpoint"
+    )]
+    pub metrics_endpoint_auth: bool,
+
     // TLS/Security
     #[arg(
         long,


### PR DESCRIPTION
endpoint - /v1/metrics
controlled by env for auth - P_METRICS_ENDPOINT_AUTH default to false
if set to true, /v1/metrics work with auth


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `metrics_endpoint_auth` CLI configuration option to enable or disable metrics endpoint authentication (configurable via command-line flag or environment variable).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->