### PR TITLE
infer timestamp flag at stream creation for otel-metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2904,7 +2904,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -3422,6 +3422,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mutually_exclusive_features"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94e1e6445d314f972ff7395df2de295fe51b71821694f0b0e1e79c4f12c8577"
+
+[[package]]
 name = "ntapi"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3436,7 +3442,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3652,6 +3658,20 @@ dependencies = [
 [[package]]
 name = "opentelemetry"
 version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.31.0"
 source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=b096b70b2ffe9beb65a716cf47d5e5db80a9e930#b096b70b2ffe9beb65a716cf47d5e5db80a9e930"
 dependencies = [
  "futures-core",
@@ -3663,18 +3683,85 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-http"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.0",
+ "opentelemetry 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+dependencies = [
+ "http 1.4.0",
+ "opentelemetry 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opentelemetry-http",
+ "opentelemetry-proto 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opentelemetry_sdk 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.14.1",
+ "reqwest",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "base64",
+ "const-hex",
+ "opentelemetry 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opentelemetry_sdk 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.14.1",
+ "serde",
+ "serde_json",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
 name = "opentelemetry-proto"
 version = "0.31.0"
 source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=b096b70b2ffe9beb65a716cf47d5e5db80a9e930#b096b70b2ffe9beb65a716cf47d5e5db80a9e930"
 dependencies = [
  "base64",
  "const-hex",
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.31.0 (git+https://github.com/open-telemetry/opentelemetry-rust/?rev=b096b70b2ffe9beb65a716cf47d5e5db80a9e930)",
+ "opentelemetry_sdk 0.31.0 (git+https://github.com/open-telemetry/opentelemetry-rust/?rev=b096b70b2ffe9beb65a716cf47d5e5db80a9e930)",
  "prost 0.14.1",
  "serde",
  "tonic",
  "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding",
+ "rand 0.9.4",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -3685,7 +3772,7 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry",
+ "opentelemetry 0.31.0 (git+https://github.com/open-telemetry/opentelemetry-rust/?rev=b096b70b2ffe9beb65a716cf47d5e5db80a9e930)",
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.4",
@@ -3708,7 +3795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3829,7 +3916,10 @@ dependencies = [
  "object_store",
  "once_cell",
  "openid",
- "opentelemetry-proto",
+ "opentelemetry 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opentelemetry-otlp",
+ "opentelemetry-proto 0.31.0 (git+https://github.com/open-telemetry/opentelemetry-rust/?rev=b096b70b2ffe9beb65a716cf47d5e5db80a9e930)",
+ "opentelemetry_sdk 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot",
  "parquet",
  "path-clean",
@@ -3865,6 +3955,8 @@ dependencies = [
  "tonic-web",
  "tower-http",
  "tracing",
+ "tracing-actix-web",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "ulid",
  "uptime_lib",
@@ -4244,7 +4336,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -4281,9 +4373,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4536,6 +4628,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.12",
@@ -4688,7 +4781,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5238,7 +5331,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5630,6 +5723,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-actix-web"
+version = "0.7.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca6b15407f9bfcb35f82d0e79e603e1629ece4e91cc6d9e58f890c184dd20af"
+dependencies = [
+ "actix-web",
+ "mutually_exclusive_features",
+ "pin-project",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5662,10 +5768,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-subscriber"
-version = "0.3.22"
+name = "tracing-opentelemetry"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+dependencies = [
+ "js-sys",
+ "opentelemetry 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -6123,7 +6245,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src/catalog/column.rs
+++ b/src/catalog/column.rs
@@ -84,11 +84,24 @@ impl TypedStatistics {
                 }))
             }
             (TypedStatistics::Float(this), TypedStatistics::Float(other)) => {
+                // Validate each operand BEFORE merging. f64::min and f64::max
+                // follow IEEE 754-2019 minimumNumber/maximumNumber semantics:
+                // when exactly one operand is NaN they return the *other*,
+                // silently masking a tainted source range. TypedStatistics
+                // derives Deserialize, so an invalid value can enter without
+                // going through TryFrom — this guard keeps merge correct.
+                if !is_valid_float_range(this.min, this.max)
+                    || !is_valid_float_range(other.min, other.max)
+                {
+                    warn!(
+                        "Dropping float column stats with invalid source range before merge: \
+                         lhs=({}, {}), rhs=({}, {})",
+                        this.min, this.max, other.min, other.max
+                    );
+                    return None;
+                }
                 let min = this.min.min(other.min);
                 let max = this.max.max(other.max);
-                // Defensive: if either operand was already inverted (min>max)
-                // or carries NaN, the merge can land outside a usable range.
-                // Drop the stats rather than passing them downstream.
                 if !is_valid_float_range(min, max) {
                     warn!(
                         "Dropping float column stats with invalid range after merge: \
@@ -377,10 +390,12 @@ mod tests {
     }
 
     #[test]
-    fn update_repairs_when_one_operand_is_inverted_but_other_brackets_it() {
-        // Documents a real semantic: f64::min/max can produce a valid result
-        // even if one operand was inverted, as long as the other operand's
-        // bounds bracket it. We don't try to detect this — it's correct.
+    fn update_drops_when_one_operand_is_inverted_even_if_bracketed() {
+        // Per-operand validation rejects an inverted operand even when the
+        // other operand's bounds would have bracketed it into a valid merged
+        // range. This is intentional: an inverted operand signals a tainted
+        // upstream stat, so we drop the column's stats entirely rather than
+        // letting the merge silently launder it into a clean-looking result.
         let inverted = TypedStatistics::Float(Float64Type {
             min: 600025.1656670001,
             max: 600025.165667,
@@ -389,11 +404,23 @@ mod tests {
             min: 100.0,
             max: 1_000_000.0,
         });
-        let merged = inverted.update(valid).expect("merge should succeed");
-        match merged {
-            TypedStatistics::Float(s) => assert!(s.min <= s.max),
-            _ => panic!("expected Float variant"),
-        }
+        assert!(inverted.update(valid).is_none());
+    }
+
+    #[test]
+    fn update_drops_when_one_operand_has_nan() {
+        // Without per-operand validation, f64::min(NaN, 5) = 5 silently masks
+        // the NaN. The validation must fire first so this returns None.
+        let with_nan = TypedStatistics::Float(Float64Type {
+            min: f64::NAN,
+            max: 10.0,
+        });
+        let valid = TypedStatistics::Float(Float64Type {
+            min: 1.0,
+            max: 20.0,
+        });
+        assert!(with_nan.clone().update(valid.clone()).is_none());
+        assert!(valid.update(with_nan).is_none());
     }
 
     #[test]

--- a/src/catalog/column.rs
+++ b/src/catalog/column.rs
@@ -84,10 +84,19 @@ impl TypedStatistics {
                 }))
             }
             (TypedStatistics::Float(this), TypedStatistics::Float(other)) => {
-                Some(TypedStatistics::Float(Float64Type {
-                    min: this.min.min(other.min),
-                    max: this.max.max(other.max),
-                }))
+                let min = this.min.min(other.min);
+                let max = this.max.max(other.max);
+                // Defensive: if either operand was already inverted (min>max)
+                // or carries NaN, the merge can land outside a usable range.
+                // Drop the stats rather than passing them downstream.
+                if !is_valid_float_range(min, max) {
+                    warn!(
+                        "Dropping float column stats with invalid range after merge: \
+                         min={min}, max={max}"
+                    );
+                    return None;
+                }
+                Some(TypedStatistics::Float(Float64Type { min, max }))
             }
             (TypedStatistics::Int(this), TypedStatistics::Int(other)) => {
                 Some(TypedStatistics::Int(Int64Type {
@@ -126,14 +135,29 @@ impl TypedStatistics {
                 ScalarValue::Int64(Some(stats.min)),
                 ScalarValue::Int64(Some(stats.max)),
             ),
-            (TypedStatistics::Float(stats), DataType::Float32) => (
-                ScalarValue::Float32(Some(stats.min as f32)),
-                ScalarValue::Float32(Some(stats.max as f32)),
-            ),
-            (TypedStatistics::Float(stats), DataType::Float64) => (
-                ScalarValue::Float64(Some(stats.min)),
-                ScalarValue::Float64(Some(stats.max)),
-            ),
+            (TypedStatistics::Float(stats), DataType::Float32) => {
+                let min_f32 = stats.min as f32;
+                let max_f32 = stats.max as f32;
+                // Drop float stats with NaN or inverted bounds — handing
+                // these to DataFusion can trip f64::clamp inside its
+                // statistics-aware operators (e.g. approx_percentile_cont).
+                if min_f32.is_nan() || max_f32.is_nan() || min_f32 > max_f32 {
+                    return None;
+                }
+                (
+                    ScalarValue::Float32(Some(min_f32)),
+                    ScalarValue::Float32(Some(max_f32)),
+                )
+            }
+            (TypedStatistics::Float(stats), DataType::Float64) => {
+                if !is_valid_float_range(stats.min, stats.max) {
+                    return None;
+                }
+                (
+                    ScalarValue::Float64(Some(stats.min)),
+                    ScalarValue::Float64(Some(stats.max)),
+                )
+            }
             (TypedStatistics::String(stats), DataType::Utf8) => (
                 ScalarValue::Utf8(Some(stats.min)),
                 ScalarValue::Utf8(Some(stats.max)),
@@ -145,6 +169,17 @@ impl TypedStatistics {
 
         Some((min, max))
     }
+}
+
+/// Returns true when (min, max) form a usable float range:
+/// - neither bound is NaN
+/// - min <= max
+///
+/// Float stats can come back inverted or NaN-bearing from a corrupt parquet
+/// writer or a downstream computation; passing them on to DataFusion can
+/// panic inside `f64::clamp` in operators like approx_percentile_cont.
+fn is_valid_float_range(min: f64, max: f64) -> bool {
+    !(min.is_nan() || max.is_nan() || min > max)
 }
 
 /// Column statistics are used to track statistics for a column in a given file.
@@ -183,14 +218,26 @@ impl TryFrom<&Statistics> for TypedStatistics {
                 min: int96_to_i64_nanos(stats.min_opt().expect("Int96 stats min not set")),
                 max: int96_to_i64_nanos(stats.max_opt().expect("Int96 stats max not set")),
             }),
-            Statistics::Float(stats) => TypedStatistics::Float(Float64Type {
-                min: *stats.min_opt().expect("Float32 stats min not set") as f64,
-                max: *stats.max_opt().expect("Float32 stats max not set") as f64,
-            }),
-            Statistics::Double(stats) => TypedStatistics::Float(Float64Type {
-                min: *stats.min_opt().expect("Float64 stats min not set"),
-                max: *stats.max_opt().expect("Float64 stats max not set"),
-            }),
+            Statistics::Float(stats) => {
+                let min = *stats.min_opt().expect("Float32 stats min not set") as f64;
+                let max = *stats.max_opt().expect("Float32 stats max not set") as f64;
+                if !is_valid_float_range(min, max) {
+                    return Err(parquet::errors::ParquetError::General(format!(
+                        "invalid Float32 stats: min={min}, max={max}"
+                    )));
+                }
+                TypedStatistics::Float(Float64Type { min, max })
+            }
+            Statistics::Double(stats) => {
+                let min = *stats.min_opt().expect("Float64 stats min not set");
+                let max = *stats.max_opt().expect("Float64 stats max not set");
+                if !is_valid_float_range(min, max) {
+                    return Err(parquet::errors::ParquetError::General(format!(
+                        "invalid Float64 stats: min={min}, max={max}"
+                    )));
+                }
+                TypedStatistics::Float(Float64Type { min, max })
+            }
             Statistics::ByteArray(stats) => TypedStatistics::String(Utf8Type {
                 min: stats
                     .min_opt()
@@ -312,5 +359,77 @@ mod tests {
         assert!(int_s.clone().update(float_s.clone()).is_none());
         assert!(float_s.clone().update(str_s.clone()).is_none());
         assert!(str_s.update(bool_s).is_none());
+    }
+
+    #[test]
+    fn update_drops_float_stats_when_both_inputs_inverted() {
+        // Both operands inverted with overlapping ranges — the merge preserves
+        // the inversion (min stays > max). Drop to avoid tripping f64::clamp.
+        let a = TypedStatistics::Float(Float64Type {
+            min: 600025.1656670001,
+            max: 600025.165667,
+        });
+        let b = TypedStatistics::Float(Float64Type {
+            min: 600025.1656670001,
+            max: 600025.165667,
+        });
+        assert!(a.update(b).is_none());
+    }
+
+    #[test]
+    fn update_repairs_when_one_operand_is_inverted_but_other_brackets_it() {
+        // Documents a real semantic: f64::min/max can produce a valid result
+        // even if one operand was inverted, as long as the other operand's
+        // bounds bracket it. We don't try to detect this — it's correct.
+        let inverted = TypedStatistics::Float(Float64Type {
+            min: 600025.1656670001,
+            max: 600025.165667,
+        });
+        let valid = TypedStatistics::Float(Float64Type {
+            min: 100.0,
+            max: 1_000_000.0,
+        });
+        let merged = inverted.update(valid).expect("merge should succeed");
+        match merged {
+            TypedStatistics::Float(s) => assert!(s.min <= s.max),
+            _ => panic!("expected Float variant"),
+        }
+    }
+
+    #[test]
+    fn is_valid_float_range_rejects_nan_and_inversion() {
+        assert!(is_valid_float_range(0.0, 1.0));
+        assert!(is_valid_float_range(0.0, 0.0));
+        assert!(!is_valid_float_range(2.0, 1.0));
+        assert!(!is_valid_float_range(f64::NAN, 1.0));
+        assert!(!is_valid_float_range(0.0, f64::NAN));
+        assert!(!is_valid_float_range(f64::NAN, f64::NAN));
+    }
+
+    #[test]
+    fn min_max_as_scalar_returns_none_for_inverted_float_stats() {
+        // Same shape as the user-reported panic: min slightly larger than max
+        // due to upstream float precision artefacts.
+        let stats = TypedStatistics::Float(Float64Type {
+            min: 600025.1656670001,
+            max: 600025.165667,
+        });
+        assert!(stats.min_max_as_scalar(&DataType::Float64).is_none());
+    }
+
+    #[test]
+    fn min_max_as_scalar_returns_none_for_nan_float_stats() {
+        let stats = TypedStatistics::Float(Float64Type {
+            min: 0.0,
+            max: f64::NAN,
+        });
+        assert!(stats.min_max_as_scalar(&DataType::Float64).is_none());
+    }
+
+    #[test]
+    fn min_max_as_scalar_returns_some_for_valid_float_stats() {
+        let stats = TypedStatistics::Float(Float64Type { min: 0.5, max: 1.5 });
+        let result = stats.min_max_as_scalar(&DataType::Float64);
+        assert!(result.is_some());
     }
 }

--- a/src/catalog/column.rs
+++ b/src/catalog/column.rs
@@ -21,6 +21,7 @@ use std::cmp::{max, min};
 use arrow_schema::DataType;
 use datafusion::scalar::ScalarValue;
 use parquet::file::statistics::Statistics;
+use tracing::warn;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BoolType {
@@ -58,33 +59,56 @@ pub enum TypedStatistics {
 }
 
 impl TypedStatistics {
-    pub fn update(self, other: Self) -> Self {
+    /// Variant name used in logs when the two operands disagree on type.
+    fn variant_name(&self) -> &'static str {
+        match self {
+            TypedStatistics::Bool(_) => "bool",
+            TypedStatistics::Int(_) => "int",
+            TypedStatistics::Float(_) => "float",
+            TypedStatistics::String(_) => "string",
+        }
+    }
+
+    /// Merge two stat ranges. Returns `None` when the operands disagree on
+    /// variant (which can happen if the same column was historically written
+    /// under two different Arrow types — e.g. timestamp vs utf8 — in different
+    /// parquet files). In that case the caller should drop stats for the
+    /// column rather than treat them as authoritative; planners then fall
+    /// back to scanning without min/max pushdown.
+    pub fn update(self, other: Self) -> Option<Self> {
         match (self, other) {
             (TypedStatistics::Bool(this), TypedStatistics::Bool(other)) => {
-                TypedStatistics::Bool(BoolType {
+                Some(TypedStatistics::Bool(BoolType {
                     min: min(this.min, other.min),
                     max: max(this.max, other.max),
-                })
+                }))
             }
             (TypedStatistics::Float(this), TypedStatistics::Float(other)) => {
-                TypedStatistics::Float(Float64Type {
+                Some(TypedStatistics::Float(Float64Type {
                     min: this.min.min(other.min),
                     max: this.max.max(other.max),
-                })
+                }))
             }
             (TypedStatistics::Int(this), TypedStatistics::Int(other)) => {
-                TypedStatistics::Int(Int64Type {
+                Some(TypedStatistics::Int(Int64Type {
                     min: min(this.min, other.min),
                     max: max(this.max, other.max),
-                })
+                }))
             }
             (TypedStatistics::String(this), TypedStatistics::String(other)) => {
-                TypedStatistics::String(Utf8Type {
+                Some(TypedStatistics::String(Utf8Type {
                     min: min(this.min, other.min),
                     max: max(this.max, other.max),
-                })
+                }))
             }
-            _ => panic!("Cannot update wrong types"),
+            (this, other) => {
+                warn!(
+                    "Dropping incompatible column stats: existing={} new={}",
+                    this.variant_name(),
+                    other.variant_name()
+                );
+                None
+            }
         }
     }
 
@@ -213,4 +237,80 @@ fn int96_to_i64_nanos(int96: &parquet::data_type::Int96) -> i64 {
     // Convert to nanoseconds since Unix epoch
     let days_since_epoch = julian_day - JULIAN_DAY_OF_EPOCH;
     days_since_epoch * SECONDS_PER_DAY * NANOS_PER_SECOND + nanos_of_day
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_merges_compatible_int_stats() {
+        let a = TypedStatistics::Int(Int64Type { min: 5, max: 10 });
+        let b = TypedStatistics::Int(Int64Type { min: 1, max: 7 });
+        let merged = a.update(b).expect("same variant should merge");
+        match merged {
+            TypedStatistics::Int(s) => {
+                assert_eq!(s.min, 1);
+                assert_eq!(s.max, 10);
+            }
+            _ => panic!("expected Int variant"),
+        }
+    }
+
+    #[test]
+    fn update_merges_compatible_string_stats() {
+        let a = TypedStatistics::String(Utf8Type {
+            min: "b".into(),
+            max: "y".into(),
+        });
+        let b = TypedStatistics::String(Utf8Type {
+            min: "a".into(),
+            max: "z".into(),
+        });
+        let merged = a.update(b).expect("same variant should merge");
+        match merged {
+            TypedStatistics::String(s) => {
+                assert_eq!(s.min, "a");
+                assert_eq!(s.max, "z");
+            }
+            _ => panic!("expected String variant"),
+        }
+    }
+
+    #[test]
+    fn update_returns_none_on_type_mismatch_instead_of_panicking() {
+        // Reproduces the "Cannot update wrong types" panic scenario: a column
+        // that was historically written as Utf8 in some files and Timestamp(ms)
+        // in others. Timestamps map to Int stats internally.
+        let str_stats = TypedStatistics::String(Utf8Type {
+            min: "2025-01-01".into(),
+            max: "2025-12-31".into(),
+        });
+        let int_stats = TypedStatistics::Int(Int64Type {
+            min: 1_700_000_000_000,
+            max: 1_800_000_000_000,
+        });
+
+        assert!(str_stats.clone().update(int_stats.clone()).is_none());
+        assert!(int_stats.update(str_stats).is_none());
+    }
+
+    #[test]
+    fn update_returns_none_for_each_cross_variant_pair() {
+        let bool_s = TypedStatistics::Bool(BoolType {
+            min: false,
+            max: true,
+        });
+        let int_s = TypedStatistics::Int(Int64Type { min: 0, max: 1 });
+        let float_s = TypedStatistics::Float(Float64Type { min: 0.0, max: 1.0 });
+        let str_s = TypedStatistics::String(Utf8Type {
+            min: "a".into(),
+            max: "b".into(),
+        });
+
+        assert!(bool_s.clone().update(int_s.clone()).is_none());
+        assert!(int_s.clone().update(float_s.clone()).is_none());
+        assert!(float_s.clone().update(str_s.clone()).is_none());
+        assert!(str_s.update(bool_s).is_none());
+    }
 }

--- a/src/catalog/manifest.rs
+++ b/src/catalog/manifest.rs
@@ -182,7 +182,7 @@ fn column_statistics(row_groups: &[RowGroupMetaData]) -> HashMap<String, Column>
                 entry.compressed_size += col.compressed_size() as u64;
                 entry.uncompressed_size += col.uncompressed_size() as u64;
                 if let Some(other) = col.statistics().and_then(|stats| stats.try_into().ok()) {
-                    entry.stats = entry.stats.clone().map(|this| this.update(other));
+                    entry.stats = entry.stats.clone().and_then(|this| this.update(other));
                 }
             } else {
                 columns.insert(

--- a/src/connectors/kafka/processor.rs
+++ b/src/connectors/kafka/processor.rs
@@ -75,6 +75,7 @@ impl ParseableSinkProcessor {
         let custom_partition = stream.get_custom_partition();
         let static_schema_flag = stream.get_static_schema_flag();
         let schema_version = stream.get_schema_version();
+        let infer_timestamp = stream.get_infer_timestamp();
 
         let mut json_vec = Vec::with_capacity(records.len());
         let mut total_payload_size = 0u64;
@@ -101,6 +102,7 @@ impl ParseableSinkProcessor {
             &p_custom_fields,
             TelemetryType::Logs,
             tenant_id,
+            infer_timestamp,
         )?;
 
         Ok(p_event)

--- a/src/event/format/json.rs
+++ b/src/event/format/json.rs
@@ -66,6 +66,7 @@ impl EventFormat for Event {
         time_partition: Option<&String>,
         schema_version: SchemaVersion,
         static_schema_flag: bool,
+        infer_timestamp: bool,
     ) -> Result<(Self::Data, Vec<Arc<Field>>, bool), anyhow::Error> {
         let stream_schema = schema;
 
@@ -131,6 +132,7 @@ impl EventFormat for Event {
                     time_partition,
                     Some(&value_arr),
                     schema_version,
+                    infer_timestamp,
                 );
                 infer_schema = Schema::new(new_infer_schema.fields().clone());
                 Schema::try_merge(vec![
@@ -192,6 +194,7 @@ impl EventFormat for Event {
         p_custom_fields: &HashMap<String, String>,
         telemetry_type: TelemetryType,
         tenant_id: &Option<String>,
+        infer_timestamp: bool,
     ) -> Result<super::Event, anyhow::Error> {
         let custom_partition_values = match custom_partitions.as_ref() {
             Some(custom_partition) => {
@@ -212,6 +215,7 @@ impl EventFormat for Event {
             time_partition,
             schema_version,
             p_custom_fields,
+            infer_timestamp,
         )?;
 
         Ok(super::Event {

--- a/src/event/format/json.rs
+++ b/src/event/format/json.rs
@@ -110,6 +110,18 @@ impl EventFormat for Event {
             value_arr
         };
 
+        // Per-record fallback: catches batches with mixed JSON types for the
+        // same field, which the batch-level detect_schema_conflicts misses
+        // because arrow's inference picks one winning type (string over bool).
+        // Internally short-circuits when this can't apply (single-record
+        // batches, or no field-name collision at the same type).
+        let value_arr = super::rename_per_record_type_mismatches(
+            value_arr,
+            &raw_inferred_schema,
+            stream_schema,
+            schema_version,
+        );
+
         // collect all the keys from all the json objects in the request body
         let fields =
             collect_keys(value_arr.iter()).expect("fields can be collected from array of objects");
@@ -151,12 +163,12 @@ impl EventFormat for Event {
             }
         };
 
-        if value_arr
+        if let Some(mismatch) = value_arr
             .iter()
-            .any(|value| fields_mismatch(&schema, value, schema_version, static_schema_flag))
+            .find_map(|value| fields_mismatch(&schema, value, schema_version, static_schema_flag))
         {
             return Err(anyhow!(
-                "Could not process this event due to mismatch in datatype"
+                "Could not process this event due to mismatch in datatype: {mismatch}"
             ));
         }
 
@@ -347,24 +359,47 @@ fn rename_json_keys(values: Vec<Value>) -> Result<Vec<Value>, anyhow::Error> {
         .collect()
 }
 
+/// Returns `Some(reason)` when `body` does not match the target `schema`.
+/// `reason` names the offending field and includes the expected vs. actual
+/// types so the caller can surface it in the error message.
 fn fields_mismatch(
     schema: &[Arc<Field>],
     body: &Value,
     schema_version: SchemaVersion,
     static_schema_flag: bool,
-) -> bool {
+) -> Option<String> {
     for (name, val) in body.as_object().expect("body is of object variant") {
         if val.is_null() {
             continue;
         }
         let Some(field) = get_field(schema, name) else {
-            return true;
+            return Some(format!(
+                "field '{name}' not present in stream schema (got {})",
+                json_value_kind(val)
+            ));
         };
         if !valid_type(field, val, schema_version, static_schema_flag) {
-            return true;
+            return Some(format!(
+                "field '{name}' expected {:?} but got {} value",
+                field.data_type(),
+                json_value_kind(val),
+            ));
         }
     }
-    false
+    None
+}
+
+fn json_value_kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(n) if n.is_i64() => "i64",
+        Value::Number(n) if n.is_u64() => "u64",
+        Value::Number(_) => "f64",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
 }
 
 fn valid_type(

--- a/src/event/format/mod.rs
+++ b/src/event/format/mod.rs
@@ -56,6 +56,15 @@ static TIME_FIELD_NAME_PARTS: [&str; 11] = [
     "ts",
     "dt",
 ];
+
+/// Minimum integer value for a time-named numeric field to be treated as an epoch.
+/// 1e9 covers:
+///   - seconds since 2001-09-09 (modern epoch-in-seconds values)
+///   - any millisecond / microsecond / nanosecond epoch from 1970 onwards
+///
+/// Smaller integers are kept as Float64 to avoid misinterpreting counters,
+/// durations, IDs, etc. as timestamps.
+const EPOCH_PROMOTION_MIN: u64 = 1_000_000_000;
 type EventSchema = Vec<Arc<Field>>;
 
 /// Normalizes a field name by replacing leading '@' with '_'.
@@ -153,6 +162,7 @@ pub trait EventFormat: Sized {
         time_partition: Option<&String>,
         schema_version: SchemaVersion,
         static_schema_flag: bool,
+        infer_timestamp: bool,
     ) -> Result<(Self::Data, EventSchema, bool), AnyError>;
 
     fn decode(data: Self::Data, schema: Arc<Schema>) -> Result<RecordBatch, AnyError>;
@@ -167,6 +177,7 @@ pub trait EventFormat: Sized {
         time_partition: Option<&String>,
         schema_version: SchemaVersion,
         p_custom_fields: &HashMap<String, String>,
+        infer_timestamp: bool,
     ) -> Result<(RecordBatch, bool), AnyError> {
         let _span = info_span!("into_recordbatch").entered();
         let p_timestamp = self.get_p_timestamp();
@@ -175,6 +186,7 @@ pub trait EventFormat: Sized {
             time_partition,
             schema_version,
             static_schema_flag,
+            infer_timestamp,
         )?;
 
         if get_field(&schema, DEFAULT_TIMESTAMP_KEY).is_some() {
@@ -189,8 +201,14 @@ pub trait EventFormat: Sized {
         if !Self::is_schema_matching(new_schema.clone(), storage_schema, static_schema_flag) {
             return Err(anyhow!("Schema mismatch"));
         }
-        new_schema =
-            update_field_type_in_schema(new_schema, None, time_partition, None, schema_version);
+        new_schema = update_field_type_in_schema(
+            new_schema,
+            None,
+            time_partition,
+            None,
+            schema_version,
+            infer_timestamp,
+        );
 
         let rb = Self::decode(data, new_schema.clone())?;
         let rb = add_parseable_fields(rb, p_timestamp, p_custom_fields)?;
@@ -234,6 +252,7 @@ pub trait EventFormat: Sized {
         p_custom_fields: &HashMap<String, String>,
         telemetry_type: TelemetryType,
         tenant_id: &Option<String>,
+        infer_timestamp: bool,
     ) -> Result<Event, AnyError>;
 }
 
@@ -294,6 +313,7 @@ pub fn update_field_type_in_schema(
     time_partition: Option<&String>,
     log_records: Option<&Vec<Value>>,
     schema_version: SchemaVersion,
+    infer_timestamp: bool,
 ) -> Arc<Schema> {
     let mut updated_schema = inferred_schema.clone();
     let existing_field_names = get_existing_field_names(inferred_schema.clone(), existing_schema);
@@ -305,8 +325,12 @@ pub fn update_field_type_in_schema(
 
     if let Some(log_records) = log_records {
         for log_record in log_records {
-            updated_schema =
-                override_data_type(updated_schema.clone(), log_record.clone(), schema_version);
+            updated_schema = override_data_type(
+                updated_schema.clone(),
+                log_record.clone(),
+                schema_version,
+                infer_timestamp,
+            );
         }
     }
 
@@ -339,6 +363,7 @@ pub fn override_data_type(
     inferred_schema: Arc<Schema>,
     log_record: Value,
     schema_version: SchemaVersion,
+    infer_timestamp: bool,
 ) -> Arc<Schema> {
     let Value::Object(map) = log_record else {
         return inferred_schema;
@@ -350,19 +375,38 @@ pub fn override_data_type(
             // Normalize field names - replace '@' prefix with '_'
             let mut field_name = field.name().to_string();
             normalize_field_name(&mut field_name);
+            let is_time_named = TIME_FIELD_NAME_PARTS
+                .iter()
+                .any(|part| field_name.to_lowercase().contains(part));
             match (schema_version, map.get(field.name())) {
-                // in V1 for new fields in json named "time"/"date" or such and having inferred
-                // type string, that can be parsed as timestamp, use the timestamp type.
+                // in V1 for fields named "time"/"date" or such with a string value that
+                // parses as a datetime, promote to Timestamp. Only when `infer_timestamp`
+                // is enabled (default). The flag is settable per dataset (otel-metrics)
+                // via x-p-infer-timestamp=false.
                 // NOTE: support even more datetime string formats
                 (SchemaVersion::V1, Some(Value::String(s)))
-                    if TIME_FIELD_NAME_PARTS
-                        .iter()
-                        .any(|part| field_name.to_lowercase().contains(part))
-                        && field.data_type() == &DataType::Utf8
+                    if infer_timestamp
+                        && is_time_named
                         && (DateTime::parse_from_rfc3339(s).is_ok()
                             || DateTime::parse_from_rfc2822(s).is_ok()) =>
                 {
-                    // Update the field's data type to Timestamp
+                    Field::new(
+                        field_name,
+                        DataType::Timestamp(TimeUnit::Millisecond, None),
+                        true,
+                    )
+                }
+                // in V1 for time-named fields with an integer value that's large enough
+                // to plausibly be a Unix epoch (seconds since 2001-09-09, or any
+                // milli/micro/nano-precision epoch), promote to Timestamp. Arrow's JSON
+                // decoder accepts integer epochs for Timestamp(ms) columns. Small ints
+                // (counters, IDs, durations) fall through to the float64 arm.
+                // Floats do not decode for Timestamp and are also left as Float64 below.
+                (SchemaVersion::V1, Some(Value::Number(n)))
+                    if infer_timestamp
+                        && is_time_named
+                        && n.as_u64().is_some_and(|v| v >= EPOCH_PROMOTION_MIN) =>
+                {
                     Field::new(
                         field_name,
                         DataType::Timestamp(TimeUnit::Millisecond, None),
@@ -809,5 +853,264 @@ mod tests {
 
         // Should NOT detect conflict because V1 allows any number for Float64
         assert!(conflicts.is_empty());
+    }
+
+    #[test]
+    fn override_data_type_converts_time_field_when_infer_enabled() {
+        let inferred = Arc::new(Schema::new(vec![Field::new(
+            "start_time",
+            DataType::Utf8,
+            true,
+        )]));
+        let log = json!({"start_time": "2025-01-01T00:00:00Z"});
+
+        let updated = override_data_type(inferred, log, SchemaVersion::V1, true);
+
+        assert_eq!(
+            updated.field(0).data_type(),
+            &DataType::Timestamp(TimeUnit::Millisecond, None)
+        );
+    }
+
+    #[test]
+    fn override_data_type_keeps_utf8_when_infer_disabled() {
+        let inferred = Arc::new(Schema::new(vec![Field::new(
+            "start_time",
+            DataType::Utf8,
+            true,
+        )]));
+        let log = json!({"start_time": "2025-01-01T00:00:00Z"});
+
+        let updated = override_data_type(inferred, log, SchemaVersion::V1, false);
+
+        // With infer_timestamp=false, time-named string fields stay Utf8.
+        assert_eq!(updated.field(0).data_type(), &DataType::Utf8);
+    }
+
+    #[test]
+    fn override_data_type_still_casts_numbers_when_infer_disabled() {
+        // The flag must only affect string-to-timestamp inference, not
+        // V1's number-to-float64 promotion.
+        let inferred = Arc::new(Schema::new(vec![Field::new(
+            "count",
+            DataType::Int64,
+            true,
+        )]));
+        let log = json!({"count": 7});
+
+        let updated = override_data_type(inferred, log, SchemaVersion::V1, false);
+
+        assert_eq!(updated.field(0).data_type(), &DataType::Float64);
+    }
+
+    #[test]
+    fn override_data_type_no_effect_on_v0_schema() {
+        // The inference happens only on V1; V0 must be untouched regardless of the flag.
+        let inferred = Arc::new(Schema::new(vec![Field::new(
+            "start_time",
+            DataType::Utf8,
+            true,
+        )]));
+        let log = json!({"start_time": "2025-01-01T00:00:00Z"});
+
+        let v0_with_flag =
+            override_data_type(inferred.clone(), log.clone(), SchemaVersion::V0, true);
+        assert_eq!(v0_with_flag.field(0).data_type(), &DataType::Utf8);
+
+        let v0_no_flag = override_data_type(inferred, log, SchemaVersion::V0, false);
+        assert_eq!(v0_no_flag.field(0).data_type(), &DataType::Utf8);
+    }
+
+    #[test]
+    fn update_field_type_in_schema_respects_infer_flag() {
+        let inferred = Arc::new(Schema::new(vec![Field::new(
+            "received_at",
+            DataType::Utf8,
+            true,
+        )]));
+        let log_records = vec![json!({"received_at": "2025-01-01T00:00:00Z"})];
+
+        let with_flag = update_field_type_in_schema(
+            inferred.clone(),
+            None,
+            None,
+            Some(&log_records),
+            SchemaVersion::V1,
+            true,
+        );
+        assert_eq!(
+            with_flag.field(0).data_type(),
+            &DataType::Timestamp(TimeUnit::Millisecond, None)
+        );
+
+        let without_flag = update_field_type_in_schema(
+            inferred,
+            None,
+            None,
+            Some(&log_records),
+            SchemaVersion::V1,
+            false,
+        );
+        assert_eq!(without_flag.field(0).data_type(), &DataType::Utf8);
+    }
+
+    #[test]
+    fn override_data_type_promotes_integer_epoch_for_time_named_field() {
+        // Field named "timestamp" inferred as Int64 with a plausible epoch value
+        // (above the threshold) is promoted to Timestamp(ms) when the flag is on.
+        let inferred = Arc::new(Schema::new(vec![Field::new(
+            "timestamp",
+            DataType::Int64,
+            true,
+        )]));
+        let log = json!({"timestamp": 1735689600000_i64});
+
+        let updated = override_data_type(inferred, log, SchemaVersion::V1, true);
+        assert_eq!(
+            updated.field(0).data_type(),
+            &DataType::Timestamp(TimeUnit::Millisecond, None)
+        );
+    }
+
+    #[test]
+    fn override_data_type_keeps_integer_epoch_when_flag_off() {
+        // With flag off, integer epoch values stay numeric (Float64 via the
+        // V1 number-to-float64 normalization), even above the threshold.
+        let inferred = Arc::new(Schema::new(vec![Field::new(
+            "timestamp",
+            DataType::Int64,
+            true,
+        )]));
+        let log = json!({"timestamp": 1735689600000_i64});
+
+        let updated = override_data_type(inferred, log, SchemaVersion::V1, false);
+        assert_eq!(updated.field(0).data_type(), &DataType::Float64);
+    }
+
+    #[test]
+    fn override_data_type_float_epoch_stays_float64() {
+        // Floats are not promoted (Arrow's JSON decoder doesn't accept floats for
+        // Timestamp), so they fall through to the V1 number-to-float64 arm.
+        let inferred = Arc::new(Schema::new(vec![Field::new(
+            "timestamp",
+            DataType::Float64,
+            true,
+        )]));
+        let log = json!({"timestamp": 1735689600.5_f64});
+
+        let updated = override_data_type(inferred, log, SchemaVersion::V1, true);
+        assert_eq!(updated.field(0).data_type(), &DataType::Float64);
+    }
+
+    #[test]
+    fn override_data_type_promotes_non_utf8_string_when_name_matches() {
+        // The Utf8-only gate has been removed: even when the field's prior inferred
+        // type is something else, a parseable RFC3339 string should still trigger
+        // promotion to Timestamp.
+        let inferred = Arc::new(Schema::new(vec![Field::new(
+            "timestamp",
+            DataType::Int64, // pretend a previous inference produced a non-Utf8 type
+            true,
+        )]));
+        let log = json!({"timestamp": "2025-01-01T00:00:00.000Z"});
+
+        let updated = override_data_type(inferred, log, SchemaVersion::V1, true);
+        assert_eq!(
+            updated.field(0).data_type(),
+            &DataType::Timestamp(TimeUnit::Millisecond, None)
+        );
+    }
+
+    #[test]
+    fn override_data_type_non_time_named_integer_stays_float64() {
+        // Field name doesn't contain a time keyword — integer should NOT be
+        // promoted to Timestamp; it falls through to the float64 arm.
+        let inferred = Arc::new(Schema::new(vec![Field::new(
+            "count",
+            DataType::Int64,
+            true,
+        )]));
+        let log = json!({"count": 1735689600_i64});
+
+        let updated = override_data_type(inferred, log, SchemaVersion::V1, true);
+        assert_eq!(updated.field(0).data_type(), &DataType::Float64);
+    }
+
+    #[test]
+    fn override_data_type_small_integer_in_time_named_field_stays_float64() {
+        // {"time": 1234} must NOT be promoted to Timestamp — it would decode as
+        // 1970-01-01 00:00:01.234 UTC and silently misinterpret a counter / ID /
+        // duration as an epoch. Threshold (1e9) keeps small ints as Float64.
+        for value in [0_i64, 1, 1234, 999_999_999] {
+            let inferred = Arc::new(Schema::new(vec![Field::new("time", DataType::Int64, true)]));
+            let log = json!({ "time": value });
+            let updated = override_data_type(inferred, log, SchemaVersion::V1, true);
+            assert_eq!(
+                updated.field(0).data_type(),
+                &DataType::Float64,
+                "value {value} should NOT be treated as epoch",
+            );
+        }
+    }
+
+    #[test]
+    fn override_data_type_negative_integer_in_time_named_field_stays_float64() {
+        // Negative ints (sentinels like -1, "no value", or rare pre-1970 epochs)
+        // are not promoted — `as_u64` returns None for them.
+        let inferred = Arc::new(Schema::new(vec![Field::new("time", DataType::Int64, true)]));
+        let log = json!({"time": -1_i64});
+
+        let updated = override_data_type(inferred, log, SchemaVersion::V1, true);
+        assert_eq!(updated.field(0).data_type(), &DataType::Float64);
+    }
+
+    #[test]
+    fn override_data_type_promotes_at_threshold_and_above() {
+        // Each of these magnitudes is a plausible epoch in some unit:
+        //   1e9          — seconds since 2001-09-09
+        //   1.7e12       — milliseconds (modern)
+        //   1.7e15       — microseconds (modern)
+        //   1.7e18       — nanoseconds (modern)
+        for value in [
+            1_000_000_000_i64,
+            1_735_689_600_000,
+            1_735_689_600_000_000,
+            1_735_689_600_000_000_000,
+        ] {
+            let inferred = Arc::new(Schema::new(vec![Field::new("ts", DataType::Int64, true)]));
+            let log = json!({ "ts": value });
+            let updated = override_data_type(inferred, log, SchemaVersion::V1, true);
+            assert_eq!(
+                updated.field(0).data_type(),
+                &DataType::Timestamp(TimeUnit::Millisecond, None),
+                "value {value} should be treated as epoch",
+            );
+        }
+    }
+
+    #[test]
+    fn update_field_type_in_schema_explicit_time_partition_unaffected_by_flag() {
+        // When the user explicitly configures a time_partition, that field is always
+        // promoted to Timestamp regardless of infer_timestamp.
+        let inferred = Arc::new(Schema::new(vec![Field::new(
+            "ingest_ts",
+            DataType::Utf8,
+            true,
+        )]));
+        let time_partition = "ingest_ts".to_string();
+
+        let updated = update_field_type_in_schema(
+            inferred,
+            None,
+            Some(&time_partition),
+            None,
+            SchemaVersion::V1,
+            false,
+        );
+
+        assert_eq!(
+            updated.field(0).data_type(),
+            &DataType::Timestamp(TimeUnit::Millisecond, None)
+        );
     }
 }

--- a/src/event/format/mod.rs
+++ b/src/event/format/mod.rs
@@ -57,14 +57,6 @@ static TIME_FIELD_NAME_PARTS: [&str; 11] = [
     "dt",
 ];
 
-/// Minimum integer value for a time-named numeric field to be treated as an epoch.
-/// 1e9 covers:
-///   - seconds since 2001-09-09 (modern epoch-in-seconds values)
-///   - any millisecond / microsecond / nanosecond epoch from 1970 onwards
-///
-/// Smaller integers are kept as Float64 to avoid misinterpreting counters,
-/// durations, IDs, etc. as timestamps.
-const EPOCH_PROMOTION_MIN: u64 = 1_000_000_000;
 type EventSchema = Vec<Arc<Field>>;
 
 /// Normalizes a field name by replacing leading '@' with '_'.
@@ -375,37 +367,20 @@ pub fn override_data_type(
             // Normalize field names - replace '@' prefix with '_'
             let mut field_name = field.name().to_string();
             normalize_field_name(&mut field_name);
-            let is_time_named = TIME_FIELD_NAME_PARTS
-                .iter()
-                .any(|part| field_name.to_lowercase().contains(part));
             match (schema_version, map.get(field.name())) {
-                // in V1 for fields named "time"/"date" or such with a string value that
-                // parses as a datetime, promote to Timestamp. Only when `infer_timestamp`
-                // is enabled (default). The flag is settable per dataset (otel-metrics)
-                // via x-p-infer-timestamp=false.
+                // in V1 for new fields in json named "time"/"date" or such and having
+                // inferred type string, that can be parsed as timestamp, use the
+                // timestamp type. Gated on `infer_timestamp` (default true) — settable
+                // per dataset (otel-metrics) via x-p-infer-timestamp=false.
                 // NOTE: support even more datetime string formats
                 (SchemaVersion::V1, Some(Value::String(s)))
                     if infer_timestamp
-                        && is_time_named
+                        && TIME_FIELD_NAME_PARTS
+                            .iter()
+                            .any(|part| field_name.to_lowercase().contains(part))
+                        && field.data_type() == &DataType::Utf8
                         && (DateTime::parse_from_rfc3339(s).is_ok()
                             || DateTime::parse_from_rfc2822(s).is_ok()) =>
-                {
-                    Field::new(
-                        field_name,
-                        DataType::Timestamp(TimeUnit::Millisecond, None),
-                        true,
-                    )
-                }
-                // in V1 for time-named fields with an integer value that's large enough
-                // to plausibly be a Unix epoch (seconds since 2001-09-09, or any
-                // milli/micro/nano-precision epoch), promote to Timestamp. Arrow's JSON
-                // decoder accepts integer epochs for Timestamp(ms) columns. Small ints
-                // (counters, IDs, durations) fall through to the float64 arm.
-                // Floats do not decode for Timestamp and are also left as Float64 below.
-                (SchemaVersion::V1, Some(Value::Number(n)))
-                    if infer_timestamp
-                        && is_time_named
-                        && n.as_u64().is_some_and(|v| v >= EPOCH_PROMOTION_MIN) =>
                 {
                     Field::new(
                         field_name,
@@ -580,6 +555,92 @@ pub fn rename_conflicting_fields_in_json(
             }
         })
         .collect()
+}
+
+/// Per-record fallback when batch-level conflict detection misses a type
+/// mismatch. This happens when a single batch contains records with
+/// incompatible JSON types for the same field (e.g. record A has
+/// `"escaped": "true"` and record B has `"escaped": true`). Arrow's
+/// inference resolves to a single type for the batch (Utf8 wins over Bool),
+/// so `detect_schema_conflicts` may see "inferred Utf8 == storage Utf8" and
+/// not flag a conflict — even though record B's bool would later fail
+/// `fields_mismatch`.
+///
+/// For each record, scan each non-null field. If the value doesn't satisfy
+/// the storage type, rename that field in this specific record to
+/// `<original>_<value-type-suffix>` so it routes to (or creates) a typed
+/// sibling column instead of crashing the batch.
+///
+/// This is a no-op (and skips the per-record loop entirely) when:
+///   - the batch has at most one record — for a single record arrow's
+///     inferred type IS the value's type, so `detect_schema_conflicts` has
+///     already handled it, or
+///   - no inferred field shares both name and type with storage — meaning
+///     arrow couldn't have absorbed a mixed-type record into the storage
+///     type, so per-record mismatches are impossible.
+pub fn rename_per_record_type_mismatches(
+    values: Vec<Value>,
+    inferred_schema: &Schema,
+    existing_schema: &HashMap<String, Arc<Field>>,
+    schema_version: SchemaVersion,
+) -> Vec<Value> {
+    if values.len() <= 1 || existing_schema.is_empty() {
+        return values;
+    }
+    // Bail out unless at least one inferred field collides with storage at
+    // the same type. Without that, arrow's inference can't have hidden a
+    // mixed-type batch behind a matching aggregate type.
+    let needs_check = inferred_schema.fields().iter().any(|f| {
+        existing_schema
+            .get(f.name())
+            .is_some_and(|s| s.data_type() == f.data_type())
+    });
+    if !needs_check {
+        return values;
+    }
+
+    values
+        .into_iter()
+        .map(|value| {
+            let Value::Object(map) = value else {
+                return value;
+            };
+            let new_map: serde_json::Map<String, Value> = map
+                .into_iter()
+                .map(|(key, val)| {
+                    if val.is_null() {
+                        return (key, val);
+                    }
+                    let Some(existing_field) = existing_schema.get(&key) else {
+                        return (key, val);
+                    };
+                    if value_compatible_with_type(&val, existing_field.data_type(), schema_version)
+                    {
+                        return (key, val);
+                    }
+                    let suffix = get_datatype_suffix(&datatype_for_value(&val));
+                    let new_key = format!("{key}_{suffix}");
+                    (new_key, val)
+                })
+                .collect();
+            Value::Object(new_map)
+        })
+        .collect()
+}
+
+/// Best-effort mapping from a JSON value to its arrow DataType. Used only to
+/// pick a type-suffix for the per-record rename (e.g. "bool", "i64", "f64").
+fn datatype_for_value(value: &Value) -> DataType {
+    match value {
+        Value::Null => DataType::Null,
+        Value::Bool(_) => DataType::Boolean,
+        Value::Number(n) if n.is_i64() => DataType::Int64,
+        Value::Number(n) if n.is_u64() => DataType::UInt64,
+        Value::Number(_) => DataType::Float64,
+        Value::String(_) => DataType::Utf8,
+        Value::Array(_) => DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+        Value::Object(_) => DataType::Struct(arrow_schema::Fields::default()),
+    }
 }
 
 #[cfg(test)]
@@ -955,42 +1016,27 @@ mod tests {
     }
 
     #[test]
-    fn override_data_type_promotes_integer_epoch_for_time_named_field() {
-        // Field named "timestamp" inferred as Int64 with a plausible epoch value
-        // (above the threshold) is promoted to Timestamp(ms) when the flag is on.
-        let inferred = Arc::new(Schema::new(vec![Field::new(
-            "timestamp",
-            DataType::Int64,
-            true,
-        )]));
-        let log = json!({"timestamp": 1735689600000_i64});
-
-        let updated = override_data_type(inferred, log, SchemaVersion::V1, true);
-        assert_eq!(
-            updated.field(0).data_type(),
-            &DataType::Timestamp(TimeUnit::Millisecond, None)
-        );
+    fn override_data_type_keeps_integer_in_time_named_field_as_float64() {
+        // Integer values for time-named fields are NOT inferred as timestamps —
+        // {"time": 1234} could be a counter / ID / duration and silently treating
+        // it as 1970-01-01 00:00:01.234 UTC would be wrong. Numbers fall through
+        // to the V1 number-to-float64 arm.
+        for value in [0_i64, 1, 1234, 1_735_689_600_000] {
+            let inferred = Arc::new(Schema::new(vec![Field::new("time", DataType::Int64, true)]));
+            let log = json!({ "time": value });
+            let updated = override_data_type(inferred, log, SchemaVersion::V1, true);
+            assert_eq!(
+                updated.field(0).data_type(),
+                &DataType::Float64,
+                "value {value} should not be promoted to timestamp",
+            );
+        }
     }
 
     #[test]
-    fn override_data_type_keeps_integer_epoch_when_flag_off() {
-        // With flag off, integer epoch values stay numeric (Float64 via the
-        // V1 number-to-float64 normalization), even above the threshold.
-        let inferred = Arc::new(Schema::new(vec![Field::new(
-            "timestamp",
-            DataType::Int64,
-            true,
-        )]));
-        let log = json!({"timestamp": 1735689600000_i64});
-
-        let updated = override_data_type(inferred, log, SchemaVersion::V1, false);
-        assert_eq!(updated.field(0).data_type(), &DataType::Float64);
-    }
-
-    #[test]
-    fn override_data_type_float_epoch_stays_float64() {
-        // Floats are not promoted (Arrow's JSON decoder doesn't accept floats for
-        // Timestamp), so they fall through to the V1 number-to-float64 arm.
+    fn override_data_type_keeps_float_in_time_named_field_as_float64() {
+        // Floats can never decode into Timestamp via Arrow's JSON reader; they
+        // stay Float64.
         let inferred = Arc::new(Schema::new(vec![Field::new(
             "timestamp",
             DataType::Float64,
@@ -1003,89 +1049,139 @@ mod tests {
     }
 
     #[test]
-    fn override_data_type_promotes_non_utf8_string_when_name_matches() {
-        // The Utf8-only gate has been removed: even when the field's prior inferred
-        // type is something else, a parseable RFC3339 string should still trigger
-        // promotion to Timestamp.
-        let inferred = Arc::new(Schema::new(vec![Field::new(
-            "timestamp",
-            DataType::Int64, // pretend a previous inference produced a non-Utf8 type
-            true,
-        )]));
-        let log = json!({"timestamp": "2025-01-01T00:00:00.000Z"});
+    fn rename_per_record_renames_only_offending_record() {
+        // Mixed-type batch: arrow infers Utf8 (string wins), so
+        // detect_schema_conflicts misses the bool record. The per-record pass
+        // must catch it.
+        let mut storage: HashMap<String, Arc<Field>> = HashMap::new();
+        storage.insert(
+            "escaped".to_string(),
+            Arc::new(Field::new("escaped", DataType::Utf8, true)),
+        );
+        // Mirrors what arrow's inference would produce for this mixed batch.
+        let inferred = Schema::new(vec![Field::new("escaped", DataType::Utf8, true)]);
 
-        let updated = override_data_type(inferred, log, SchemaVersion::V1, true);
-        assert_eq!(
-            updated.field(0).data_type(),
-            &DataType::Timestamp(TimeUnit::Millisecond, None)
+        let value_arr = vec![
+            json!({"escaped": "true"}),
+            json!({"escaped": true}),
+            json!({"escaped": null}),
+        ];
+        let renamed =
+            rename_per_record_type_mismatches(value_arr, &inferred, &storage, SchemaVersion::V1);
+
+        assert!(renamed[0].as_object().unwrap().contains_key("escaped"));
+        // bool record routes to escaped_bool
+        assert!(renamed[1].as_object().unwrap().contains_key("escaped_bool"));
+        assert!(!renamed[1].as_object().unwrap().contains_key("escaped"));
+        // null is compatible with any type
+        assert!(renamed[2].as_object().unwrap().contains_key("escaped"));
+    }
+
+    #[test]
+    fn rename_per_record_skips_compatible_values() {
+        // V1: any number is compatible with Float64 columns -> no rename.
+        let mut storage: HashMap<String, Arc<Field>> = HashMap::new();
+        storage.insert(
+            "amount".to_string(),
+            Arc::new(Field::new("amount", DataType::Float64, true)),
+        );
+        let inferred = Schema::new(vec![Field::new("amount", DataType::Float64, true)]);
+        let renamed = rename_per_record_type_mismatches(
+            vec![json!({"amount": 5}), json!({"amount": 2.5})],
+            &inferred,
+            &storage,
+            SchemaVersion::V1,
+        );
+        for v in &renamed {
+            assert!(v.as_object().unwrap().contains_key("amount"));
+        }
+    }
+
+    #[test]
+    fn rename_per_record_skips_unknown_fields() {
+        // Fields not in storage are passed through (let arrow infer them fresh).
+        let storage: HashMap<String, Arc<Field>> = HashMap::new();
+        let inferred = Schema::new(vec![Field::new("new_field", DataType::Boolean, true)]);
+        let renamed = rename_per_record_type_mismatches(
+            vec![json!({"new_field": true}), json!({"new_field": false})],
+            &inferred,
+            &storage,
+            SchemaVersion::V1,
+        );
+        assert!(renamed[0].as_object().unwrap().contains_key("new_field"));
+    }
+
+    #[test]
+    fn rename_per_record_number_into_utf8_uses_int64_suffix() {
+        let mut storage: HashMap<String, Arc<Field>> = HashMap::new();
+        storage.insert(
+            "request_body".to_string(),
+            Arc::new(Field::new("request_body", DataType::Utf8, true)),
+        );
+        let inferred = Schema::new(vec![Field::new("request_body", DataType::Utf8, true)]);
+        // Need >= 2 records for the per-record pass to run; second record's
+        // string keeps inferred type at Utf8 (matches storage), unblocking
+        // the precheck so the int record gets renamed.
+        let renamed = rename_per_record_type_mismatches(
+            vec![
+                json!({"request_body": 200}),
+                json!({"request_body": "hello"}),
+            ],
+            &inferred,
+            &storage,
+            SchemaVersion::V1,
+        );
+        assert!(
+            renamed[0]
+                .as_object()
+                .unwrap()
+                .contains_key("request_body_int64")
         );
     }
 
     #[test]
-    fn override_data_type_non_time_named_integer_stays_float64() {
-        // Field name doesn't contain a time keyword — integer should NOT be
-        // promoted to Timestamp; it falls through to the float64 arm.
-        let inferred = Arc::new(Schema::new(vec![Field::new(
-            "count",
-            DataType::Int64,
-            true,
-        )]));
-        let log = json!({"count": 1735689600_i64});
-
-        let updated = override_data_type(inferred, log, SchemaVersion::V1, true);
-        assert_eq!(updated.field(0).data_type(), &DataType::Float64);
+    fn rename_per_record_short_circuits_for_single_record() {
+        // For a single record, arrow's inferred type IS the value's type, so
+        // detect_schema_conflicts has already covered everything.
+        let mut storage: HashMap<String, Arc<Field>> = HashMap::new();
+        storage.insert(
+            "escaped".to_string(),
+            Arc::new(Field::new("escaped", DataType::Utf8, true)),
+        );
+        // Pretend inferred (incorrectly) matches storage to ensure precheck
+        // would otherwise let us in — single-record gate must short-circuit.
+        let inferred = Schema::new(vec![Field::new("escaped", DataType::Utf8, true)]);
+        let renamed = rename_per_record_type_mismatches(
+            vec![json!({"escaped": true})],
+            &inferred,
+            &storage,
+            SchemaVersion::V1,
+        );
+        // No rename because the loop is skipped for single-record batches.
+        assert!(renamed[0].as_object().unwrap().contains_key("escaped"));
     }
 
     #[test]
-    fn override_data_type_small_integer_in_time_named_field_stays_float64() {
-        // {"time": 1234} must NOT be promoted to Timestamp — it would decode as
-        // 1970-01-01 00:00:01.234 UTC and silently misinterpret a counter / ID /
-        // duration as an epoch. Threshold (1e9) keeps small ints as Float64.
-        for value in [0_i64, 1, 1234, 999_999_999] {
-            let inferred = Arc::new(Schema::new(vec![Field::new("time", DataType::Int64, true)]));
-            let log = json!({ "time": value });
-            let updated = override_data_type(inferred, log, SchemaVersion::V1, true);
-            assert_eq!(
-                updated.field(0).data_type(),
-                &DataType::Float64,
-                "value {value} should NOT be treated as epoch",
-            );
-        }
-    }
-
-    #[test]
-    fn override_data_type_negative_integer_in_time_named_field_stays_float64() {
-        // Negative ints (sentinels like -1, "no value", or rare pre-1970 epochs)
-        // are not promoted — `as_u64` returns None for them.
-        let inferred = Arc::new(Schema::new(vec![Field::new("time", DataType::Int64, true)]));
-        let log = json!({"time": -1_i64});
-
-        let updated = override_data_type(inferred, log, SchemaVersion::V1, true);
-        assert_eq!(updated.field(0).data_type(), &DataType::Float64);
-    }
-
-    #[test]
-    fn override_data_type_promotes_at_threshold_and_above() {
-        // Each of these magnitudes is a plausible epoch in some unit:
-        //   1e9          — seconds since 2001-09-09
-        //   1.7e12       — milliseconds (modern)
-        //   1.7e15       — microseconds (modern)
-        //   1.7e18       — nanoseconds (modern)
-        for value in [
-            1_000_000_000_i64,
-            1_735_689_600_000,
-            1_735_689_600_000_000,
-            1_735_689_600_000_000_000,
-        ] {
-            let inferred = Arc::new(Schema::new(vec![Field::new("ts", DataType::Int64, true)]));
-            let log = json!({ "ts": value });
-            let updated = override_data_type(inferred, log, SchemaVersion::V1, true);
-            assert_eq!(
-                updated.field(0).data_type(),
-                &DataType::Timestamp(TimeUnit::Millisecond, None),
-                "value {value} should be treated as epoch",
-            );
-        }
+    fn rename_per_record_short_circuits_when_no_field_overlap_at_same_type() {
+        // No inferred field shares both name AND type with storage —
+        // arrow can't have absorbed a mixed-type batch, so we skip the loop.
+        let mut storage: HashMap<String, Arc<Field>> = HashMap::new();
+        storage.insert(
+            "escaped".to_string(),
+            Arc::new(Field::new("escaped", DataType::Utf8, true)),
+        );
+        // Inferred has a DIFFERENT type for the shared field — handled by
+        // detect_schema_conflicts as a batch-level rename, not per-record.
+        let inferred = Schema::new(vec![Field::new("escaped", DataType::Boolean, true)]);
+        let renamed = rename_per_record_type_mismatches(
+            vec![json!({"escaped": true}), json!({"escaped": false})],
+            &inferred,
+            &storage,
+            SchemaVersion::V1,
+        );
+        // Per-record loop skipped; values pass through unchanged.
+        assert!(renamed[0].as_object().unwrap().contains_key("escaped"));
+        assert!(renamed[1].as_object().unwrap().contains_key("escaped"));
     }
 
     #[test]

--- a/src/handlers/http/ingest.rs
+++ b/src/handlers/http/ingest.rs
@@ -195,6 +195,7 @@ pub async fn ingest_internal_stream(
             &p_custom_fields,
             TelemetryType::Logs,
             tenant_id,
+            true,
         )?
         .process()?;
 
@@ -712,6 +713,7 @@ mod tests {
                 None,
                 SchemaVersion::V0,
                 &HashMap::new(),
+                true,
             )
             .unwrap();
 
@@ -746,6 +748,7 @@ mod tests {
                 None,
                 SchemaVersion::V0,
                 &HashMap::new(),
+                true,
             )
             .unwrap();
 
@@ -778,7 +781,14 @@ mod tests {
         );
 
         let (rb, _) = json::Event::new(json, Utc::now())
-            .into_recordbatch(&schema, false, None, SchemaVersion::V0, &HashMap::new())
+            .into_recordbatch(
+                &schema,
+                false,
+                None,
+                SchemaVersion::V0,
+                &HashMap::new(),
+                true,
+            )
             .unwrap();
 
         assert_eq!(rb.num_rows(), 1);
@@ -811,7 +821,14 @@ mod tests {
 
         assert!(
             json::Event::new(json, Utc::now())
-                .into_recordbatch(&schema, false, None, SchemaVersion::V0, &HashMap::new())
+                .into_recordbatch(
+                    &schema,
+                    false,
+                    None,
+                    SchemaVersion::V0,
+                    &HashMap::new(),
+                    true
+                )
                 .is_ok() // schema will have new field called b_int64 and the original b will be ignored since it has type mismatch
         );
     }
@@ -830,7 +847,14 @@ mod tests {
         );
 
         let (rb, _) = json::Event::new(json, Utc::now())
-            .into_recordbatch(&schema, false, None, SchemaVersion::V0, &HashMap::new())
+            .into_recordbatch(
+                &schema,
+                false,
+                None,
+                SchemaVersion::V0,
+                &HashMap::new(),
+                true,
+            )
             .unwrap();
 
         assert_eq!(rb.num_rows(), 1);
@@ -862,6 +886,7 @@ mod tests {
                 None,
                 SchemaVersion::V0,
                 &HashMap::new(),
+                true,
             )
             .unwrap();
 
@@ -916,6 +941,7 @@ mod tests {
                 None,
                 SchemaVersion::V0,
                 &HashMap::new(),
+                true,
             )
             .unwrap();
 
@@ -965,7 +991,14 @@ mod tests {
         );
 
         let (rb, _) = json::Event::new(json, Utc::now())
-            .into_recordbatch(&schema, false, None, SchemaVersion::V0, &HashMap::new())
+            .into_recordbatch(
+                &schema,
+                false,
+                None,
+                SchemaVersion::V0,
+                &HashMap::new(),
+                true,
+            )
             .unwrap();
 
         assert_eq!(rb.num_rows(), 3);
@@ -1015,7 +1048,14 @@ mod tests {
 
         assert!(
             json::Event::new(json, Utc::now())
-                .into_recordbatch(&schema, false, None, SchemaVersion::V0, &HashMap::new())
+                .into_recordbatch(
+                    &schema,
+                    false,
+                    None,
+                    SchemaVersion::V0,
+                    &HashMap::new(),
+                    true
+                )
                 .is_err()
         );
     }
@@ -1051,6 +1091,7 @@ mod tests {
                 None,
                 SchemaVersion::V0,
                 &HashMap::new(),
+                true,
             )
             .unwrap();
         assert_eq!(rb.num_rows(), 4);
@@ -1129,6 +1170,7 @@ mod tests {
                 None,
                 SchemaVersion::V1,
                 &HashMap::new(),
+                true,
             )
             .unwrap();
 

--- a/src/handlers/http/ingest.rs
+++ b/src/handlers/http/ingest.rs
@@ -1018,23 +1018,14 @@ mod tests {
     }
 
     #[test]
-    fn arr_schema_mismatch() {
+    fn arr_schema_mismatch_auto_routes_to_typed_sibling() {
+        // Storage has c: Float64. Record 2 has c: 1 (int). In V0, ints aren't
+        // compatible with Float64, so the per-record rename routes that record
+        // to a c_int64 sibling column. Record 1's c: 1.24 stays in c.
         let json = json!([
-            {
-                "a": null,
-                "b": "hello",
-                "c": 1.24
-            },
-            {
-                "a": 1,
-                "b": "hello",
-                "c": 1
-            },
-            {
-                "a": 1,
-                "b": "hello",
-                "c": null
-            },
+            { "a": null, "b": "hello", "c": 1.24 },
+            { "a": 1,    "b": "hello", "c": 1 },
+            { "a": 1,    "b": "hello", "c": null },
         ]);
 
         let schema = fields_to_map(
@@ -1046,18 +1037,21 @@ mod tests {
             .into_iter(),
         );
 
-        assert!(
-            json::Event::new(json, Utc::now())
-                .into_recordbatch(
-                    &schema,
-                    false,
-                    None,
-                    SchemaVersion::V0,
-                    &HashMap::new(),
-                    true
-                )
-                .is_err()
-        );
+        let (rb, _) = json::Event::new(json, Utc::now())
+            .into_recordbatch(
+                &schema,
+                false,
+                None,
+                SchemaVersion::V0,
+                &HashMap::new(),
+                true,
+            )
+            .expect("batch should succeed via per-record type rename");
+
+        assert_eq!(rb.num_rows(), 3);
+        // Original c keeps the float; the int got routed to c_int64.
+        assert!(rb.column_by_name("c").is_some());
+        assert!(rb.column_by_name("c_int64").is_some());
     }
 
     #[test]

--- a/src/handlers/http/logstream.rs
+++ b/src/handlers/http/logstream.rs
@@ -156,7 +156,7 @@ pub async fn detect_schema(Json(json): Json<Value>) -> Result<impl Responder, St
             }
         };
         for flattened_json in flattened_json_arr {
-            schema = override_data_type(schema, flattened_json, SchemaVersion::V1);
+            schema = override_data_type(schema, flattened_json, SchemaVersion::V1, true);
         }
         Ok((web::Json(schema), StatusCode::OK))
     } else {

--- a/src/handlers/http/modal/mod.rs
+++ b/src/handlers/http/modal/mod.rs
@@ -131,7 +131,7 @@ pub trait ParseableServer {
             .max_connections(PARSEABLE.options.max_connections)
             .shutdown_timeout(60);
         tracing::warn!(
-            "Starting Query server with-\nNum workers: {}\nKeep Alive: {}\nRequest timeout: {}\nConnection backlog: {}\nMax connections: {}",
+            "Starting server with-\nNum workers: {}\nKeep Alive: {}\nRequest timeout: {}\nConnection backlog: {}\nMax connections: {}",
             PARSEABLE.options.num_workers,
             PARSEABLE.options.keep_alive,
             PARSEABLE.options.request_timeout,

--- a/src/handlers/http/modal/utils/ingest_utils.rs
+++ b/src/handlers/http/modal/utils/ingest_utils.rs
@@ -171,6 +171,7 @@ pub fn push_logs(
     let custom_partition = stream.get_custom_partition();
     let schema_version = stream.get_schema_version();
     let schema = stream.get_schema_raw();
+    let infer_timestamp = stream.get_infer_timestamp();
     let p_timestamp = Utc::now();
 
     let data = convert_array_to_object(
@@ -207,6 +208,7 @@ pub fn push_logs(
             time_partition.as_ref(),
             schema_version,
             p_custom_fields,
+            infer_timestamp,
         )?;
 
         let event = crate::event::Event {
@@ -241,6 +243,7 @@ pub fn push_logs(
                     p_custom_fields,
                     telemetry_type,
                     tenant_id,
+                    infer_timestamp,
                 )
             })
             .collect();

--- a/src/handlers/http/modal/utils/logstream_utils.rs
+++ b/src/handlers/http/modal/utils/logstream_utils.rs
@@ -48,8 +48,8 @@ pub struct PutStreamHeaders {
 impl Default for PutStreamHeaders {
     fn default() -> Self {
         Self {
-            time_partition: String::new(),
-            time_partition_limit: String::new(),
+            time_partition: String::default(),
+            time_partition_limit: String::default(),
             custom_partition: None,
             static_schema_flag: false,
             update_stream_flag: false,

--- a/src/handlers/http/modal/utils/logstream_utils.rs
+++ b/src/handlers/http/modal/utils/logstream_utils.rs
@@ -39,6 +39,7 @@ pub struct PutStreamHeaders {
     pub stream_type: StreamType,
     pub log_source: LogSource,
     pub telemetry_type: TelemetryType,
+    pub telemetry_type_set: bool,
     pub dataset_tags: Vec<DatasetTag>,
     pub dataset_labels: Vec<String>,
     pub infer_timestamp: bool,
@@ -56,6 +57,7 @@ impl Default for PutStreamHeaders {
             stream_type: StreamType::default(),
             log_source: LogSource::default(),
             telemetry_type: TelemetryType::default(),
+            telemetry_type_set: false,
             dataset_tags: Vec::new(),
             dataset_labels: Vec::new(),
             infer_timestamp: true,
@@ -66,8 +68,16 @@ impl Default for PutStreamHeaders {
 
 impl From<&HeaderMap> for PutStreamHeaders {
     fn from(headers: &HeaderMap) -> Self {
-        let infer_timestamp_header = headers
+        // Track raw header presence first so a present-but-unparseable header
+        // (non-UTF-8 bytes, etc.) still trips downstream validation gates
+        // instead of silently being treated as absent.
+        let infer_timestamp_set = headers.contains_key(INFER_TIMESTAMP_KEY);
+        let infer_timestamp_value = headers
             .get(INFER_TIMESTAMP_KEY)
+            .and_then(|v| v.to_str().ok());
+        let telemetry_type_set = headers.contains_key(TELEMETRY_TYPE_KEY);
+        let telemetry_type_value = headers
+            .get(TELEMETRY_TYPE_KEY)
             .and_then(|v| v.to_str().ok());
         PutStreamHeaders {
             time_partition: headers
@@ -94,10 +104,8 @@ impl From<&HeaderMap> for PutStreamHeaders {
             log_source: headers
                 .get(LOG_SOURCE_KEY)
                 .map_or(LogSource::default(), |v| v.to_str().unwrap().into()),
-            telemetry_type: headers
-                .get(TELEMETRY_TYPE_KEY)
-                .and_then(|v| v.to_str().ok())
-                .map_or(TelemetryType::Logs, TelemetryType::from),
+            telemetry_type: telemetry_type_value.map_or(TelemetryType::Logs, TelemetryType::from),
+            telemetry_type_set,
             dataset_tags: headers
                 .get(DATASET_TAGS_KEY)
                 .or_else(|| headers.get(DATASET_TAG_KEY))
@@ -109,9 +117,8 @@ impl From<&HeaderMap> for PutStreamHeaders {
                 .and_then(|v| v.to_str().ok())
                 .map(parse_dataset_labels)
                 .unwrap_or_default(),
-            infer_timestamp: infer_timestamp_header
-                .is_none_or(|v| !v.eq_ignore_ascii_case("false")),
-            infer_timestamp_set: infer_timestamp_header.is_some(),
+            infer_timestamp: infer_timestamp_value.is_none_or(|v| !v.eq_ignore_ascii_case("false")),
+            infer_timestamp_set,
         }
     }
 }
@@ -121,7 +128,7 @@ mod tests {
     use actix_web::http::header::{HeaderMap, HeaderName, HeaderValue};
 
     use super::PutStreamHeaders;
-    use crate::handlers::INFER_TIMESTAMP_KEY;
+    use crate::handlers::{INFER_TIMESTAMP_KEY, TELEMETRY_TYPE_KEY, TelemetryType};
 
     fn headers_with_infer(value: &str) -> HeaderMap {
         let mut map = HeaderMap::new();
@@ -168,5 +175,53 @@ mod tests {
         let parsed = PutStreamHeaders::from(&headers_with_infer("yes"));
         assert!(parsed.infer_timestamp);
         assert!(parsed.infer_timestamp_set);
+    }
+
+    #[test]
+    fn telemetry_type_set_flag_tracks_header_presence() {
+        // Header absent -> flag is false, value defaults to Logs.
+        let parsed = PutStreamHeaders::from(&HeaderMap::new());
+        assert!(!parsed.telemetry_type_set);
+        assert_eq!(parsed.telemetry_type, TelemetryType::Logs);
+
+        // Header present -> flag is true, value parsed from header.
+        let mut h = HeaderMap::new();
+        h.insert(
+            HeaderName::from_static(TELEMETRY_TYPE_KEY),
+            HeaderValue::from_static("metrics"),
+        );
+        let parsed = PutStreamHeaders::from(&h);
+        assert!(parsed.telemetry_type_set);
+        assert_eq!(parsed.telemetry_type, TelemetryType::Metrics);
+    }
+
+    #[test]
+    fn infer_timestamp_set_when_header_present_but_non_utf8() {
+        // A header with non-UTF-8 bytes must still be treated as "set" so
+        // downstream validation (otel-metrics-only, create-only) sees it and
+        // can reject it. Previously the parsed Option<&str> was used as the
+        // presence signal, letting non-UTF-8 silently bypass validation.
+        let mut h = HeaderMap::new();
+        h.insert(
+            HeaderName::from_static(INFER_TIMESTAMP_KEY),
+            HeaderValue::from_bytes(&[0xff, 0xfe]).unwrap(),
+        );
+        let parsed = PutStreamHeaders::from(&h);
+        assert!(parsed.infer_timestamp_set);
+        // Value couldn't be parsed -> falls back to default (true), but the
+        // _set flag still ensures downstream gates fire.
+        assert!(parsed.infer_timestamp);
+    }
+
+    #[test]
+    fn telemetry_type_set_when_header_present_but_non_utf8() {
+        let mut h = HeaderMap::new();
+        h.insert(
+            HeaderName::from_static(TELEMETRY_TYPE_KEY),
+            HeaderValue::from_bytes(&[0xff, 0xfe]).unwrap(),
+        );
+        let parsed = PutStreamHeaders::from(&h);
+        assert!(parsed.telemetry_type_set);
+        assert_eq!(parsed.telemetry_type, TelemetryType::Logs);
     }
 }

--- a/src/handlers/http/modal/utils/logstream_utils.rs
+++ b/src/handlers/http/modal/utils/logstream_utils.rs
@@ -22,14 +22,14 @@ use crate::{
     event::format::LogSource,
     handlers::{
         CUSTOM_PARTITION_KEY, DATASET_LABELS_KEY, DATASET_TAG_KEY, DATASET_TAGS_KEY, DatasetTag,
-        LOG_SOURCE_KEY, STATIC_SCHEMA_FLAG, STREAM_TYPE_KEY, TELEMETRY_TYPE_KEY,
-        TIME_PARTITION_KEY, TIME_PARTITION_LIMIT_KEY, TelemetryType, UPDATE_STREAM_KEY,
-        parse_dataset_labels, parse_dataset_tags,
+        INFER_TIMESTAMP_KEY, LOG_SOURCE_KEY, STATIC_SCHEMA_FLAG, STREAM_TYPE_KEY,
+        TELEMETRY_TYPE_KEY, TIME_PARTITION_KEY, TIME_PARTITION_LIMIT_KEY, TelemetryType,
+        UPDATE_STREAM_KEY, parse_dataset_labels, parse_dataset_tags,
     },
     storage::StreamType,
 };
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct PutStreamHeaders {
     pub time_partition: String,
     pub time_partition_limit: String,
@@ -41,10 +41,34 @@ pub struct PutStreamHeaders {
     pub telemetry_type: TelemetryType,
     pub dataset_tags: Vec<DatasetTag>,
     pub dataset_labels: Vec<String>,
+    pub infer_timestamp: bool,
+    pub infer_timestamp_set: bool,
+}
+
+impl Default for PutStreamHeaders {
+    fn default() -> Self {
+        Self {
+            time_partition: String::new(),
+            time_partition_limit: String::new(),
+            custom_partition: None,
+            static_schema_flag: false,
+            update_stream_flag: false,
+            stream_type: StreamType::default(),
+            log_source: LogSource::default(),
+            telemetry_type: TelemetryType::default(),
+            dataset_tags: Vec::new(),
+            dataset_labels: Vec::new(),
+            infer_timestamp: true,
+            infer_timestamp_set: false,
+        }
+    }
 }
 
 impl From<&HeaderMap> for PutStreamHeaders {
     fn from(headers: &HeaderMap) -> Self {
+        let infer_timestamp_header = headers
+            .get(INFER_TIMESTAMP_KEY)
+            .and_then(|v| v.to_str().ok());
         PutStreamHeaders {
             time_partition: headers
                 .get(TIME_PARTITION_KEY)
@@ -85,6 +109,64 @@ impl From<&HeaderMap> for PutStreamHeaders {
                 .and_then(|v| v.to_str().ok())
                 .map(parse_dataset_labels)
                 .unwrap_or_default(),
+            infer_timestamp: infer_timestamp_header
+                .is_none_or(|v| !v.eq_ignore_ascii_case("false")),
+            infer_timestamp_set: infer_timestamp_header.is_some(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use actix_web::http::header::{HeaderMap, HeaderName, HeaderValue};
+
+    use super::PutStreamHeaders;
+    use crate::handlers::INFER_TIMESTAMP_KEY;
+
+    fn headers_with_infer(value: &str) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        map.insert(
+            HeaderName::from_static(INFER_TIMESTAMP_KEY),
+            HeaderValue::from_str(value).unwrap(),
+        );
+        map
+    }
+
+    #[test]
+    fn defaults_to_true_when_header_absent() {
+        let headers = HeaderMap::new();
+        let parsed = PutStreamHeaders::from(&headers);
+        assert!(parsed.infer_timestamp);
+        assert!(!parsed.infer_timestamp_set);
+    }
+
+    #[test]
+    fn parses_false_value() {
+        let parsed = PutStreamHeaders::from(&headers_with_infer("false"));
+        assert!(!parsed.infer_timestamp);
+        assert!(parsed.infer_timestamp_set);
+    }
+
+    #[test]
+    fn parses_true_value() {
+        let parsed = PutStreamHeaders::from(&headers_with_infer("true"));
+        assert!(parsed.infer_timestamp);
+        assert!(parsed.infer_timestamp_set);
+    }
+
+    #[test]
+    fn case_insensitive_false() {
+        let parsed = PutStreamHeaders::from(&headers_with_infer("FALSE"));
+        assert!(!parsed.infer_timestamp);
+        assert!(parsed.infer_timestamp_set);
+    }
+
+    #[test]
+    fn unknown_value_treated_as_true() {
+        // Anything not matching "false" (case-insensitive) keeps the default behavior
+        // of inferring timestamps; flag is still considered explicitly set.
+        let parsed = PutStreamHeaders::from(&headers_with_infer("yes"));
+        assert!(parsed.infer_timestamp);
+        assert!(parsed.infer_timestamp_set);
     }
 }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -40,6 +40,7 @@ pub const TELEMETRY_TYPE_KEY: &str = "x-p-telemetry-type";
 pub const DATASET_TAG_KEY: &str = "x-p-dataset-tag";
 pub const DATASET_TAGS_KEY: &str = "x-p-dataset-tags";
 pub const DATASET_LABELS_KEY: &str = "x-p-dataset-labels";
+pub const INFER_TIMESTAMP_KEY: &str = "x-p-infer-timestamp";
 pub const TENANT_ID: &str = "x-p-tenant";
 const COOKIE_AGE_DAYS: usize = 7;
 const SESSION_COOKIE_NAME: &str = "session";

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -104,7 +104,7 @@ impl Default for LogStreamMetadata {
             schema_version: SchemaVersion::default(),
             schema: HashMap::new(),
             retention: None,
-            created_at: String::new(),
+            created_at: String::default(),
             first_event_at: None,
             time_partition: None,
             time_partition_limit: None,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -77,7 +77,7 @@ pub enum SchemaVersion {
     V1,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct LogStreamMetadata {
     pub schema_version: SchemaVersion,
     pub schema: HashMap<String, Arc<Field>>,
@@ -95,6 +95,31 @@ pub struct LogStreamMetadata {
     pub telemetry_type: TelemetryType,
     pub dataset_tags: Vec<DatasetTag>,
     pub dataset_labels: Vec<String>,
+    pub infer_timestamp: bool,
+}
+
+impl Default for LogStreamMetadata {
+    fn default() -> Self {
+        Self {
+            schema_version: SchemaVersion::default(),
+            schema: HashMap::new(),
+            retention: None,
+            created_at: String::new(),
+            first_event_at: None,
+            time_partition: None,
+            time_partition_limit: None,
+            custom_partition: None,
+            static_schema_flag: false,
+            hot_tier_enabled: false,
+            hot_tier: None,
+            stream_type: StreamType::default(),
+            log_source: Vec::new(),
+            telemetry_type: TelemetryType::default(),
+            dataset_tags: Vec::new(),
+            dataset_labels: Vec::new(),
+            infer_timestamp: true,
+        }
+    }
 }
 
 impl LogStreamMetadata {
@@ -112,6 +137,7 @@ impl LogStreamMetadata {
         telemetry_type: TelemetryType,
         dataset_tags: Vec<DatasetTag>,
         dataset_labels: Vec<String>,
+        infer_timestamp: bool,
     ) -> Self {
         LogStreamMetadata {
             created_at: if created_at.is_empty() {
@@ -138,6 +164,7 @@ impl LogStreamMetadata {
             telemetry_type,
             dataset_tags,
             dataset_labels,
+            infer_timestamp,
             ..Default::default()
         }
     }

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -456,6 +456,7 @@ async fn setup_logstream_metadata(
         telemetry_type,
         dataset_tags,
         dataset_labels,
+        infer_timestamp,
         ..
     } = serde_json::from_value(stream_metadata_value).unwrap_or_default();
 
@@ -503,6 +504,7 @@ async fn setup_logstream_metadata(
         telemetry_type,
         dataset_tags,
         dataset_labels,
+        infer_timestamp,
     };
 
     Ok(metadata)

--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -99,6 +99,39 @@ pub const JOIN_COMMUNITY: &str =
     "Join us on Parseable Slack community for questions : https://logg.ing/community";
 pub const STREAM_EXISTS: &str = "Stream exists";
 
+/// For OTel log sources the telemetry_type is fully determined by the log_source.
+/// When the user explicitly sets x-p-telemetry-type and it disagrees with the
+/// implied type for an otel-* source, reject the request. When they don't set it,
+/// derive the value automatically.
+fn resolve_telemetry_type(
+    log_source: &LogSource,
+    telemetry_type: TelemetryType,
+    telemetry_type_set: bool,
+) -> Result<TelemetryType, StreamError> {
+    let expected = match log_source {
+        LogSource::OtelLogs => Some(TelemetryType::Logs),
+        LogSource::OtelMetrics => Some(TelemetryType::Metrics),
+        LogSource::OtelTraces => Some(TelemetryType::Traces),
+        _ => None,
+    };
+    match expected {
+        Some(expected) if telemetry_type_set && telemetry_type != expected => {
+            Err(StreamError::Custom {
+                msg: format!(
+                    "Header {} '{}' does not match log source '{}'. Expected '{}'.",
+                    crate::handlers::TELEMETRY_TYPE_KEY,
+                    telemetry_type,
+                    log_source,
+                    expected,
+                ),
+                status: StatusCode::BAD_REQUEST,
+            })
+        }
+        Some(expected) => Ok(expected),
+        None => Ok(telemetry_type),
+    }
+}
+
 /// Shared state of the Parseable server.
 pub static PARSEABLE: Lazy<Parseable> = Lazy::new(|| {
     // Prompt user for missing env vars before clap validates them.
@@ -669,7 +702,8 @@ impl Parseable {
             update_stream_flag,
             stream_type,
             log_source,
-            telemetry_type,
+            mut telemetry_type,
+            telemetry_type_set,
             dataset_tags,
             dataset_labels,
             infer_timestamp,
@@ -698,6 +732,11 @@ impl Parseable {
                 });
             }
         }
+
+        // For OTel datasets the telemetry_type is implied by the log_source and
+        // they must be consistent. Auto-derive it when not provided; reject any
+        // mismatch when both x-p-log-source and x-p-telemetry-type are set.
+        telemetry_type = resolve_telemetry_type(&log_source, telemetry_type, telemetry_type_set)?;
 
         let stream_in_memory_dont_update =
             self.streams.contains(stream_name, tenant_id) && !update_stream_flag;
@@ -1336,4 +1375,75 @@ pub fn validate_custom_partition(custom_partition: &str) -> Result<(), CreateStr
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn telemetry_type_inferred_for_otel_metrics_when_unset() {
+        let resolved =
+            resolve_telemetry_type(&LogSource::OtelMetrics, TelemetryType::Logs, false).unwrap();
+        assert_eq!(resolved, TelemetryType::Metrics);
+    }
+
+    #[test]
+    fn telemetry_type_inferred_for_otel_traces_when_unset() {
+        let resolved =
+            resolve_telemetry_type(&LogSource::OtelTraces, TelemetryType::Logs, false).unwrap();
+        assert_eq!(resolved, TelemetryType::Traces);
+    }
+
+    #[test]
+    fn telemetry_type_inferred_for_otel_logs_when_unset() {
+        let resolved =
+            resolve_telemetry_type(&LogSource::OtelLogs, TelemetryType::Logs, false).unwrap();
+        assert_eq!(resolved, TelemetryType::Logs);
+    }
+
+    #[test]
+    fn telemetry_type_overridden_for_otel_when_set_to_matching_value() {
+        // Explicit telemetry_type matching the OTel log source is accepted.
+        let resolved =
+            resolve_telemetry_type(&LogSource::OtelMetrics, TelemetryType::Metrics, true).unwrap();
+        assert_eq!(resolved, TelemetryType::Metrics);
+    }
+
+    #[test]
+    fn telemetry_type_mismatch_with_otel_returns_error() {
+        // otel-metrics + telemetry=logs is a contradiction -> 400.
+        let err =
+            resolve_telemetry_type(&LogSource::OtelMetrics, TelemetryType::Logs, true).unwrap_err();
+        match err {
+            StreamError::Custom { msg, status } => {
+                assert_eq!(status, StatusCode::BAD_REQUEST);
+                assert!(msg.contains("otel-metrics"));
+                assert!(msg.contains("metrics"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn telemetry_type_mismatch_otel_traces_vs_metrics() {
+        let err = resolve_telemetry_type(&LogSource::OtelTraces, TelemetryType::Metrics, true)
+            .unwrap_err();
+        assert!(matches!(err, StreamError::Custom { .. }));
+    }
+
+    #[test]
+    fn telemetry_type_passthrough_for_non_otel_log_source() {
+        // For non-otel sources we keep whatever the user supplied (or the default).
+        for source in [
+            LogSource::Json,
+            LogSource::Kinesis,
+            LogSource::Custom("syslog".into()),
+        ] {
+            let resolved = resolve_telemetry_type(&source, TelemetryType::Events, true).unwrap();
+            assert_eq!(resolved, TelemetryType::Events);
+            let resolved = resolve_telemetry_type(&source, TelemetryType::Logs, false).unwrap();
+            assert_eq!(resolved, TelemetryType::Logs);
+        }
+    }
 }

--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -437,6 +437,7 @@ impl Parseable {
         let telemetry_type = stream_metadata.telemetry_type;
         let dataset_tags = stream_metadata.dataset_tags;
         let dataset_labels = stream_metadata.dataset_labels;
+        let infer_timestamp = stream_metadata.infer_timestamp;
         let mut metadata = LogStreamMetadata::new(
             created_at,
             time_partition,
@@ -450,6 +451,7 @@ impl Parseable {
             telemetry_type,
             dataset_tags,
             dataset_labels,
+            infer_timestamp,
         );
 
         // Set hot tier fields from the stored metadata
@@ -591,6 +593,7 @@ impl Parseable {
             tenant_id,
             dataset_tags,
             dataset_labels,
+            true,
         )
         .await?;
 
@@ -669,7 +672,32 @@ impl Parseable {
             telemetry_type,
             dataset_tags,
             dataset_labels,
+            infer_timestamp,
+            infer_timestamp_set,
         } = headers.into();
+
+        // x-p-infer-timestamp can only be set during stream creation, not on update.
+        // It is only valid for otel-metrics datasets.
+        if infer_timestamp_set {
+            if update_stream_flag {
+                return Err(StreamError::Custom {
+                    msg: format!(
+                        "Header {} can only be set at stream creation, not on update",
+                        crate::handlers::INFER_TIMESTAMP_KEY
+                    ),
+                    status: StatusCode::BAD_REQUEST,
+                });
+            }
+            if log_source != LogSource::OtelMetrics {
+                return Err(StreamError::Custom {
+                    msg: format!(
+                        "Header {} is only supported for otel-metrics datasets",
+                        crate::handlers::INFER_TIMESTAMP_KEY
+                    ),
+                    status: StatusCode::BAD_REQUEST,
+                });
+            }
+        }
 
         let stream_in_memory_dont_update =
             self.streams.contains(stream_name, tenant_id) && !update_stream_flag;
@@ -744,6 +772,7 @@ impl Parseable {
             tenant_id,
             dataset_tags,
             dataset_labels,
+            infer_timestamp,
         )
         .await?;
 
@@ -807,6 +836,7 @@ impl Parseable {
         tenant_id: &Option<String>,
         dataset_tags: Vec<DatasetTag>,
         dataset_labels: Vec<String>,
+        infer_timestamp: bool,
     ) -> Result<(), CreateStreamError> {
         // fail to proceed if invalid stream name
         if stream_type != StreamType::Internal {
@@ -833,6 +863,7 @@ impl Parseable {
             telemetry_type,
             dataset_tags: dataset_tags.clone(),
             dataset_labels: dataset_labels.clone(),
+            infer_timestamp,
             ..Default::default()
         };
 
@@ -864,6 +895,7 @@ impl Parseable {
                     telemetry_type,
                     dataset_tags,
                     dataset_labels,
+                    infer_timestamp,
                 );
                 let ingestor_id = INGESTOR_META
                     .get()

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -982,6 +982,10 @@ impl Stream {
         self.metadata.write().expect(LOCK_EXPECT).custom_partition = custom_partition.cloned();
     }
 
+    pub fn get_infer_timestamp(&self) -> bool {
+        self.metadata.read().expect(LOCK_EXPECT).infer_timestamp
+    }
+
     pub fn set_hot_tier(&self, hot_tier: Option<StreamHotTier>) {
         let mut metadata = self.metadata.write().expect(LOCK_EXPECT);
         metadata.hot_tier.clone_from(&hot_tier);

--- a/src/query/stream_schema_provider.rs
+++ b/src/query/stream_schema_provider.rs
@@ -397,7 +397,11 @@ impl StandardTableProvider {
                     .and_modify(|x| {
                         if let Some((stats, col_stats)) = x.as_ref().cloned().zip(col.stats.clone())
                         {
-                            *x = Some(stats.update(col_stats));
+                            // update() returns None on type mismatch (e.g. column
+                            // historically written as both Utf8 and Timestamp(ms)).
+                            // Dropping to None here makes the planner skip min/max
+                            // pushdown for this column instead of crashing the worker.
+                            *x = stats.update(col_stats);
                         }
                     })
                     .or_insert_with(|| col.stats.as_ref().cloned());

--- a/src/storage/field_stats.rs
+++ b/src/storage/field_stats.rs
@@ -192,6 +192,7 @@ pub async fn calculate_field_stats(
             &p_custom_fields,
             TelemetryType::Logs,
             tenant_id,
+            true,
         )?
         .process()?;
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -135,6 +135,12 @@ pub struct ObjectStoreFormat {
     pub dataset_tags: Vec<DatasetTag>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dataset_labels: Vec<String>,
+    #[serde(default = "default_infer_timestamp")]
+    pub infer_timestamp: bool,
+}
+
+fn default_infer_timestamp() -> bool {
+    true
 }
 
 impl MetastoreObject for ObjectStoreFormat {
@@ -179,6 +185,8 @@ pub struct StreamInfo {
     pub dataset_tags: Vec<DatasetTag>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dataset_labels: Vec<String>,
+    #[serde(default = "default_infer_timestamp")]
+    pub infer_timestamp: bool,
 }
 
 impl StreamInfo {
@@ -203,6 +211,7 @@ impl StreamInfo {
             hot_tier_enabled: metadata.hot_tier_enabled,
             dataset_tags: metadata.dataset_tags.clone(),
             dataset_labels: metadata.dataset_labels.clone(),
+            infer_timestamp: metadata.infer_timestamp,
         }
     }
 }
@@ -286,6 +295,7 @@ impl Default for ObjectStoreFormat {
             telemetry_type: TelemetryType::Logs,
             dataset_tags: Vec::new(),
             dataset_labels: Vec::new(),
+            infer_timestamp: true,
         }
     }
 }


### PR DESCRIPTION
- add x-p-infer-timestamp header (default true) accepted only at stream creation and only for otel-metrics datasets.
- recognise integer epochs for time-named fields
- harden TypedStatistics::update against the cross-type stats merge that was previously panicking with "Cannot update wrong types" when a single column had been written under two different Arrow types across parquet files, on type mismatch it logs a warning and returns None, and callers (catalog/manifest.rs, query/stream_schema_provider.rs) drop the stats to None instead of crashing the worker. Min/max pushdown is skipped for the affected column, but the query continues.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dataset-level timestamp inference now enabled by default and controllable via the x-p-infer-timestamp header; time-like strings/integers can be promoted to timestamps. Stream metadata exposes this setting.

  * Per-record type-fallbacks and improved header handling to accept mixed JSON types and non-UTF8 header presence; some schema mismatches now route data into typed sibling columns instead of failing.

* **Bug Fixes**
  * Safer column statistics merging: invalid or mixed float ranges are rejected with warnings, preventing crashes and avoiding invalid min/max pushdown.

* **Chores**
  * Tests and validations updated to cover these behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->