### PR TITLE
fix: convert int and double to string in otel body

### DIFF
--- a/src/otel/otel_utils.rs
+++ b/src/otel/otel_utils.rs
@@ -81,7 +81,6 @@ fn collect_json_from_array_value(array_value: &ArrayValue) -> Value {
                 OtelValue::BoolValue(b) => json_array.push(Value::Bool(*b)),
                 OtelValue::IntValue(i) => {
                     json_array.push(Value::String(i.to_string()));
-                    json_array.push(Value::Number(serde_json::Number::from(*i)))
                 }
                 OtelValue::DoubleValue(d) => {
                     json_array.push(Value::String(d.to_string()));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Numeric telemetry values (integers and doubles), including those inside arrays, are now serialized as strings rather than as JSON numbers.
  * This change improves consistency of exported telemetry payloads and reduces parsing variability for downstream consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->