### PR TITLE
flatten json log messages inside log record body into individual fields

### DIFF
--- a/src/otel/logs.rs
+++ b/src/otel/logs.rs
@@ -100,6 +100,7 @@ pub fn flatten_log_record(log_record: &LogRecord) -> Map<String, Value> {
             // If value is a string that can be parsed as JSON object, extract its fields
             if let Value::String(s) = value
                 && let Ok(parsed) = serde_json::from_str::<Value>(s)
+                && parsed.is_object()
                 && let Ok(flattened_values) = generic_flattening(&parsed)
             {
                 for flattened_value in flattened_values {


### PR DESCRIPTION
if a log event is json, with otel-collector, log records's body will contain the entire log event 
in order to make it usable and queryable, we flatten the json into individual columns 
original body field is also pertained for backward compatibility

if log event is unstructured (not a json), it remains as-is in body field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced log processing to automatically flatten JSON objects found inside string-valued log fields into new top-level fields prefixed with the original field name.
  * The original field value is preserved; flattening only applies when the string parses as a JSON object and does not change other log behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->