### PR TITLE
fix: update datatype in FieldStats and QueryRow to f64

### DIFF
--- a/src/storage/field_stats.rs
+++ b/src/storage/field_stats.rs
@@ -488,18 +488,18 @@ pub struct DataSetStatsRequest {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct FieldStats {
-    field_count: i64,
-    distinct_count: i64,
-    distinct_values: IndexMap<String, i64>,
+    field_count: f64,
+    distinct_count: f64,
+    distinct_values: IndexMap<String, f64>,
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct QueryRow {
     field_name: String,
-    field_count: i64,
-    distinct_count: i64,
+    field_count: f64,
+    distinct_count: f64,
     distinct_value: String,
-    distinct_value_count: i64,
+    distinct_value_count: f64,
 }
 
 /// API handler to get the field stats for a dataset


### PR DESCRIPTION
this is required because we ingest as f64
with i64, the type casting fails



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal precision handling for statistics calculations to support more accurate data analysis.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->