### PR TITLE
replace std RwLock and Mutex with parking-lot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,6 +165,7 @@ lazy_static = "1.4.0"
 prost = "0.13.1"
 dashmap = "6.1.0"
 indexmap = { version = "2.13.0", features = ["serde"] }
+parking_lot = "0.12.5"
 
 [build-dependencies]
 cargo_toml = "0.21"

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -26,7 +26,6 @@ use std::sync::Arc;
 
 use self::error::EventError;
 use crate::{
-    LOCK_EXPECT,
     handlers::TelemetryType,
     metadata::update_stats,
     metrics::{increment_events_ingested_by_date, increment_events_ingested_size_by_date},
@@ -127,14 +126,13 @@ pub fn get_schema_key(fields: &[Arc<Field>]) -> String {
 }
 
 pub fn commit_schema(stream_name: &str, schema: Arc<Schema>) -> Result<(), StagingError> {
-    let mut stream_metadata = PARSEABLE.streams.write().expect("lock poisoned");
+    let mut stream_metadata = PARSEABLE.streams.write();
 
     let map = &mut stream_metadata
         .get_mut(stream_name)
         .ok_or_else(|| StagingError::NotFound(stream_name.to_string()))?
         .metadata
         .write()
-        .expect(LOCK_EXPECT)
         .schema;
     let current_schema = Schema::new(map.values().cloned().collect::<Fields>());
     let schema = Schema::try_merge(vec![current_schema, schema.as_ref().clone()])?;

--- a/src/handlers/http/logstream.rs
+++ b/src/handlers/http/logstream.rs
@@ -33,7 +33,7 @@ use crate::utils::actix::extract_session_key_from_req;
 use crate::utils::json::flatten::{
     self, convert_to_array, generic_flattening, has_more_than_max_allowed_levels,
 };
-use crate::{LOCK_EXPECT, stats, validator};
+use crate::{stats, validator};
 
 use actix_web::http::StatusCode;
 use actix_web::web::{Json, Path};
@@ -348,13 +348,12 @@ pub async fn get_stream_info(stream_name: Path<String>) -> Result<impl Responder
         }
     };
 
-    let hash_map = PARSEABLE.streams.read().unwrap();
+    let hash_map = PARSEABLE.streams.read();
     let stream_meta = hash_map
         .get(&stream_name)
         .ok_or_else(|| StreamNotFound(stream_name.clone()))?
         .metadata
-        .read()
-        .expect(LOCK_EXPECT);
+        .read();
 
     let stream_info =
         StreamInfo::from_metadata(&stream_meta, stream_first_event_at, stream_latest_event_at);

--- a/src/handlers/http/modal/mod.rs
+++ b/src/handlers/http/modal/mod.rs
@@ -621,7 +621,7 @@ pub async fn initialize_hot_tier_metadata_on_startup(
 ) -> anyhow::Result<()> {
     // Collect hot tier configurations from streams before doing async operations
     let hot_tier_configs: Vec<(String, StreamHotTier)> = {
-        let streams_guard = PARSEABLE.streams.read().unwrap();
+        let streams_guard = PARSEABLE.streams.read();
         streams_guard
             .iter()
             .filter_map(|(stream_name, stream)| {

--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -196,7 +196,6 @@ impl Parseable {
     pub fn get_stream(&self, stream_name: &str) -> Result<StreamRef, StreamNotFound> {
         self.streams
             .read()
-            .unwrap()
             .get(stream_name)
             .ok_or_else(|| StreamNotFound(stream_name.to_owned()))
             .cloned()

--- a/src/prism/logstream/mod.rs
+++ b/src/prism/logstream/mod.rs
@@ -26,7 +26,6 @@ use serde::{Deserialize, Serialize};
 use tracing::warn;
 
 use crate::{
-    LOCK_EXPECT,
     handlers::http::{
         cluster::{
             fetch_stats_from_ingestors,
@@ -168,13 +167,12 @@ pub async fn get_stream_info_helper(stream_name: &str) -> Result<StreamInfo, Str
         }
     };
 
-    let hash_map = PARSEABLE.streams.read().unwrap();
+    let hash_map = PARSEABLE.streams.read();
     let stream_meta = hash_map
         .get(stream_name)
         .ok_or_else(|| StreamNotFound(stream_name.to_owned()))?
         .metadata
-        .read()
-        .expect(LOCK_EXPECT);
+        .read();
 
     let stream_info =
         StreamInfo::from_metadata(&stream_meta, stream_first_event_at, stream_latest_event_at);


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Debugging the `too many open files (os error 24)` error which we got due to a network issue
The machine was running ingest server along with fluent-bit

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
