### PR TITLE
fix: create new client if token decoding fails

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ argon2 = "0.5.0"
 base64 = "0.22.0"
 cookie = "0.18.1"
 hex = "0.4"
-openid = { version = "0.15.0", default-features = false, features = ["rustls"] }
+openid = { version = "0.18.3", default-features = false, features = ["rustls"] }
 rustls = "0.22.4"
 rustls-pemfile = "2.1.2"
 sha2 = "0.10.8"

--- a/src/handlers/http/modal/mod.rs
+++ b/src/handlers/http/modal/mod.rs
@@ -117,8 +117,9 @@ pub trait ParseableServer {
             let client = config
                 .connect(&format!("{API_BASE_PATH}/{API_VERSION}/o/code"))
                 .await?;
-            OIDC_CLIENT
-                .get_or_init(|| Some(Arc::new(RwLock::new(GlobalClient::new(client.clone())))));
+            OIDC_CLIENT.get_or_init(|| Some(Arc::new(RwLock::new(GlobalClient::new(client)))));
+        } else {
+            OIDC_CLIENT.get_or_init(|| None);
         }
 
         // get the ssl stuff

--- a/src/handlers/http/modal/mod.rs
+++ b/src/handlers/http/modal/mod.rs
@@ -18,23 +18,20 @@
 
 use std::{fmt, path::Path, sync::Arc};
 
-use actix_web::{
-    App, HttpServer,
-    middleware::from_fn,
-    web::{self, ServiceConfig},
-};
+use actix_web::{App, HttpServer, middleware::from_fn, web::ServiceConfig};
 use actix_web_prometheus::PrometheusMetrics;
 use anyhow::Context;
 use async_trait::async_trait;
 use base64::{Engine, prelude::BASE64_STANDARD};
 use bytes::Bytes;
 use futures::future;
+use once_cell::sync::OnceCell;
 use openid::Discovered;
 use relative_path::RelativePathBuf;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use ssl_acceptor::get_ssl_acceptor;
-use tokio::sync::oneshot;
+use tokio::sync::{RwLock, oneshot};
 use tracing::{error, info, warn};
 
 use crate::{
@@ -43,7 +40,7 @@ use crate::{
     correlation::CORRELATIONS,
     hottier::{HotTierManager, StreamHotTier},
     metastore::metastore_traits::MetastoreObject,
-    oidc::Claims,
+    oidc::{Claims, DiscoveredClient},
     option::Mode,
     parseable::PARSEABLE,
     storage::{ObjectStorageProvider, PARSEABLE_ROOT_DIRECTORY},
@@ -62,6 +59,27 @@ pub mod ssl_acceptor;
 pub mod utils;
 
 pub type OpenIdClient = Arc<openid::Client<Discovered, Claims>>;
+
+pub static OIDC_CLIENT: OnceCell<Option<Arc<RwLock<GlobalClient>>>> = OnceCell::new();
+
+#[derive(Debug)]
+pub struct GlobalClient {
+    client: DiscoveredClient,
+}
+
+impl GlobalClient {
+    pub fn set(&mut self, client: DiscoveredClient) {
+        self.client = client;
+    }
+
+    pub fn client(&self) -> &DiscoveredClient {
+        &self.client
+    }
+
+    pub fn new(client: DiscoveredClient) -> Self {
+        Self { client }
+    }
+}
 
 // to be decided on what the Default version should be
 pub const DEFAULT_VERSION: &str = "v4";
@@ -95,16 +113,13 @@ pub trait ParseableServer {
     where
         Self: Sized,
     {
-        let oidc_client = match oidc_client {
-            Some(config) => {
-                let client = config
-                    .connect(&format!("{API_BASE_PATH}/{API_VERSION}/o/code"))
-                    .await?;
-                Some(client)
-            }
-
-            None => None,
-        };
+        if let Some(config) = oidc_client {
+            let client = config
+                .connect(&format!("{API_BASE_PATH}/{API_VERSION}/o/code"))
+                .await?;
+            OIDC_CLIENT
+                .get_or_init(|| Some(Arc::new(RwLock::new(GlobalClient::new(client.clone())))));
+        }
 
         // get the ssl stuff
         let ssl = get_ssl_acceptor(
@@ -120,7 +135,6 @@ pub trait ParseableServer {
         // fn that creates the app
         let create_app_fn = move || {
             App::new()
-                .app_data(web::Data::new(oidc_client.clone()))
                 .wrap(prometheus.clone())
                 .configure(|config| Self::configure_routes(config))
                 .wrap(from_fn(health_check::check_shutdown_middleware))


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->
In case the jwks becomes invalid, create a new oidc client with a set of fresh keys
Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated openid dependency to v0.18.3.

* **Bug Fixes**
  * Token refresh now fails gracefully and clears stale sessions on failure.
  * Login/logout flows return Unauthorized when the OIDC client cannot be resolved.
  * Improved error handling and logging for token and session errors.

* **Improvements**
  * Introduced a global OIDC client mechanism with automatic recovery on token validation failures, reducing unexpected login interruptions and improving authentication reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->