### PR TITLE
Change runner version to ubuntu-22.04 in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   build-linux:
     name: Build for ${{matrix.target}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # or ubuntu-24.04, ubuntu-20.04
     permissions:
       id-token: write
       contents: write
@@ -172,7 +172,7 @@ jobs:
 
   build-kafka-linux:
     name: Build Kafka for x86_64-unknown-linux-gnu
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # or ubuntu-24.04 ubuntu-20.04
     permissions:
       id-token: write
       contents: write
@@ -322,7 +322,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   create-checksum:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # or ubuntu-24.04, ubuntu-20.04
     needs: [build-linux, build-windows, build-mac, build-kafka-linux, build-kafka-mac]
     steps:
       - name: Download artifacts created


### PR DESCRIPTION
Updated the runner version for multiple jobs in the release workflow to ubuntu-22.04. 
This is need to ensure runtime dependencies like glibc are not broken at runtime when
the binary is run on a new machine.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure to use a specific Ubuntu version across multiple deployment jobs for improved consistency and reproducibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->