### PR TITLE
fix: middleware dos, storage metadata

### DIFF
--- a/src/handlers/http/middleware.rs
+++ b/src/handlers/http/middleware.rs
@@ -152,18 +152,21 @@ where
         For requests made from other clients, no change.
 
         ## Section start */
-        if let Some(kinesis_common_attributes) =
-            req.request().headers().get(KINESIS_COMMON_ATTRIBUTES_KEY)
+        if self.action.eq(&Action::Ingest)
+            && let Some(kinesis_common_attributes) =
+                req.request().headers().get(KINESIS_COMMON_ATTRIBUTES_KEY)
+            && let Ok(attribute_value) = kinesis_common_attributes.to_str()
+            && let Ok(message) = serde_json::from_str::<Message>(attribute_value)
+            && let Ok(auth_value) =
+                header::HeaderValue::from_str(&message.common_attributes.authorization)
+            && let Ok(stream_name_key) =
+                header::HeaderValue::from_str(&message.common_attributes.x_p_stream)
         {
-            let attribute_value: &str = kinesis_common_attributes.to_str().unwrap();
-            let message: Message = serde_json::from_str(attribute_value).unwrap();
-            req.headers_mut().insert(
-                HeaderName::from_static(AUTHORIZATION_KEY),
-                header::HeaderValue::from_str(&message.common_attributes.authorization).unwrap(),
-            );
+            req.headers_mut()
+                .insert(HeaderName::from_static(AUTHORIZATION_KEY), auth_value);
             req.headers_mut().insert(
                 HeaderName::from_static(STREAM_NAME_HEADER_KEY),
-                header::HeaderValue::from_str(&message.common_attributes.x_p_stream).unwrap(),
+                stream_name_key,
             );
             req.headers_mut().insert(
                 HeaderName::from_static(LOG_SOURCE_KEY),

--- a/src/storage/store_metadata.rs
+++ b/src/storage/store_metadata.rs
@@ -43,7 +43,7 @@ use super::PARSEABLE_METADATA_FILE_NAME;
 
 // Expose some static variables for internal usage
 pub static STORAGE_METADATA: OnceCell<StaticStorageMetadata> = OnceCell::new();
-pub const CURRENT_STORAGE_METADATA_VERSION: &str = "v6";
+pub const CURRENT_STORAGE_METADATA_VERSION: &str = "v8";
 // For use in global static
 #[derive(Debug, PartialEq, Eq)]
 pub struct StaticStorageMetadata {


### PR DESCRIPTION
removed usage of unwraps in middleware to prevent unauthenticated dos

bumped the default  storage metadata version to v8

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated request header processing to improve validation, reduce error paths, and ensure more reliable upstream ingestion behavior.

* **Chores**
  * Bumped internal storage metadata version to v8 to align persisted metadata with the latest system expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->