### PR TITLE
feat: Update `StateTransition` for alerts

### DIFF
--- a/src/alerts/alert_structs.rs
+++ b/src/alerts/alert_structs.rs
@@ -757,6 +757,10 @@ pub struct StateTransition {
     pub state: AlertState,
     /// Timestamp when this state was set/updated
     pub last_updated_at: DateTime<Utc>,
+    /// The previous alert state before this transition, if any
+    pub previous_alert_state: Option<AlertState>,
+    /// Duration in seconds
+    pub previous_state_duration: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -768,10 +772,23 @@ pub struct AlertStateEntry {
 
 impl StateTransition {
     /// Creates a new state transition with the current timestamp
-    pub fn new(state: AlertState) -> Self {
+    pub fn new(
+        state: AlertState,
+        previous_alert_state: Option<AlertState>,
+        previous_alert_time: Option<DateTime<Utc>>,
+    ) -> Self {
+        let now = Utc::now();
+        // calculate duration if previous alert time is provided
+        let previous_state_duration = if let Some(alert_time) = previous_alert_time {
+            Some((now - alert_time).num_seconds())
+        } else {
+            None
+        };
         Self {
             state,
-            last_updated_at: Utc::now(),
+            last_updated_at: now,
+            previous_alert_state,
+            previous_state_duration,
         }
     }
 }
@@ -781,7 +798,7 @@ impl AlertStateEntry {
     pub fn new(alert_id: Ulid, initial_state: AlertState) -> Self {
         Self {
             alert_id,
-            states: vec![StateTransition::new(initial_state)],
+            states: vec![StateTransition::new(initial_state, None, None)],
         }
     }
 
@@ -792,7 +809,11 @@ impl AlertStateEntry {
             Some(last_transition) => {
                 if last_transition.state != new_state {
                     // State changed - add new transition
-                    self.states.push(StateTransition::new(new_state));
+                    self.states.push(StateTransition::new(
+                        new_state,
+                        Some(last_transition.state),
+                        Some(last_transition.last_updated_at),
+                    ));
                     true
                 } else {
                     // If state hasn't changed, do nothing - preserve the original timestamp
@@ -801,7 +822,8 @@ impl AlertStateEntry {
             }
             None => {
                 // No previous states - add the first one
-                self.states.push(StateTransition::new(new_state));
+                self.states
+                    .push(StateTransition::new(new_state, None, None));
                 true
             }
         }

--- a/src/handlers/http/alerts.rs
+++ b/src/handlers/http/alerts.rs
@@ -44,15 +44,19 @@ const MAX_LIMIT: usize = 1000;
 const DEFAULT_LIMIT: usize = 100;
 
 /// Query parameters for listing alerts
-struct ListQueryParams {
-    tags_list: Vec<String>,
-    offset: usize,
-    limit: usize,
-    other_fields_filters: HashMap<String, String>,
+pub struct ListQueryParams {
+    /// Comma-separated tag filters; empty if no tag filtering
+    pub tags_list: Vec<String>,
+    /// Number of results to skip (default: 0)
+    pub offset: usize,
+    /// Maximum results to return (1-1000, default: 100)
+    pub limit: usize,
+    /// Additional field filters not covered by reserved params
+    pub other_fields_filters: HashMap<String, String>,
 }
 
 /// Parse and validate query parameters for listing alerts
-fn parse_list_query_params(
+pub fn parse_list_query_params(
     query_map: &HashMap<String, String>,
 ) -> Result<ListQueryParams, AlertError> {
     let mut tags_list = Vec::new();


### PR DESCRIPTION
Add `previous_alert_state` and `previous_alert_duration`. If not present at runtime, will get created using historical values

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Retain historical alert state transitions, recording the previous state and elapsed duration for each transition.
  * Expose alert list query parameters and their parser to enable external filtering, tagging and pagination controls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->