### PR TITLE
fix: Ingestion staging sync issue

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -541,6 +541,25 @@ pub struct Options {
         help = "Max allowed age gap (in hours) between events within the same node, relative to the reference event"
     )]
     pub event_max_chunk_age: u64,
+
+    // enable multipart uploads to object store
+    #[arg(
+        long,
+        env = "P_ENABLE_MULTIPART",
+        default_value = "true",
+        help = "Enable multipart uploads to object store"
+    )]
+    pub enable_multipart: bool,
+
+    // minimum multipart upload size
+    #[arg(
+        long,
+        env = "P_MULTIPART_MIN_SIZE",
+        default_value = "26214400",
+        value_parser = clap::value_parser!(u64).range(26214400..),
+        help = "Minimum file size for multipart uploads (25MB)"
+    )]
+    pub min_multipart_size: u64,
 }
 
 #[derive(Parser, Debug)]

--- a/src/handlers/http/modal/ingest_server.rs
+++ b/src/handlers/http/modal/ingest_server.rs
@@ -20,7 +20,6 @@ use std::sync::Arc;
 use std::thread;
 
 use actix_web::Scope;
-use actix_web::middleware::from_fn;
 use actix_web::web;
 use actix_web_prometheus::PrometheusMetrics;
 use async_trait::async_trait;
@@ -40,7 +39,7 @@ use crate::{
         http::{
             base_path, ingest, logstream,
             middleware::{DisAllowRootUser, RouteExt},
-            resource_check, role,
+            role,
         },
     },
     migration,
@@ -79,9 +78,7 @@ impl ParseableServer for IngestServer {
                     .service(Server::get_readiness_factory())
                     .service(Server::get_demo_data_webscope()),
             )
-            .service(Server::get_ingest_otel_factory().wrap(from_fn(
-                resource_check::check_resource_utilization_middleware,
-            )));
+            .service(Server::get_ingest_otel_factory());
     }
 
     async fn load_metadata(&self) -> anyhow::Result<Option<Bytes>> {
@@ -237,10 +234,7 @@ impl IngestServer {
                             web::post()
                                 .to(ingest::post_event)
                                 .authorize_for_resource(Action::Ingest),
-                        )
-                        .wrap(from_fn(
-                            resource_check::check_resource_utilization_middleware,
-                        )),
+                        ),
                 )
                 .service(
                     web::resource("/sync")

--- a/src/handlers/http/modal/ingest_server.rs
+++ b/src/handlers/http/modal/ingest_server.rs
@@ -68,9 +68,7 @@ impl ParseableServer for IngestServer {
             .service(
                 // Base path "{url}/api/v1"
                 web::scope(&base_path())
-                    .service(Server::get_ingest_factory().wrap(from_fn(
-                        resource_check::check_resource_utilization_middleware,
-                    )))
+                    .service(Server::get_ingest_factory())
                     .service(Self::logstream_api())
                     .service(Server::get_about_factory())
                     .service(Self::analytics_factory())
@@ -120,11 +118,7 @@ impl ParseableServer for IngestServer {
         migration::run_migration(&PARSEABLE).await?;
 
         // local sync on init
-        let startup_sync_handle = tokio::spawn(async {
-            if let Err(e) = sync_start().await {
-                tracing::warn!("local sync on server start failed: {e}");
-            }
-        });
+        thread::spawn(sync_start);
 
         // Run sync on a background thread
         let (cancel_tx, cancel_rx) = oneshot::channel();
@@ -136,9 +130,6 @@ impl ParseableServer for IngestServer {
         let result = self.start(shutdown_rx, prometheus.clone(), None).await;
         // Cancel sync jobs
         cancel_tx.send(()).expect("Cancellation should not fail");
-        if let Err(join_err) = startup_sync_handle.await {
-            tracing::warn!("startup sync task panicked: {join_err}");
-        }
         result
     }
 }

--- a/src/handlers/http/modal/query_server.rs
+++ b/src/handlers/http/modal/query_server.rs
@@ -25,12 +25,11 @@ use crate::handlers::http::logstream;
 use crate::handlers::http::max_event_payload_size;
 use crate::handlers::http::middleware::{DisAllowRootUser, RouteExt};
 use crate::handlers::http::modal::initialize_hot_tier_metadata_on_startup;
-use crate::handlers::http::{base_path, prism_base_path, resource_check};
+use crate::handlers::http::{base_path, prism_base_path};
 use crate::handlers::http::{rbac, role};
 use crate::hottier::HotTierManager;
 use crate::rbac::role::Action;
 use crate::{analytics, migration, storage, sync};
-use actix_web::middleware::from_fn;
 use actix_web::web::{ServiceConfig, resource};
 use actix_web::{Scope, web};
 use actix_web_prometheus::PrometheusMetrics;
@@ -54,9 +53,7 @@ impl ParseableServer for QueryServer {
             .service(
                 web::scope(&base_path())
                     .service(Server::get_correlation_webscope())
-                    .service(Server::get_query_factory().wrap(from_fn(
-                        resource_check::check_resource_utilization_middleware,
-                    )))
+                    .service(Server::get_query_factory())
                     .service(Server::get_liveness_factory())
                     .service(Server::get_readiness_factory())
                     .service(Server::get_about_factory())
@@ -69,9 +66,7 @@ impl ParseableServer for QueryServer {
                     .service(Server::get_oauth_webscope())
                     .service(Server::get_roles_webscope())
                     .service(Self::get_user_role_webscope())
-                    .service(Server::get_counts_webscope().wrap(from_fn(
-                        resource_check::check_resource_utilization_middleware,
-                    )))
+                    .service(Server::get_counts_webscope())
                     .service(Server::get_metrics_webscope())
                     .service(Server::get_alerts_webscope())
                     .service(Server::get_targets_webscope())

--- a/src/handlers/http/modal/query_server.rs
+++ b/src/handlers/http/modal/query_server.rs
@@ -29,7 +29,6 @@ use crate::handlers::http::{base_path, prism_base_path, resource_check};
 use crate::handlers::http::{rbac, role};
 use crate::hottier::HotTierManager;
 use crate::rbac::role::Action;
-use crate::sync::sync_start;
 use crate::{analytics, migration, storage, sync};
 use actix_web::middleware::from_fn;
 use actix_web::web::{ServiceConfig, resource};
@@ -132,12 +131,6 @@ impl ParseableServer for QueryServer {
             analytics::init_analytics_scheduler()?;
         }
 
-        // local sync on init
-        let startup_sync_handle = tokio::spawn(async {
-            if let Err(e) = sync_start().await {
-                tracing::warn!("local sync on server start failed: {e}");
-            }
-        });
         if let Some(hot_tier_manager) = HotTierManager::global() {
             // Initialize hot tier metadata files for streams that have hot tier configuration
             // but don't have local hot tier metadata files yet
@@ -158,9 +151,6 @@ impl ParseableServer for QueryServer {
             .await?;
         // Cancel sync jobs
         cancel_tx.send(()).expect("Cancellation should not fail");
-        if let Err(join_err) = startup_sync_handle.await {
-            tracing::warn!("startup sync task panicked: {join_err}");
-        }
         Ok(result)
     }
 }

--- a/src/handlers/http/modal/server.rs
+++ b/src/handlers/http/modal/server.rs
@@ -78,12 +78,8 @@ impl ParseableServer for Server {
             .service(
                 web::scope(&base_path())
                     .service(Self::get_correlation_webscope())
-                    .service(Self::get_query_factory().wrap(from_fn(
-                        resource_check::check_resource_utilization_middleware,
-                    )))
-                    .service(Self::get_ingest_factory().wrap(from_fn(
-                        resource_check::check_resource_utilization_middleware,
-                    )))
+                    .service(Self::get_query_factory())
+                    .service(Self::get_ingest_factory())
                     .service(Self::get_liveness_factory())
                     .service(Self::get_readiness_factory())
                     .service(Self::get_about_factory())
@@ -96,9 +92,7 @@ impl ParseableServer for Server {
                     .service(Self::get_oauth_webscope())
                     .service(Self::get_user_role_webscope())
                     .service(Self::get_roles_webscope())
-                    .service(Self::get_counts_webscope().wrap(from_fn(
-                        resource_check::check_resource_utilization_middleware,
-                    )))
+                    .service(Self::get_counts_webscope())
                     .service(Self::get_alerts_webscope())
                     .service(Self::get_targets_webscope())
                     .service(Self::get_metrics_webscope())
@@ -140,11 +134,7 @@ impl ParseableServer for Server {
         storage::retention::load_retention_from_global();
 
         // local sync on init
-        let startup_sync_handle = tokio::spawn(async {
-            if let Err(e) = sync_start().await {
-                tracing::warn!("local sync on server start failed: {e}");
-            }
-        });
+        thread::spawn(sync_start);
 
         if let Some(hot_tier_manager) = HotTierManager::global() {
             // Initialize hot tier metadata files for streams that have hot tier configuration
@@ -171,9 +161,6 @@ impl ParseableServer for Server {
             .await;
         // Cancel sync jobs
         cancel_tx.send(()).expect("Cancellation should not fail");
-        if let Err(join_err) = startup_sync_handle.await {
-            tracing::warn!("startup sync task panicked: {join_err}");
-        }
         return result;
     }
 }

--- a/src/handlers/http/modal/server.rs
+++ b/src/handlers/http/modal/server.rs
@@ -30,7 +30,6 @@ use crate::handlers::http::middleware::IntraClusterRequest;
 use crate::handlers::http::modal::initialize_hot_tier_metadata_on_startup;
 use crate::handlers::http::prism_base_path;
 use crate::handlers::http::query;
-use crate::handlers::http::resource_check;
 use crate::handlers::http::targets;
 use crate::handlers::http::users::dashboards;
 use crate::handlers::http::users::filters;
@@ -44,7 +43,6 @@ use crate::sync::sync_start;
 
 use actix_web::Resource;
 use actix_web::Scope;
-use actix_web::middleware::from_fn;
 use actix_web::web;
 use actix_web::web::resource;
 use actix_web_prometheus::PrometheusMetrics;
@@ -105,9 +103,7 @@ impl ParseableServer for Server {
                     .service(Server::get_prism_datasets())
                     .service(Self::get_dataset_stats_webscope()),
             )
-            .service(Self::get_ingest_otel_factory().wrap(from_fn(
-                resource_check::check_resource_utilization_middleware,
-            )))
+            .service(Self::get_ingest_otel_factory())
             .service(Self::get_generated());
     }
 
@@ -447,10 +443,7 @@ impl Server {
                             .route(
                                 web::post()
                                     .to(ingest::post_event)
-                                    .authorize_for_resource(Action::Ingest)
-                                    .wrap(from_fn(
-                                        resource_check::check_resource_utilization_middleware,
-                                    )),
+                                    .authorize_for_resource(Action::Ingest),
                             )
                             // DELETE "/logstream/{logstream}" ==> Delete log stream
                             .route(

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -33,6 +33,7 @@ use parquet::{
     schema::types::ColumnPath,
 };
 use relative_path::RelativePathBuf;
+use std::sync::PoisonError;
 use std::{
     collections::{HashMap, HashSet},
     fs::{self, File, OpenOptions, remove_file, write},
@@ -41,7 +42,6 @@ use std::{
     sync::{Arc, Mutex, RwLock},
     time::{Instant, SystemTime, UNIX_EPOCH},
 };
-use std::{io::BufReader, sync::PoisonError};
 use tokio::task::JoinSet;
 use tracing::{Instrument, error, info, info_span, instrument, trace, warn};
 use ulid::Ulid;
@@ -1118,50 +1118,47 @@ impl Stream {
                         // Try to validate the arrow file by reading its schema
                         match File::open(&path) {
                             Ok(file) => {
-                                match StreamReader::try_new(BufReader::new(file), None) {
-                                    Ok(_reader) => {
-                                        // File has valid schema, rename to .arrows
-                                        let mut arrow_path = path.clone();
-                                        arrow_path.set_extension(ARROW_FILE_EXTENSION);
-
-                                        // If arrow file with same name exists, generate a unique name
-                                        if arrow_path.exists() {
-                                            let file_name =
-                                                arrow_path.file_name().unwrap().to_string_lossy();
-                                            if let Some(date_pos) = file_name.find(".date") {
-                                                let random_suffix = ulid::Ulid::new().to_string();
-                                                let new_name = format!(
-                                                    "{}{}",
-                                                    random_suffix,
-                                                    &file_name[date_pos..]
-                                                );
-                                                arrow_path.set_file_name(new_name);
-                                            }
-                                        }
-
-                                        info!(
-                                            "Recovering orphaned .part file: {:?} -> {:?} for stream {}",
-                                            path, arrow_path, self.stream_name
+                                if let Err(e) = StreamReader::try_new_buffered(file, None) {
+                                    // File is invalid/corrupted, remove it
+                                    warn!(
+                                        "Removing invalid/corrupted .part file: {:?} for stream {}: {e}",
+                                        path, self.stream_name
+                                    );
+                                    if let Err(e) = remove_file(&path) {
+                                        error!(
+                                            "Failed to remove invalid .part file {:?}: {e}",
+                                            path
                                         );
-                                        if let Err(e) = std::fs::rename(&path, &arrow_path) {
-                                            error!(
-                                                "Failed to rename .part file {:?} to {:?}: {e}",
-                                                path, arrow_path
+                                    }
+                                } else {
+                                    // File has valid schema, rename to .arrows
+                                    let mut arrow_path = path.clone();
+                                    arrow_path.set_extension(ARROW_FILE_EXTENSION);
+
+                                    // If arrow file with same name exists, generate a unique name
+                                    if arrow_path.exists() {
+                                        let file_name =
+                                            arrow_path.file_name().unwrap().to_string_lossy();
+                                        if let Some(date_pos) = file_name.find(".date") {
+                                            let random_suffix = ulid::Ulid::new().to_string();
+                                            let new_name = format!(
+                                                "{}{}",
+                                                random_suffix,
+                                                &file_name[date_pos..]
                                             );
+                                            arrow_path.set_file_name(new_name);
                                         }
                                     }
-                                    Err(e) => {
-                                        // File is invalid/corrupted, remove it
-                                        warn!(
-                                            "Removing invalid/corrupted .part file: {:?} for stream {}: {e}",
-                                            path, self.stream_name
+
+                                    info!(
+                                        "Recovering orphaned .part file: {:?} -> {:?} for stream {}",
+                                        path, arrow_path, self.stream_name
+                                    );
+                                    if let Err(e) = std::fs::rename(&path, &arrow_path) {
+                                        error!(
+                                            "Failed to rename .part file {:?} to {:?}: {e}",
+                                            path, arrow_path
                                         );
-                                        if let Err(e) = remove_file(&path) {
-                                            error!(
-                                                "Failed to remove invalid .part file {:?}: {e}",
-                                                path
-                                            );
-                                        }
                                     }
                                 }
                             }
@@ -1201,7 +1198,7 @@ impl Stream {
         // For regular cycles, use false to only flush non-current writers
         let forced = init_signal || shutdown_signal;
         self.flush(forced);
-        trace!(
+        info!(
             "Flushing stream ({}) took: {}s",
             self.stream_name,
             start_flush.elapsed().as_secs_f64()
@@ -1210,7 +1207,7 @@ impl Stream {
         let start_convert = Instant::now();
 
         self.prepare_parquet(init_signal, shutdown_signal, tenant_id)?;
-        trace!(
+        info!(
             "Converting arrows to parquet on stream ({}) took: {}s",
             self.stream_name,
             start_convert.elapsed().as_secs_f64()

--- a/src/storage/azure_blob.rs
+++ b/src/storage/azure_blob.rs
@@ -47,14 +47,13 @@ use crate::{
         increment_files_scanned_in_object_store_calls_by_date,
         increment_object_store_calls_by_date,
     },
-    parseable::{DEFAULT_TENANT, LogStream},
+    parseable::{DEFAULT_TENANT, LogStream, PARSEABLE},
 };
 
 use super::{
-    CONNECT_TIMEOUT_SECS, MIN_MULTIPART_UPLOAD_SIZE, ObjectStorage, ObjectStorageError,
-    ObjectStorageProvider, PARSEABLE_ROOT_DIRECTORY, REQUEST_TIMEOUT_SECS,
-    STREAM_METADATA_FILE_NAME, metrics_layer::MetricLayer, object_storage::parseable_json_path,
-    to_object_store_path,
+    CONNECT_TIMEOUT_SECS, ObjectStorage, ObjectStorageError, ObjectStorageProvider,
+    PARSEABLE_ROOT_DIRECTORY, REQUEST_TIMEOUT_SECS, STREAM_METADATA_FILE_NAME,
+    metrics_layer::MetricLayer, object_storage::parseable_json_path, to_object_store_path,
 };
 
 #[derive(Debug, Clone, clap::Args)]
@@ -390,7 +389,8 @@ impl BlobStore {
 
         let meta = file.metadata().await?;
         let total_size = meta.len() as usize;
-        if total_size < MIN_MULTIPART_UPLOAD_SIZE {
+        let min_multipart_size = PARSEABLE.options.min_multipart_size as usize;
+        if total_size < min_multipart_size || !PARSEABLE.options.enable_multipart {
             let mut data = Vec::new();
             file.read_to_end(&mut data).await?;
             let result = self.client.put(location, data.into()).await;
@@ -422,19 +422,19 @@ impl BlobStore {
 
             // let mut upload_parts = Vec::new();
 
-            let has_final_partial_part = !total_size.is_multiple_of(MIN_MULTIPART_UPLOAD_SIZE);
-            let num_full_parts = total_size / MIN_MULTIPART_UPLOAD_SIZE;
+            let has_final_partial_part = !total_size.is_multiple_of(min_multipart_size);
+            let num_full_parts = total_size / min_multipart_size;
             let total_parts = num_full_parts + if has_final_partial_part { 1 } else { 0 };
 
             // Upload each part with metrics
             for part_number in 0..(total_parts) {
-                let start_pos = part_number * MIN_MULTIPART_UPLOAD_SIZE;
+                let start_pos = part_number * min_multipart_size;
                 let end_pos = if part_number == num_full_parts && has_final_partial_part {
                     // Last part might be smaller than 5MB (which is allowed)
                     total_size
                 } else {
                     // All other parts must be at least 5MB
-                    start_pos + MIN_MULTIPART_UPLOAD_SIZE
+                    start_pos + min_multipart_size
                 };
 
                 // Extract this part's data

--- a/src/storage/azure_blob.rs
+++ b/src/storage/azure_blob.rs
@@ -379,13 +379,6 @@ impl BlobStore {
         let mut file = OpenOptions::new().read(true).open(path).await?;
         let location = &to_object_store_path(key);
         let tenant = tenant_id.as_deref().unwrap_or(DEFAULT_TENANT);
-        let async_writer = self.client.put_multipart(location).await;
-        let mut async_writer = match async_writer {
-            Ok(writer) => writer,
-            Err(err) => {
-                return Err(err.into());
-            }
-        };
 
         let meta = file.metadata().await?;
         let total_size = meta.len() as usize;
@@ -413,10 +406,17 @@ impl BlobStore {
                     return Err(err.into());
                 }
             }
-            // async_writer.put_part(data.into()).await?;
-            // async_writer.complete().await?;
+
             return Ok(());
         } else {
+            let async_writer = self.client.put_multipart(location).await;
+            let mut async_writer = match async_writer {
+                Ok(writer) => writer,
+                Err(err) => {
+                    return Err(err.into());
+                }
+            };
+
             let mut data = Vec::new();
             file.read_to_end(&mut data).await?;
 

--- a/src/storage/field_stats.rs
+++ b/src/storage/field_stats.rs
@@ -458,7 +458,8 @@ fn format_arrow_value(array: &dyn Array, idx: usize) -> String {
     }
 }
 
-fn extract_datetime_from_parquet_path_regex(
+#[inline(always)]
+pub fn extract_datetime_from_parquet_path_regex(
     parquet_path: &Path,
 ) -> Result<DateTime<Utc>, Box<dyn std::error::Error>> {
     let filename = parquet_path

--- a/src/storage/field_stats.rs
+++ b/src/storage/field_stats.rs
@@ -115,7 +115,7 @@ pub async fn calculate_field_stats(
     max_field_statistics: usize,
     tenant_id: &Option<String>,
 ) -> Result<bool, PostError> {
-    //create datetime from timestamp present in parquet path
+    // create datetime from timestamp present in parquet path
     let parquet_ts = extract_datetime_from_parquet_path_regex(parquet_path).map_err(|e| {
         PostError::Invalid(anyhow::anyhow!(
             "Failed to extract datetime from parquet path: {}",

--- a/src/storage/gcs.rs
+++ b/src/storage/gcs.rs
@@ -24,7 +24,7 @@ use crate::{
         increment_files_scanned_in_object_store_calls_by_date,
         increment_object_store_calls_by_date,
     },
-    parseable::{DEFAULT_TENANT, LogStream},
+    parseable::{DEFAULT_TENANT, LogStream, PARSEABLE},
 };
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -49,10 +49,9 @@ use tokio::{fs::OpenOptions, io::AsyncReadExt};
 use tracing::error;
 
 use super::{
-    CONNECT_TIMEOUT_SECS, MIN_MULTIPART_UPLOAD_SIZE, ObjectStorage, ObjectStorageError,
-    ObjectStorageProvider, PARSEABLE_ROOT_DIRECTORY, REQUEST_TIMEOUT_SECS,
-    STREAM_METADATA_FILE_NAME, metrics_layer::MetricLayer, object_storage::parseable_json_path,
-    to_object_store_path,
+    CONNECT_TIMEOUT_SECS, ObjectStorage, ObjectStorageError, ObjectStorageProvider,
+    PARSEABLE_ROOT_DIRECTORY, REQUEST_TIMEOUT_SECS, STREAM_METADATA_FILE_NAME,
+    metrics_layer::MetricLayer, object_storage::parseable_json_path, to_object_store_path,
 };
 
 #[derive(Debug, Clone, clap::Args)]
@@ -354,7 +353,8 @@ impl Gcs {
 
         let meta = file.metadata().await?;
         let total_size = meta.len() as usize;
-        if total_size < MIN_MULTIPART_UPLOAD_SIZE {
+        let min_multipart_size = PARSEABLE.options.min_multipart_size as usize;
+        if total_size < min_multipart_size || !PARSEABLE.options.enable_multipart {
             let mut data = Vec::new();
             file.read_to_end(&mut data).await?;
 
@@ -383,19 +383,19 @@ impl Gcs {
             let mut data = Vec::new();
             file.read_to_end(&mut data).await?;
 
-            let has_final_partial_part = !total_size.is_multiple_of(MIN_MULTIPART_UPLOAD_SIZE);
-            let num_full_parts = total_size / MIN_MULTIPART_UPLOAD_SIZE;
+            let has_final_partial_part = !total_size.is_multiple_of(min_multipart_size);
+            let num_full_parts = total_size / min_multipart_size;
             let total_parts = num_full_parts + if has_final_partial_part { 1 } else { 0 };
 
             // Upload each part with metrics
             for part_number in 0..(total_parts) {
-                let start_pos = part_number * MIN_MULTIPART_UPLOAD_SIZE;
+                let start_pos = part_number * min_multipart_size;
                 let end_pos = if part_number == num_full_parts && has_final_partial_part {
                     // Last part might be smaller than 5MB (which is allowed)
                     total_size
                 } else {
                     // All other parts must be at least 5MB
-                    start_pos + MIN_MULTIPART_UPLOAD_SIZE
+                    start_pos + min_multipart_size
                 };
 
                 // Extract this part's data

--- a/src/storage/gcs.rs
+++ b/src/storage/gcs.rs
@@ -343,14 +343,6 @@ impl Gcs {
         let mut file = OpenOptions::new().read(true).open(path).await?;
         let location = &to_object_store_path(key);
         let tenant = tenant_id.as_deref().unwrap_or(DEFAULT_TENANT);
-        let async_writer = self.client.put_multipart(location).await;
-        let mut async_writer = match async_writer {
-            Ok(writer) => writer,
-            Err(err) => {
-                return Err(err.into());
-            }
-        };
-
         let meta = file.metadata().await?;
         let total_size = meta.len() as usize;
         let min_multipart_size = PARSEABLE.options.min_multipart_size as usize;
@@ -380,6 +372,13 @@ impl Gcs {
             }
             return Ok(());
         } else {
+            let async_writer = self.client.put_multipart(location).await;
+            let mut async_writer = match async_writer {
+                Ok(writer) => writer,
+                Err(err) => {
+                    return Err(err.into());
+                }
+            };
             let mut data = Vec::new();
             file.read_to_end(&mut data).await?;
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -85,7 +85,6 @@ pub const CURRENT_SCHEMA_VERSION: &str = "v7";
 const CONNECT_TIMEOUT_SECS: u64 = 5;
 const REQUEST_TIMEOUT_SECS: u64 = 300;
 
-pub const MIN_MULTIPART_UPLOAD_SIZE: usize = 25 * 1024 * 1024;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ObjectStoreFormat {
     /// Version of schema registry

--- a/src/storage/object_storage.rs
+++ b/src/storage/object_storage.rs
@@ -35,6 +35,7 @@ use std::fmt::Debug;
 use std::fs::{File, remove_file};
 use std::num::NonZeroU32;
 use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
@@ -61,6 +62,7 @@ use crate::storage::SETTINGS_ROOT_DIRECTORY;
 use crate::storage::TARGETS_ROOT_DIRECTORY;
 use crate::storage::field_stats::DATASET_STATS_STREAM_NAME;
 use crate::storage::field_stats::calculate_field_stats;
+use crate::sync::ACTIVE_OBJECT_STORE_SYNC_FILES;
 
 use super::{
     ALERTS_ROOT_DIRECTORY, MANIFEST_FILE, ObjectStorageError, ObjectStoreFormat,
@@ -1022,8 +1024,25 @@ async fn process_parquet_files(
     let mut join_set = JoinSet::new();
     let object_store = PARSEABLE.storage().get_object_store();
 
+    // collect all parquet files to upload
+    let parquet_paths = {
+        let mut guard = ACTIVE_OBJECT_STORE_SYNC_FILES.write().await;
+
+        let parquet_paths: Vec<PathBuf> = upload_context
+            .stream
+            .parquet_files()
+            .into_par_iter()
+            .filter(|p| !guard.contains(p))
+            .collect();
+
+        let mut ret = Vec::with_capacity(parquet_paths.len());
+        ret.clone_from(&parquet_paths);
+        guard.extend(parquet_paths);
+        ret
+    };
+
     // Spawn upload tasks for each parquet file
-    for path in upload_context.stream.parquet_files() {
+    for path in parquet_paths {
         spawn_parquet_upload_task(
             &mut join_set,
             semaphore.clone(),
@@ -1111,6 +1130,13 @@ async fn collect_upload_results(
         }
     }
 
+    // successfully uploaded files, remove from in-mem hashset
+    {
+        let mut guard = ACTIVE_OBJECT_STORE_SYNC_FILES.write().await;
+        for (path, _) in uploaded_files.iter() {
+            guard.remove(path);
+        }
+    }
     let manifest_files: Vec<_> = uploaded_files
         .into_par_iter()
         .map(|(path, manifest_file)| {

--- a/src/storage/object_storage.rs
+++ b/src/storage/object_storage.rs
@@ -62,6 +62,7 @@ use crate::storage::SETTINGS_ROOT_DIRECTORY;
 use crate::storage::TARGETS_ROOT_DIRECTORY;
 use crate::storage::field_stats::DATASET_STATS_STREAM_NAME;
 use crate::storage::field_stats::calculate_field_stats;
+use crate::storage::field_stats::extract_datetime_from_parquet_path_regex;
 use crate::sync::ACTIVE_OBJECT_STORE_SYNC_FILES;
 
 use super::{
@@ -104,7 +105,7 @@ async fn upload_single_parquet_file(
     stream_name: String,
     schema: Arc<Schema>,
     tenant_id: Option<String>,
-) -> Result<UploadResult, ObjectStorageError> {
+) -> Result<UploadResult, (PathBuf, ObjectStorageError)> {
     let filename = path
         .file_name()
         .expect("only parquet files are returned by iterator")
@@ -114,7 +115,12 @@ async fn upload_single_parquet_file(
     // Get the local file size for validation
     let local_file_size = path
         .metadata()
-        .map_err(|e| ObjectStorageError::Custom(format!("Failed to get local file metadata: {e}")))?
+        .map_err(|e| {
+            (
+                path.clone(),
+                ObjectStorageError::Custom(format!("Failed to get local file metadata: {e}")),
+            )
+        })?
         .len();
 
     // Upload the file
@@ -127,7 +133,10 @@ async fn upload_single_parquet_file(
         .await
         .map_err(|e| {
             error!("Failed to upload file {filename:?} to {stream_relative_path}: {e}");
-            ObjectStorageError::Custom(format!("Failed to upload {filename}: {e}"))
+            (
+                path.clone(),
+                ObjectStorageError::Custom(format!("Failed to upload {filename}: {e}")),
+            )
         })?;
 
     // Validate the uploaded file size matches local file
@@ -138,7 +147,8 @@ async fn upload_single_parquet_file(
         &stream_name,
         &tenant_id,
     )
-    .await?;
+    .await
+    .map_err(|e| (path.clone(), e))?;
 
     if !upload_is_valid {
         // Upload validation failed, clean up the uploaded file and return error
@@ -158,14 +168,16 @@ async fn upload_single_parquet_file(
         &stream_name,
         filename,
         tenant_id.as_deref().unwrap_or(DEFAULT_TENANT),
-    )?;
+    )
+    .map_err(|e| (path.clone(), e))?;
 
     // Create manifest entry
     let absolute_path = store
         .absolute_url(RelativePath::from_path(&stream_relative_path).expect("valid relative path"))
         .to_string();
 
-    let manifest = catalog::create_from_parquet_file(absolute_path, &path)?;
+    let manifest = catalog::create_from_parquet_file(absolute_path, &path)
+        .map_err(|e| (path.clone(), ObjectStorageError::from(e)))?;
 
     // Calculate field stats if enabled
     calculate_stats_if_enabled(&stream_name, &path, &schema, tenant_id).await;
@@ -1061,7 +1073,7 @@ async fn process_parquet_files(
 
 /// Spawns an individual parquet file upload task
 async fn spawn_parquet_upload_task(
-    join_set: &mut JoinSet<Result<UploadResult, ObjectStorageError>>,
+    join_set: &mut JoinSet<Result<UploadResult, (PathBuf, ObjectStorageError)>>,
     semaphore: Arc<tokio::sync::Semaphore>,
     store: Arc<dyn ObjectStorage>,
     upload_context: &UploadContext,
@@ -1102,7 +1114,7 @@ async fn spawn_parquet_upload_task(
 
 /// Collects results from all upload tasks
 async fn collect_upload_results(
-    mut join_set: JoinSet<Result<UploadResult, ObjectStorageError>>,
+    mut join_set: JoinSet<Result<UploadResult, (PathBuf, ObjectStorageError)>>,
 ) -> Result<Vec<catalog::manifest::File>, ObjectStorageError> {
     let mut uploaded_files = Vec::new();
 
@@ -1117,10 +1129,18 @@ async fn collect_upload_results(
                         "Parquet file upload size validation failed for {:?}, preserving in staging for retry",
                         upload_result.file_path
                     );
+                    {
+                        let mut guard = ACTIVE_OBJECT_STORE_SYNC_FILES.write().await;
+                        guard.remove(&upload_result.file_path);
+                    }
                 }
             }
-            Ok(Err(e)) => {
+            Ok(Err((path, e))) => {
                 error!("Error uploading parquet file: {e}");
+                {
+                    let mut guard = ACTIVE_OBJECT_STORE_SYNC_FILES.write().await;
+                    guard.remove(&path);
+                }
                 return Err(e);
             }
             Err(e) => {
@@ -1136,6 +1156,18 @@ async fn collect_upload_results(
         for (path, _) in uploaded_files.iter() {
             guard.remove(path);
         }
+
+        // check if file has been in hashset for more than 5 minutes
+        let now = Utc::now();
+        guard.retain(|f| {
+            if let Ok(ts) = extract_datetime_from_parquet_path_regex(f)
+                && (now - ts).num_minutes() >= 5
+            {
+                false
+            } else {
+                true
+            }
+        });
     }
     let manifest_files: Vec<_> = uploaded_files
         .into_par_iter()

--- a/src/storage/object_storage.rs
+++ b/src/storage/object_storage.rs
@@ -1160,13 +1160,8 @@ async fn collect_upload_results(
         // check if file has been in hashset for more than 5 minutes
         let now = Utc::now();
         guard.retain(|f| {
-            if let Ok(ts) = extract_datetime_from_parquet_path_regex(f)
-                && (now - ts).num_minutes() >= 5
-            {
-                false
-            } else {
-                true
-            }
+            !extract_datetime_from_parquet_path_regex(f)
+                .is_ok_and(|ts| (now - ts).num_minutes() >= 5)
         });
     }
     let manifest_files: Vec<_> = uploaded_files

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -48,14 +48,13 @@ use crate::{
         increment_files_scanned_in_object_store_calls_by_date,
         increment_object_store_calls_by_date,
     },
-    parseable::{DEFAULT_TENANT, LogStream},
+    parseable::{DEFAULT_TENANT, LogStream, PARSEABLE},
 };
 
 use super::{
-    CONNECT_TIMEOUT_SECS, MIN_MULTIPART_UPLOAD_SIZE, ObjectStorage, ObjectStorageError,
-    ObjectStorageProvider, PARSEABLE_ROOT_DIRECTORY, REQUEST_TIMEOUT_SECS,
-    STREAM_METADATA_FILE_NAME, metrics_layer::MetricLayer, object_storage::parseable_json_path,
-    to_object_store_path,
+    CONNECT_TIMEOUT_SECS, ObjectStorage, ObjectStorageError, ObjectStorageProvider,
+    PARSEABLE_ROOT_DIRECTORY, REQUEST_TIMEOUT_SECS, STREAM_METADATA_FILE_NAME,
+    metrics_layer::MetricLayer, object_storage::parseable_json_path, to_object_store_path,
 };
 
 // in bytes
@@ -543,7 +542,8 @@ impl S3 {
 
         let meta = file.metadata().await?;
         let total_size = meta.len() as usize;
-        if total_size < MIN_MULTIPART_UPLOAD_SIZE {
+        let min_multipart_size = PARSEABLE.options.min_multipart_size as usize;
+        if total_size < min_multipart_size || !PARSEABLE.options.enable_multipart {
             let mut data = Vec::new();
             file.read_to_end(&mut data).await?;
 
@@ -577,19 +577,19 @@ impl S3 {
 
             // let mut upload_parts = Vec::new();
 
-            let has_final_partial_part = !total_size.is_multiple_of(MIN_MULTIPART_UPLOAD_SIZE);
-            let num_full_parts = total_size / MIN_MULTIPART_UPLOAD_SIZE;
+            let has_final_partial_part = !total_size.is_multiple_of(min_multipart_size);
+            let num_full_parts = total_size / min_multipart_size;
             let total_parts = num_full_parts + if has_final_partial_part { 1 } else { 0 };
 
             // Upload each part with metrics
             for part_number in 0..(total_parts) {
-                let start_pos = part_number * MIN_MULTIPART_UPLOAD_SIZE;
+                let start_pos = part_number * min_multipart_size;
                 let end_pos = if part_number == num_full_parts && has_final_partial_part {
                     // Last part might be smaller than 5MB (which is allowed)
                     total_size
                 } else {
                     // All other parts must be at least 5MB
-                    start_pos + MIN_MULTIPART_UPLOAD_SIZE
+                    start_pos + min_multipart_size
                 };
 
                 // Extract this part's data

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -532,14 +532,6 @@ impl S3 {
         let mut file = OpenOptions::new().read(true).open(path).await?;
         let location = &to_object_store_path(key);
 
-        let async_writer = self.client.put_multipart(location).await;
-        let mut async_writer = match async_writer {
-            Ok(writer) => writer,
-            Err(err) => {
-                return Err(err.into());
-            }
-        };
-
         let meta = file.metadata().await?;
         let total_size = meta.len() as usize;
         let min_multipart_size = PARSEABLE.options.min_multipart_size as usize;
@@ -568,10 +560,16 @@ impl S3 {
                 }
             }
 
-            // async_writer.put_part(data.into()).await?;
-            // async_writer.complete().await?;
             return Ok(());
         } else {
+            let async_writer = self.client.put_multipart(location).await;
+            let mut async_writer = match async_writer {
+                Ok(writer) => writer,
+                Err(err) => {
+                    return Err(err.into());
+                }
+            };
+
             let mut data = Vec::new();
             file.read_to_end(&mut data).await?;
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -17,12 +17,16 @@
  */
 
 use chrono::{TimeDelta, Timelike};
+use datafusion::common::HashSet;
 use futures::FutureExt;
+use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::future::Future;
 use std::panic::AssertUnwindSafe;
+use std::path::PathBuf;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{RwLock, mpsc, oneshot};
 use tokio::task::JoinSet;
 use tokio::time::{Duration, Instant, interval_at, sleep};
 use tokio::{select, task};
@@ -31,6 +35,8 @@ use tracing::{Instrument, error, info, info_span, trace, warn};
 static LOCAL_SYNC_RUNNING: AtomicBool = AtomicBool::new(false);
 static REMOTE_SYNC_RUNNING: AtomicBool = AtomicBool::new(false);
 
+pub static ACTIVE_OBJECT_STORE_SYNC_FILES: Lazy<Arc<RwLock<HashSet<PathBuf>>>> =
+    Lazy::new(|| Arc::new(RwLock::new(HashSet::new())));
 /// RAII guard that clears a sync-running flag on drop, so a panic inside the
 /// sync body cannot leave the flag stuck at `true` and wedge future ticks.
 struct SyncRunningGuard(&'static AtomicBool);
@@ -268,7 +274,8 @@ pub fn local_sync() -> (
     (handle, outbox_rx, inbox_tx)
 }
 
-// local and object store sync at the start of the server
+/// local and object store sync at the start of the server
+#[tokio::main(flavor = "current_thread")]
 pub async fn sync_start() -> anyhow::Result<()> {
     // Monitor local sync duration at startup
     monitor_task_duration(


### PR DESCRIPTION
During server startup, if there are multiple files in staging then their conversion alone takes up almost all the resources of the server. Delegate just a single thread for that instead. Added env vars to control multi-part uploads to object store.

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI flags to enable/disable multipart uploads and set the minimum multipart size (default 25MB).

* **Bug Fixes**
  * Detect and remove corrupted recovery files during orphan recovery.
  * Prevent duplicate concurrent uploads via shared in-memory tracking; failed uploads are cleaned up and pruned.

* **Improvements**
  * Increased logging visibility for flush and conversion operations.

* **Behavior Changes**
  * Certain endpoints no longer apply prior resource-usage middleware; startup sync now runs in a plain background thread.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->