### PR TITLE
chore: license object

### DIFF
--- a/src/handlers/http/about.rs
+++ b/src/handlers/http/about.rs
@@ -83,16 +83,12 @@ pub async fn about() -> Json<Value> {
 
     let ms_clarity_tag = &PARSEABLE.options.ms_clarity_tag;
 
-    let license_name = "Parseable OSS";
-    let license_version = "v1";
-    let plan = "OSS";
-    let deployment_info = "Managed";
     let license_info = {
         json!({
-            "name": license_name,
-            "version": license_version,
-            "plan": plan,
-            "deploymentInfo": deployment_info,
+            "name": "AGPL-3.0-only",
+            "version": "v1",
+            "plan": "OSS",
+            "deploymentInfo": "Managed",
         })
     };
 


### PR DESCRIPTION
current: change license from string `AGPL-3.0-only` to object
```
"license": {
        "name": "AGPL-3.0-only",
        "version": "v1",
        "plan": "OSS",
        "deploymentInfo": "Managed"
    }
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The about endpoint now returns structured license information (name, version, plan, deployment type) instead of a single license string, giving clearer, more detailed license and deployment status in responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->