### PR TITLE
fix: exclude internal streams from datasets api

### DIFF
--- a/src/prism/logstream/mod.rs
+++ b/src/prism/logstream/mod.rs
@@ -275,6 +275,16 @@ impl PrismDatasetRequest {
             return Ok(None);
         }
 
+        // exclude internal streams
+        let is_internal = PARSEABLE.get_stream(&stream).is_ok_and(|stream| {
+            stream
+                .get_stream_type()
+                .eq(&crate::storage::StreamType::Internal)
+        });
+        if is_internal {
+            return Ok(None);
+        }
+
         // Process stream data
         match get_prism_logstream_info(&stream).await {
             Ok(info) => Ok(Some(self.build_dataset_response(stream, info).await?)),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where internal streams were being incorrectly included in dataset responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->