### PR TITLE
fix: load IRSA web identity config for S3

### DIFF
--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -264,25 +264,34 @@ impl S3Config {
             builder = builder.with_checksum_algorithm(Checksum::SHA256)
         }
 
+        assert!(
+            self.access_key_id.is_some() == self.secret_key.is_some(),
+            "P_S3_ACCESS_KEY and P_S3_SECRET_KEY must be set together"
+        );
+
         if let Some((access_key, secret_key)) =
             self.access_key_id.as_ref().zip(self.secret_key.as_ref())
         {
             builder = builder
                 .with_access_key_id(access_key)
                 .with_secret_access_key(secret_key);
-        }
+        } else {
+            let token_file = std::env::var(AWS_WEB_IDENTITY_TOKEN_FILE).ok();
+            let role_arn = std::env::var(AWS_ROLE_ARN).ok();
 
-        if self.access_key_id.is_none() && self.secret_key.is_none() {
-            if let Ok(token_file) = std::env::var(AWS_WEB_IDENTITY_TOKEN_FILE) {
-                builder = builder.with_config(AmazonS3ConfigKey::WebIdentityTokenFile, token_file);
-            }
+            assert!(
+                token_file.is_some() == role_arn.is_some(),
+                "{AWS_WEB_IDENTITY_TOKEN_FILE} and {AWS_ROLE_ARN} must be set together"
+            );
 
-            if let Ok(role_arn) = std::env::var(AWS_ROLE_ARN) {
-                builder = builder.with_config(AmazonS3ConfigKey::RoleArn, role_arn);
-            }
+            if let Some((token_file, role_arn)) = token_file.zip(role_arn) {
+                builder = builder
+                    .with_config(AmazonS3ConfigKey::WebIdentityTokenFile, token_file)
+                    .with_config(AmazonS3ConfigKey::RoleArn, role_arn);
 
-            if let Ok(session_name) = std::env::var(AWS_ROLE_SESSION_NAME) {
-                builder = builder.with_config(AmazonS3ConfigKey::RoleSessionName, session_name);
+                if let Ok(session_name) = std::env::var(AWS_ROLE_SESSION_NAME) {
+                    builder = builder.with_config(AmazonS3ConfigKey::RoleSessionName, session_name);
+                }
             }
         }
 

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -69,6 +69,9 @@ use super::{
 // in bytes
 // const MULTIPART_UPLOAD_SIZE: usize = 1024 * 1024 * 100;
 const AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: &str = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
+const AWS_WEB_IDENTITY_TOKEN_FILE: &str = "AWS_WEB_IDENTITY_TOKEN_FILE";
+const AWS_ROLE_ARN: &str = "AWS_ROLE_ARN";
+const AWS_ROLE_SESSION_NAME: &str = "AWS_ROLE_SESSION_NAME";
 
 #[derive(Debug, Clone, clap::Args)]
 #[command(
@@ -267,6 +270,20 @@ impl S3Config {
             builder = builder
                 .with_access_key_id(access_key)
                 .with_secret_access_key(secret_key);
+        }
+
+        if self.access_key_id.is_none() && self.secret_key.is_none() {
+            if let Ok(token_file) = std::env::var(AWS_WEB_IDENTITY_TOKEN_FILE) {
+                builder = builder.with_config(AmazonS3ConfigKey::WebIdentityTokenFile, token_file);
+            }
+
+            if let Ok(role_arn) = std::env::var(AWS_ROLE_ARN) {
+                builder = builder.with_config(AmazonS3ConfigKey::RoleArn, role_arn);
+            }
+
+            if let Ok(session_name) = std::env::var(AWS_ROLE_SESSION_NAME) {
+                builder = builder.with_config(AmazonS3ConfigKey::RoleSessionName, session_name);
+            }
         }
 
         if let Some(ssec_encryption_key) = &self.ssec_encryption_key {


### PR DESCRIPTION
 Fixes #1646.

  ### Description

  This PR restores IRSA support for `s3-store` deployments on EKS when static S3 credentials are not configured.

  After the `object_store` upgrade used by v2.7.x, `AmazonS3Builder::new()` no longer implicitly reads `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_ARN` during `build()`. That behavior now belongs to
  `AmazonS3Builder::from_env()` or explicit `with_config(...)` calls.

  This is likely an API correctness cleanup in `object_store`: `new()` starts with an empty builder, while `from_env()` loads configuration from the environment. Parseable was relying on the older
  implicit behavior, so the WebIdentity credential provider path was skipped and S3 access fell back to the EC2/node role.

  The chosen fix keeps Parseable’s explicit S3 builder setup and only forwards the IRSA-specific env vars when `P_S3_ACCESS_KEY` and `P_S3_SECRET_KEY` are absent:

  - `AWS_WEB_IDENTITY_TOKEN_FILE`
  - `AWS_ROLE_ARN`
  - `AWS_ROLE_SESSION_NAME`, if present

  EKS Pod Identity env handling is separate from this IRSA regression and can be addressed in a follow-up if needed.


  This PR has:
  - [ ] been tested to ensure log ingestion and log query works.
  - [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
  - [ ] added documentation for new or modified features or behaviors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for AWS web-identity environment variables for S3 connections when explicit access keys are not provided. The client will read AWS_WEB_IDENTITY_TOKEN_FILE and AWS_ROLE_ARN together, and optionally AWS_ROLE_SESSION_NAME. Access key and secret must be supplied together; otherwise web-identity variables are used to configure S3 credentialing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->