### PR TITLE
chore: disable default features in Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
  "actix-web",
  "futures-lite",
  "pin-project",
- "prometheus 0.13.4",
+ "prometheus",
  "quanta",
  "thiserror 1.0.69",
 ]
@@ -3798,7 +3798,7 @@ dependencies = [
  "opentelemetry-proto",
  "parquet",
  "path-clean",
- "prometheus 0.14.0",
+ "prometheus",
  "prometheus-parse",
  "prost 0.13.5",
  "rand 0.8.5",
@@ -4024,21 +4024,22 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.17.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
+checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
 dependencies = [
  "bitflags 2.10.0",
  "hex",
+ "lazy_static",
  "procfs-core",
  "rustix 0.38.44",
 ]
 
 [[package]]
 name = "procfs-core"
-version = "0.17.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
 dependencies = [
  "bitflags 2.10.0",
  "hex",
@@ -4053,25 +4054,11 @@ dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
- "memchr",
- "parking_lot",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "prometheus"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
-dependencies = [
- "cfg-if",
- "fnv",
- "lazy_static",
  "libc",
  "memchr",
  "parking_lot",
  "procfs",
- "thiserror 2.0.17",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ opentelemetry-proto = { git = "https://github.com/parmesant/opentelemetry-rust/"
     "metrics",
     "trace",
 ] }
-prometheus = { version = "0.14", default-features = false, features = ["process"] }
+prometheus = { version = "0.13.4", default-features = false, features = ["process"] }
 prometheus-parse = "0.2.5"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "time"] }


### PR DESCRIPTION
 disable default features for prometheus and actix-web-prometheus in Cargo.toml
this is to remove the indirect dependency of protobuf crate
to address the dependabot alert raised in enterprise -
https://github.com/parseablehq/enterprise/security/dependabot/2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Prometheus client to 0.13.4.
  * Disabled default features for Prometheus integrations and enabled the process feature to improve compatibility.
  * Disabled default features for the Actix Prometheus integration.
  * No public API or exported interface changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->