### PR TITLE
Add OpenTelemetry instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3332,6 +3332,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mutually_exclusive_features"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94e1e6445d314f972ff7395df2de295fe51b71821694f0b0e1e79c4f12c8577"
+
+[[package]]
 name = "ntapi"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3562,6 +3568,20 @@ dependencies = [
 [[package]]
 name = "opentelemetry"
 version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.31.0"
 source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=b096b70b2ffe9beb65a716cf47d5e5db80a9e930#b096b70b2ffe9beb65a716cf47d5e5db80a9e930"
 dependencies = [
  "futures-core",
@@ -3573,18 +3593,85 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-http"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.0",
+ "opentelemetry 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+dependencies = [
+ "http 1.4.0",
+ "opentelemetry 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opentelemetry-http",
+ "opentelemetry-proto 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opentelemetry_sdk 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.14.1",
+ "reqwest",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "base64",
+ "const-hex",
+ "opentelemetry 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opentelemetry_sdk 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.14.1",
+ "serde",
+ "serde_json",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
 name = "opentelemetry-proto"
 version = "0.31.0"
 source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=b096b70b2ffe9beb65a716cf47d5e5db80a9e930#b096b70b2ffe9beb65a716cf47d5e5db80a9e930"
 dependencies = [
  "base64",
  "const-hex",
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.31.0 (git+https://github.com/open-telemetry/opentelemetry-rust/?rev=b096b70b2ffe9beb65a716cf47d5e5db80a9e930)",
+ "opentelemetry_sdk 0.31.0 (git+https://github.com/open-telemetry/opentelemetry-rust/?rev=b096b70b2ffe9beb65a716cf47d5e5db80a9e930)",
  "prost 0.14.1",
  "serde",
  "tonic",
  "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding",
+ "rand 0.9.2",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -3595,7 +3682,7 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry",
+ "opentelemetry 0.31.0 (git+https://github.com/open-telemetry/opentelemetry-rust/?rev=b096b70b2ffe9beb65a716cf47d5e5db80a9e930)",
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.2",
@@ -3739,7 +3826,10 @@ dependencies = [
  "object_store",
  "once_cell",
  "openid",
- "opentelemetry-proto",
+ "opentelemetry 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opentelemetry-otlp",
+ "opentelemetry-proto 0.31.0 (git+https://github.com/open-telemetry/opentelemetry-rust/?rev=b096b70b2ffe9beb65a716cf47d5e5db80a9e930)",
+ "opentelemetry_sdk 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot",
  "parquet",
  "path-clean",
@@ -3775,6 +3865,8 @@ dependencies = [
  "tonic-web",
  "tower-http",
  "tracing",
+ "tracing-actix-web",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "ulid",
  "uptime_lib",
@@ -4412,6 +4504,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.12",
@@ -5506,6 +5599,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-actix-web"
+version = "0.7.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca6b15407f9bfcb35f82d0e79e603e1629ece4e91cc6d9e58f890c184dd20af"
+dependencies = [
+ "actix-web",
+ "mutually_exclusive_features",
+ "pin-project",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5535,6 +5641,22 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+dependencies = [
+ "js-sys",
+ "opentelemetry 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,6 +166,11 @@ prost = "0.13.1"
 dashmap = "6.1.0"
 parking_lot = "0.12.5"
 indexmap = { version = "2.13.0", features = ["serde"] }
+opentelemetry = { version = "0.31.0", features = ["trace"] }
+opentelemetry_sdk = { version = "0.31.0", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.31.1", features = ["grpc-tonic", "http-proto", "http-json"] }
+tracing-opentelemetry = "0.32.1"
+tracing-actix-web = "0.7"
 
 [build-dependencies]
 cargo_toml = "0.21"

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -27,7 +27,7 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 use std::time::Duration;
 use sysinfo::System;
-use tracing::{error, info};
+use tracing::{error, info, instrument};
 use ulid::Ulid;
 
 use crate::{
@@ -184,6 +184,7 @@ impl Report {
 }
 
 /// build the node metrics for the node ingestor endpoint
+#[instrument(name = "GET /analytics", skip_all, fields(http.route = "/analytics"))]
 pub async fn get_analytics(_: HttpRequest) -> impl Responder {
     let json = NodeMetrics::build();
     web::Json(json)

--- a/src/handlers/http/role.rs
+++ b/src/handlers/http/role.rs
@@ -25,6 +25,8 @@ use actix_web::{
     web::{self, Json},
 };
 
+use tracing::instrument;
+
 use crate::rbac::map::roles;
 use crate::rbac::role::model::{Role, RoleType, RoleUI};
 use crate::{
@@ -109,6 +111,7 @@ pub async fn get(req: HttpRequest, name: web::Path<String>) -> Result<impl Respo
 
 // Handler for GET /api/v1/role
 // Fetch all roles in the system
+#[instrument(name = "GET /role", skip(req), fields(http.route = "/role"))]
 pub async fn list(req: HttpRequest) -> Result<impl Responder, RoleError> {
     let tenant_id = get_tenant_id_from_request(&req);
     let metadata = get_metadata(&tenant_id).await?;
@@ -164,6 +167,7 @@ pub async fn delete(
 
 // Handler for PUT /api/v1/role/default
 // Delete existing role
+#[instrument(name = "PUT /role/default", skip(req, name), fields(http.route = "/role/default"))]
 pub async fn put_default(
     req: HttpRequest,
     name: web::Json<String>,
@@ -211,6 +215,7 @@ pub async fn get_default(req: HttpRequest) -> Result<impl Responder, RoleError> 
     Ok(web::Json(res))
 }
 
+#[instrument(name = "get_metadata", skip_all)]
 async fn get_metadata(
     tenant_id: &Option<String>,
 ) -> Result<crate::storage::StorageMetadata, ObjectStorageError> {
@@ -223,6 +228,7 @@ async fn get_metadata(
     Ok(serde_json::from_slice::<StorageMetadata>(&metadata)?)
 }
 
+#[instrument(name = "put_metadata", skip_all)]
 async fn put_metadata(
     metadata: &StorageMetadata,
     tenant_id: &Option<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ mod static_schema;
 mod stats;
 pub mod storage;
 pub mod sync;
+pub mod telemetry;
 pub mod tenants;
 pub mod users;
 pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,8 @@ use std::process::exit;
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_sdk::trace::SdkTracerProvider;
 #[cfg(feature = "kafka")]
 use parseable::connectors;
 use parseable::{
@@ -27,13 +29,14 @@ use tokio::signal::ctrl_c;
 use tokio::sync::oneshot;
 use tracing::Level;
 use tracing::{info, warn};
+use tracing_subscriber::Layer as _;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Registry, fmt};
 
 #[actix_web::main]
 async fn main() -> anyhow::Result<()> {
-    init_logger();
+    let otel_provider = init_logger();
     // Install the rustls crypto provider before any TLS operations.
     // This is required for rustls 0.23+ which needs an explicit crypto provider.
     // If the installation fails, log a warning but continue execution.
@@ -95,11 +98,19 @@ async fn main() -> anyhow::Result<()> {
         parseable_server.await?;
     }
 
+    if let Some(provider) = otel_provider {
+        if let Err(e) = provider.shutdown() {
+            warn!("Failed to shutdown OTel tracer provider: {:?}", e);
+        }
+    }
+
     Ok(())
 }
 
-pub fn init_logger() {
-    let filter_layer = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+pub fn init_logger() -> Option<SdkTracerProvider> {
+    let otel_provider = parseable::telemetry::init_tracing();
+
+    let fmt_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         let default_level = if cfg!(debug_assertions) {
             Level::DEBUG
         } else {
@@ -116,10 +127,22 @@ pub fn init_logger() {
         .with_target(true)
         .compact();
 
+    let otel_layer = otel_provider.as_ref().map(|provider| {
+        let otel_filter =
+            EnvFilter::try_from_env("OTEL_TRACE_LEVEL").unwrap_or_else(|_| EnvFilter::new("info"));
+        let tracer = provider.tracer("parseable");
+        tracing_opentelemetry::layer()
+            .with_tracer(tracer)
+            .with_filter(otel_filter)
+    });
+
     Registry::default()
-        .with(filter_layer)
+        .with(fmt_filter)
         .with(fmt_layer)
+        .with(otel_layer)
         .init();
+
+    otel_provider
 }
 
 #[cfg(windows)]

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,123 @@
+/*
+ * Parseable Server (C) 2022 - 2025 Parseable, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use opentelemetry_otlp::Protocol;
+use opentelemetry_otlp::SpanExporter;
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::{
+    Resource,
+    propagation::TraceContextPropagator,
+    trace::{BatchSpanProcessor, SdkTracerProvider},
+};
+
+const OTEL_EXPORTER_OTLP_ENDPOINT: &str = "OTEL_EXPORTER_OTLP_ENDPOINT";
+const OTEL_EXPORTER_OTLP_PROTOCOL: &str = "OTEL_EXPORTER_OTLP_PROTOCOL";
+
+/// Initialise an OTLP tracer provider.
+///
+/// **Required env var:**
+/// - `OTEL_EXPORTER_OTLP_ENDPOINT` — collector address.
+///   For HTTP exporters the SDK appends the signal path automatically:
+///   e.g. `http://localhost:4318` → `http://localhost:4318/v1/traces`.
+///   Set a signal-specific var `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` to
+///   supply a full URL without any path suffix being added.
+///
+/// **Optional env vars (all read by the SDK automatically):**
+/// - `OTEL_EXPORTER_OTLP_PROTOCOL` — transport + serialisation (default: `http/json`):
+///   - `grpc`           → gRPC / tonic  (Jaeger, Tempo, …)
+///   - `http/json`      → HTTP + JSON   (Parseable OSS ingest at `/v1/traces`)
+///   - `http/protobuf`  → HTTP + protobuf
+/// - `OTEL_EXPORTER_OTLP_HEADERS` — comma-separated `key=value` pairs forwarded
+///   as gRPC metadata or HTTP headers, e.g.
+///   `authorization=Basic <token>,x-p-stream=my-stream,x-p-log-source=otel-traces`
+///
+/// Returns `None` when `OTEL_EXPORTER_OTLP_ENDPOINT` is not set (OTEL disabled).
+/// The caller must call `provider.shutdown()` before process exit.
+pub fn init_tracing() -> Option<SdkTracerProvider> {
+    // Only used to decide whether OTEL is enabled; the SDK reads it again
+    // from env to build the exporter (which also appends /v1/traces for HTTP).
+    std::env::var(OTEL_EXPORTER_OTLP_ENDPOINT).ok()?;
+
+    let protocol =
+        std::env::var(OTEL_EXPORTER_OTLP_PROTOCOL).unwrap_or_else(|_| "http/json".to_string());
+
+    // Build the exporter using the SDK's env-var-aware builders.
+    // We intentionally do NOT call .with_endpoint() / .with_headers() /
+    // .with_metadata() here — the SDK reads OTEL_EXPORTER_OTLP_ENDPOINT and
+    // OTEL_EXPORTER_OTLP_HEADERS from the environment automatically, which
+    // preserves correct path-appending behaviour for HTTP exporters.
+    let exporter = match protocol.as_str() {
+        // ── gRPC ─────────────────────────────────────────────────────────────
+        "grpc" => opentelemetry_otlp::SpanExporter::builder()
+            .with_tonic()
+            .build(),
+        // ── HTTP/Protobuf ────────────────────────────────────────────────────
+        "http/protobuf" => SpanExporter::builder()
+            .with_http()
+            .with_protocol(Protocol::HttpBinary)
+            .build(),
+        // ── HTTP/JSON ─────────────────────────────────────────────────────────
+        "http/json" => SpanExporter::builder()
+            .with_http()
+            .with_protocol(Protocol::HttpJson)
+            .build(),
+        // return none if an invalid value is set
+        other => {
+            tracing::warn!(
+                "Unknown OTEL_EXPORTER_OTLP_PROTOCOL value '{}'; disabling OTEL tracing. \
+                 Supported values: grpc, http/protobuf, http/json",
+                other
+            );
+            return None;
+        }
+    };
+
+    let exporter = exporter
+        .map_err(|e| tracing::warn!("Failed to build OTEL span exporter: {}", e))
+        .ok()?;
+
+    // Declare conformance to OTel Semantic Conventions v1.40.0 via schema_url.
+    // Downstream collectors (e.g., the Schema Translate Processor) can apply
+    // migration tables to rewrite attribute names across semconv versions —
+    // so even if upstream semconv drifts, emitted telemetry remains translatable.
+    let resource = Resource::builder_empty()
+        .with_service_name("parseable")
+        .with_schema_url(
+            std::iter::empty::<opentelemetry::KeyValue>(),
+            "https://opentelemetry.io/schemas/1.40.0",
+        )
+        .build();
+
+    let processor = BatchSpanProcessor::builder(exporter).build();
+
+    let provider = SdkTracerProvider::builder()
+        .with_span_processor(processor)
+        .with_resource(resource)
+        .build();
+
+    opentelemetry::global::set_tracer_provider(provider.clone());
+
+    // Register the W3C TraceContext propagator globally.
+    // This is REQUIRED for:
+    //   - Incoming HTTP header extraction (traceparent/tracestate)
+    //   - Cross-thread channel propagation via inject/extract
+    // Without this, propagator.extract() returns an empty context.
+    opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+
+    Some(provider)
+}


### PR DESCRIPTION
## What changed
- `src/telemetry.rs` — created OTel init module with OTLP exporter (HTTP/JSON default), W3C TraceContext propagator, and resource with service.name="parseable"
- `src/lib.rs` — registered `pub mod telemetry;` alongside existing module declarations
- `src/main.rs` — wired OTel TracerProvider into tracing subscriber in `init_logger()`, added OTel layer with per-layer filter, added provider shutdown before process exit
- `src/analytics.rs` — added `#[instrument]` to `get_analytics` handler with span name `GET /analytics`
- `src/handlers/http/role.rs` — added `#[instrument]` to `list`, `put_default`, `get_metadata`, and `put_metadata` functions

## Dependencies added
- opentelemetry 0.31.0 (features: trace)
- opentelemetry_sdk 0.31.0 (features: rt-tokio)
- opentelemetry-otlp 0.31.1 (features: grpc-tonic, http-proto, http-json)
- tracing-opentelemetry 0.32.1
- tracing-actix-web 0.7

Co-authored-by: otex-dev <dev@otex.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated OpenTelemetry and distributed tracing capabilities for comprehensive observability and monitoring of API requests and application operations.
  * Added automatic span instrumentation to core HTTP endpoints for enhanced visibility into system behavior and performance.

* **Chores**
  * Added OpenTelemetry and tracing library dependencies for telemetry infrastructure support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->