### PR TITLE
fix: custom partition validation

### DIFF
--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -1015,5 +1015,15 @@ pub fn validate_custom_partition(custom_partition: &str) -> Result<(), CreateStr
             status: StatusCode::BAD_REQUEST,
         });
     }
+
+    for partition in custom_partition_list.iter() {
+        if partition.contains('.') {
+            return Err(CreateStreamError::Custom {
+                msg: format!("custom partition field {partition} must not contain '.'"),
+                status: StatusCode::BAD_REQUEST,
+            });
+        }
+    }
+
     Ok(())
 }


### PR DESCRIPTION
add check to reject dataset creation / updation
when field name contains period (.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Partition field names are now validated to reject definitions containing dots, with a clear error message provided for invalid configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->