### PR TITLE
fix: hottier in datasets

### DIFF
--- a/src/handlers/http/logstream.rs
+++ b/src/handlers/http/logstream.rs
@@ -356,20 +356,8 @@ pub async fn get_stream_info(stream_name: Path<String>) -> Result<impl Responder
         .read()
         .expect(LOCK_EXPECT);
 
-    let stream_info = StreamInfo {
-        stream_type: stream_meta.stream_type,
-        created_at: stream_meta.created_at.clone(),
-        first_event_at: stream_first_event_at,
-        latest_event_at: stream_latest_event_at,
-        time_partition: stream_meta.time_partition.clone(),
-        time_partition_limit: stream_meta
-            .time_partition_limit
-            .map(|limit| limit.to_string()),
-        custom_partition: stream_meta.custom_partition.clone(),
-        static_schema_flag: stream_meta.static_schema_flag,
-        log_source: stream_meta.log_source.clone(),
-        telemetry_type: stream_meta.telemetry_type,
-    };
+    let stream_info =
+        StreamInfo::from_metadata(&stream_meta, stream_first_event_at, stream_latest_event_at);
 
     Ok((web::Json(stream_info), StatusCode::OK))
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -169,6 +169,32 @@ pub struct StreamInfo {
     pub log_source: Vec<LogSourceEntry>,
     #[serde(default)]
     pub telemetry_type: TelemetryType,
+    #[serde(default)]
+    pub hot_tier_enabled: bool,
+}
+
+impl StreamInfo {
+    /// Creates a StreamInfo from LogStreamMetadata
+    /// and first_event_at and latest_event_at timestamps
+    pub fn from_metadata(
+        metadata: &crate::metadata::LogStreamMetadata,
+        first_event_at: Option<String>,
+        latest_event_at: Option<String>,
+    ) -> Self {
+        StreamInfo {
+            stream_type: metadata.stream_type,
+            created_at: metadata.created_at.clone(),
+            first_event_at,
+            latest_event_at,
+            time_partition: metadata.time_partition.clone(),
+            time_partition_limit: metadata.time_partition_limit.map(|limit| limit.to_string()),
+            custom_partition: metadata.custom_partition.clone(),
+            static_schema_flag: metadata.static_schema_flag,
+            log_source: metadata.log_source.clone(),
+            telemetry_type: metadata.telemetry_type,
+            hot_tier_enabled: metadata.hot_tier_enabled,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]


### PR DESCRIPTION
add hot_tier_enabled = true/false in StreamInfo that fetches the data from stream.json 
remove redundant key `hottier` from DatasetsResponse as this info is available inside StreamInfo



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Introduced a new helper method for stream information construction from metadata
  * Removed hot tier manager integration from stream processing operations
  * Added hot tier enabled flag to stream metadata

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->