### PR TITLE
fix: bugfix for logout, oncecell for sse

### DIFF
--- a/src/alerts/mod.rs
+++ b/src/alerts/mod.rs
@@ -634,8 +634,9 @@ impl AlertConfig {
                 }),
             })
             && !broadcast_to.is_empty()
+            && let Some(handler) = SSE_HANDLER.get()
         {
-            SSE_HANDLER.broadcast(msg, Some(&broadcast_to)).await;
+            handler.broadcast(msg, Some(&broadcast_to)).await;
         }
 
         Ok(())

--- a/src/handlers/http/middleware.rs
+++ b/src/handlers/http/middleware.rs
@@ -182,14 +182,7 @@ where
 
             // if session is expired, refresh token
             if sessions().is_session_expired(&key) {
-                let oidc_client = if let Some(client) = OIDC_CLIENT.get()
-                    && let Some(client) = client
-                {
-                    let guard = client.read().await;
-                    Some(guard.client().clone())
-                } else {
-                    None
-                };
+                let oidc_client = OIDC_CLIENT.get();
 
                 if let Some(client) = oidc_client
                     && let Ok(userid) = userid
@@ -209,6 +202,9 @@ where
 
                     if let Some(oauth_data) = bearer_to_refresh {
                         let refreshed_token = match client
+                            .read()
+                            .await
+                            .client()
                             .refresh_token(&oauth_data, Some(PARSEABLE.options.scope.as_str()))
                             .await
                         {

--- a/src/handlers/http/modal/mod.rs
+++ b/src/handlers/http/modal/mod.rs
@@ -60,7 +60,7 @@ pub mod utils;
 
 pub type OpenIdClient = Arc<openid::Client<Discovered, Claims>>;
 
-pub static OIDC_CLIENT: OnceCell<Option<Arc<RwLock<GlobalClient>>>> = OnceCell::new();
+pub static OIDC_CLIENT: OnceCell<Arc<RwLock<GlobalClient>>> = OnceCell::new();
 
 #[derive(Debug)]
 pub struct GlobalClient {
@@ -117,9 +117,7 @@ pub trait ParseableServer {
             let client = config
                 .connect(&format!("{API_BASE_PATH}/{API_VERSION}/o/code"))
                 .await?;
-            OIDC_CLIENT.get_or_init(|| Some(Arc::new(RwLock::new(GlobalClient::new(client)))));
-        } else {
-            OIDC_CLIENT.get_or_init(|| None);
+            OIDC_CLIENT.get_or_init(|| Arc::new(RwLock::new(GlobalClient::new(client))));
         }
 
         // get the ssl stuff


### PR DESCRIPTION
logout flow incorrectly assumed the oidc client to always be present

shifted sse handler from lazy to oncecell

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal handling for authentication and real-time event components to reduce nesting and streamline initialization/access.
  * Consolidated initialization paths so clients and event broadcasters are instantiated deterministically when configured.
  * Preserved public behavior and APIs; no changes to external signatures or client-facing flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->