### PR TITLE
allow tags at dataset creation

### DIFF
--- a/src/connectors/kafka/processor.rs
+++ b/src/connectors/kafka/processor.rs
@@ -58,6 +58,7 @@ impl ParseableSinkProcessor {
                 None,
                 vec![log_source_entry],
                 TelemetryType::default(),
+                None,
             )
             .await?;
 

--- a/src/handlers/http/ingest.rs
+++ b/src/handlers/http/ingest.rs
@@ -118,6 +118,7 @@ pub async fn ingest(
             None,
             vec![log_source_entry.clone()],
             telemetry_type,
+            None,
         )
         .await
         .map_err(|e| {
@@ -226,6 +227,7 @@ pub async fn setup_otel_stream(
             None,
             vec![log_source_entry.clone()],
             telemetry_type,
+            None,
         )
         .await?;
     let mut time_partition = None;

--- a/src/handlers/http/modal/utils/logstream_utils.rs
+++ b/src/handlers/http/modal/utils/logstream_utils.rs
@@ -17,13 +17,14 @@
  */
 
 use actix_web::http::header::HeaderMap;
+use tracing::warn;
 
 use crate::{
     event::format::LogSource,
     handlers::{
-        CUSTOM_PARTITION_KEY, LOG_SOURCE_KEY, STATIC_SCHEMA_FLAG, STREAM_TYPE_KEY,
-        TELEMETRY_TYPE_KEY, TIME_PARTITION_KEY, TIME_PARTITION_LIMIT_KEY, TelemetryType,
-        UPDATE_STREAM_KEY,
+        CUSTOM_PARTITION_KEY, DATASET_TAG_KEY, DatasetTag, LOG_SOURCE_KEY, STATIC_SCHEMA_FLAG,
+        STREAM_TYPE_KEY, TELEMETRY_TYPE_KEY, TIME_PARTITION_KEY, TIME_PARTITION_LIMIT_KEY,
+        TelemetryType, UPDATE_STREAM_KEY,
     },
     storage::StreamType,
 };
@@ -38,6 +39,7 @@ pub struct PutStreamHeaders {
     pub stream_type: StreamType,
     pub log_source: LogSource,
     pub telemetry_type: TelemetryType,
+    pub dataset_tag: Option<DatasetTag>,
 }
 
 impl From<&HeaderMap> for PutStreamHeaders {
@@ -71,6 +73,16 @@ impl From<&HeaderMap> for PutStreamHeaders {
                 .get(TELEMETRY_TYPE_KEY)
                 .and_then(|v| v.to_str().ok())
                 .map_or(TelemetryType::Logs, TelemetryType::from),
+            dataset_tag: headers
+                .get(DATASET_TAG_KEY)
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| match DatasetTag::try_from(v) {
+                    Ok(tag) => Some(tag),
+                    Err(err) => {
+                        warn!("Invalid dataset tag '{v}': {err}");
+                        None
+                    }
+                }),
         }
     }
 }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -35,6 +35,7 @@ pub const AUTHORIZATION_KEY: &str = "authorization";
 pub const UPDATE_STREAM_KEY: &str = "x-p-update-stream";
 pub const STREAM_TYPE_KEY: &str = "x-p-stream-type";
 pub const TELEMETRY_TYPE_KEY: &str = "x-p-telemetry-type";
+pub const DATASET_TAG_KEY: &str = "x-p-dataset-tag";
 const COOKIE_AGE_DAYS: usize = 7;
 const SESSION_COOKIE_NAME: &str = "session";
 const USER_COOKIE_NAME: &str = "username";
@@ -78,6 +79,40 @@ impl Display for TelemetryType {
             TelemetryType::Metrics => "metrics",
             TelemetryType::Traces => "traces",
             TelemetryType::Events => "events",
+        })
+    }
+}
+
+/// Tag for categorizing datasets/streams by observability domain
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum DatasetTag {
+    AgentObservability,
+    K8sObservability,
+    DatabaseObservability,
+}
+
+impl TryFrom<&str> for DatasetTag {
+    type Error = &'static str;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s.to_lowercase().as_str() {
+            "agent-observability" => Ok(DatasetTag::AgentObservability),
+            "k8s-observability" => Ok(DatasetTag::K8sObservability),
+            "database-observability" => Ok(DatasetTag::DatabaseObservability),
+            _ => Err(
+                "Invalid dataset tag. Supported values: agent-observability, k8s-observability, database-observability",
+            ),
+        }
+    }
+}
+
+impl Display for DatasetTag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            DatasetTag::AgentObservability => "agent-observability",
+            DatasetTag::K8sObservability => "k8s-observability",
+            DatasetTag::DatabaseObservability => "database-observability",
         })
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 
 use crate::catalog::snapshot::ManifestItem;
 use crate::event::format::LogSourceEntry;
-use crate::handlers::TelemetryType;
+use crate::handlers::{DatasetTag, TelemetryType};
 use crate::hottier::StreamHotTier;
 use crate::metrics::{
     EVENTS_INGESTED, EVENTS_INGESTED_DATE, EVENTS_INGESTED_SIZE, EVENTS_INGESTED_SIZE_DATE,
@@ -92,6 +92,7 @@ pub struct LogStreamMetadata {
     pub stream_type: StreamType,
     pub log_source: Vec<LogSourceEntry>,
     pub telemetry_type: TelemetryType,
+    pub dataset_tag: Option<DatasetTag>,
 }
 
 impl LogStreamMetadata {
@@ -107,6 +108,7 @@ impl LogStreamMetadata {
         schema_version: SchemaVersion,
         log_source: Vec<LogSourceEntry>,
         telemetry_type: TelemetryType,
+        dataset_tag: Option<DatasetTag>,
     ) -> Self {
         LogStreamMetadata {
             created_at: if created_at.is_empty() {
@@ -131,6 +133,7 @@ impl LogStreamMetadata {
             schema_version,
             log_source,
             telemetry_type,
+            dataset_tag,
             ..Default::default()
         }
     }

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -371,6 +371,7 @@ async fn setup_logstream_metadata(
         stream_type,
         log_source,
         telemetry_type,
+        dataset_tag,
         ..
     } = serde_json::from_value(stream_metadata_value).unwrap_or_default();
 
@@ -407,6 +408,7 @@ async fn setup_logstream_metadata(
         stream_type,
         log_source,
         telemetry_type,
+        dataset_tag,
     };
 
     Ok(metadata)

--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -47,7 +47,7 @@ use crate::{
         format::{LogSource, LogSourceEntry},
     },
     handlers::{
-        STREAM_TYPE_KEY, TelemetryType,
+        DatasetTag, STREAM_TYPE_KEY, TelemetryType,
         http::{
             cluster::{
                 BILLING_METRICS_STREAM_NAME, PMETA_STREAM_NAME, sync_streams_with_ingestors,
@@ -365,6 +365,7 @@ impl Parseable {
         let schema_version = stream_metadata.schema_version;
         let log_source = stream_metadata.log_source;
         let telemetry_type = stream_metadata.telemetry_type;
+        let dataset_tag = stream_metadata.dataset_tag;
         let mut metadata = LogStreamMetadata::new(
             created_at,
             time_partition,
@@ -376,6 +377,7 @@ impl Parseable {
             schema_version,
             log_source,
             telemetry_type,
+            dataset_tag,
         );
 
         // Set hot tier fields from the stored metadata
@@ -414,6 +416,7 @@ impl Parseable {
                 None,
                 vec![log_source_entry],
                 TelemetryType::Logs,
+                None,
             )
             .await;
 
@@ -425,6 +428,7 @@ impl Parseable {
                 None,
                 vec![log_source_entry],
                 TelemetryType::Logs,
+                None,
             )
             .await;
 
@@ -476,6 +480,7 @@ impl Parseable {
         custom_partition: Option<&String>,
         log_source: Vec<LogSourceEntry>,
         telemetry_type: TelemetryType,
+        dataset_tag: Option<DatasetTag>,
     ) -> Result<bool, PostError> {
         if self.streams.contains(stream_name) {
             return Ok(true);
@@ -507,6 +512,7 @@ impl Parseable {
             stream_type,
             log_source,
             telemetry_type,
+            dataset_tag,
         )
         .await?;
 
@@ -579,6 +585,7 @@ impl Parseable {
             stream_type,
             log_source,
             telemetry_type,
+            dataset_tag,
         } = headers.into();
 
         let stream_in_memory_dont_update =
@@ -648,6 +655,7 @@ impl Parseable {
             stream_type,
             vec![log_source_entry],
             telemetry_type,
+            dataset_tag,
         )
         .await?;
 
@@ -705,6 +713,7 @@ impl Parseable {
         stream_type: StreamType,
         log_source: Vec<LogSourceEntry>,
         telemetry_type: TelemetryType,
+        dataset_tag: Option<DatasetTag>,
     ) -> Result<(), CreateStreamError> {
         // fail to proceed if invalid stream name
         if stream_type != StreamType::Internal {
@@ -728,6 +737,7 @@ impl Parseable {
             },
             log_source: log_source.clone(),
             telemetry_type,
+            dataset_tag,
             ..Default::default()
         };
 
@@ -757,6 +767,7 @@ impl Parseable {
                     SchemaVersion::V1, // New stream
                     log_source,
                     telemetry_type,
+                    dataset_tag,
                 );
                 let ingestor_id = INGESTOR_META
                     .get()

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -53,6 +53,7 @@ use crate::{
         DEFAULT_TIMESTAMP_KEY,
         format::{LogSource, LogSourceEntry},
     },
+    handlers::DatasetTag,
     hottier::StreamHotTier,
     metadata::{LogStreamMetadata, SchemaVersion},
     metrics,
@@ -946,6 +947,10 @@ impl Stream {
 
     pub fn get_log_source(&self) -> Vec<LogSourceEntry> {
         self.metadata.read().expect(LOCK_EXPECT).log_source.clone()
+    }
+
+    pub fn get_dataset_tag(&self) -> Option<DatasetTag> {
+        self.metadata.read().expect(LOCK_EXPECT).dataset_tag
     }
 
     pub fn add_log_source(&self, log_source: LogSourceEntry) {

--- a/src/storage/field_stats.rs
+++ b/src/storage/field_stats.rs
@@ -142,6 +142,7 @@ pub async fn calculate_field_stats(
             Some(&DATASET_STATS_CUSTOM_PARTITION.to_string()),
             vec![log_source_entry],
             TelemetryType::Logs,
+            None,
         )
         .await?;
     let vec_json = apply_generic_flattening_for_partition(

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -24,7 +24,7 @@ use tokio::task::JoinError;
 use crate::{
     catalog::snapshot::Snapshot,
     event::format::LogSourceEntry,
-    handlers::TelemetryType,
+    handlers::{DatasetTag, TelemetryType},
     hottier::StreamHotTier,
     metadata::SchemaVersion,
     metastore::{MetastoreErrorDetail, metastore_traits::MetastoreObject},
@@ -131,6 +131,8 @@ pub struct ObjectStoreFormat {
     pub log_source: Vec<LogSourceEntry>,
     #[serde(default)]
     pub telemetry_type: TelemetryType,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dataset_tag: Option<DatasetTag>,
 }
 
 impl MetastoreObject for ObjectStoreFormat {
@@ -171,6 +173,8 @@ pub struct StreamInfo {
     pub telemetry_type: TelemetryType,
     #[serde(default)]
     pub hot_tier_enabled: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dataset_tag: Option<DatasetTag>,
 }
 
 impl StreamInfo {
@@ -193,6 +197,7 @@ impl StreamInfo {
             log_source: metadata.log_source.clone(),
             telemetry_type: metadata.telemetry_type,
             hot_tier_enabled: metadata.hot_tier_enabled,
+            dataset_tag: metadata.dataset_tag,
         }
     }
 }
@@ -274,6 +279,7 @@ impl Default for ObjectStoreFormat {
             hot_tier: None,
             log_source: vec![LogSourceEntry::default()],
             telemetry_type: TelemetryType::Logs,
+            dataset_tag: None,
         }
     }
 }


### PR DESCRIPTION
accept header x-p-dataset-tag in dataset creation request 
supported values - agent-observability, k8s-observability, database-observability 
anything else, server will log warn and set as null

store this field in stream.json (objectstoremetadata) and logstreammetadata (in memory struct)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dataset tag support for log streams, enabling categorization by observability type (Agent Observability, K8s Observability, or Database Observability).
  * Dataset tags can be specified via HTTP headers when creating or updating streams and are persisted in stream metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->