### PR TITLE
track insertion time instead of data time for eviction

### DIFF
--- a/src/storage/object_storage.rs
+++ b/src/storage/object_storage.rs
@@ -16,10 +16,32 @@
  *
  */
 
+use crate::catalog::{self, snapshot::Snapshot};
+use crate::event::format::LogSource;
+use crate::event::format::LogSourceEntry;
+use crate::handlers::DatasetTag;
+use crate::handlers::http::fetch_schema;
+use crate::handlers::http::modal::ingest_server::INGESTOR_EXPECT;
+use crate::handlers::http::modal::ingest_server::INGESTOR_META;
+use crate::handlers::http::users::{FILTER_DIR, USERS_ROOT_DIR};
+use crate::metrics::increment_parquets_stored_by_date;
+use crate::metrics::increment_parquets_stored_size_by_date;
+use crate::metrics::{EVENTS_STORAGE_SIZE_DATE, LIFETIME_EVENTS_STORAGE_SIZE, STORAGE_SIZE};
+use crate::option::Mode;
+use crate::parseable::DEFAULT_TENANT;
+use crate::parseable::{LogStream, PARSEABLE, Stream};
+use crate::stats::FullStats;
+use crate::storage::SETTINGS_ROOT_DIRECTORY;
+use crate::storage::TARGETS_ROOT_DIRECTORY;
+use crate::storage::field_stats::DATASET_STATS_STREAM_NAME;
+use crate::storage::field_stats::calculate_field_stats;
+use crate::storage::field_stats::extract_datetime_from_parquet_path_regex;
+use crate::sync::{ACTIVE_OBJECT_STORE_SYNC_FILES, FLUSH_AND_CONVERT_RUNTIME};
 use arrow_schema::Schema;
 use async_trait::async_trait;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
+use dashmap::mapref::entry::Entry;
 use datafusion::{datasource::listing::ListingTableUrl, execution::runtime_env::RuntimeEnvBuilder};
 use itertools::Itertools;
 use object_store::ListResult;
@@ -42,29 +64,6 @@ use std::time::Instant;
 use tokio::task::JoinSet;
 use tracing::{Instrument, error, info, info_span, warn};
 use ulid::Ulid;
-
-use crate::catalog::{self, snapshot::Snapshot};
-use crate::event::format::LogSource;
-use crate::event::format::LogSourceEntry;
-use crate::handlers::DatasetTag;
-use crate::handlers::http::fetch_schema;
-use crate::handlers::http::modal::ingest_server::INGESTOR_EXPECT;
-use crate::handlers::http::modal::ingest_server::INGESTOR_META;
-use crate::handlers::http::users::{FILTER_DIR, USERS_ROOT_DIR};
-use crate::metrics::increment_parquets_stored_by_date;
-use crate::metrics::increment_parquets_stored_size_by_date;
-use crate::metrics::{EVENTS_STORAGE_SIZE_DATE, LIFETIME_EVENTS_STORAGE_SIZE, STORAGE_SIZE};
-use crate::option::Mode;
-use crate::parseable::DEFAULT_TENANT;
-use crate::parseable::{LogStream, PARSEABLE, Stream};
-use crate::stats::FullStats;
-use crate::storage::SETTINGS_ROOT_DIRECTORY;
-use crate::storage::TARGETS_ROOT_DIRECTORY;
-use crate::storage::field_stats::DATASET_STATS_STREAM_NAME;
-use crate::storage::field_stats::calculate_field_stats;
-use crate::storage::field_stats::extract_datetime_from_parquet_path_regex;
-use crate::sync::{ACTIVE_OBJECT_STORE_SYNC_FILES, SyncFileEntry};
-use crate::sync::FLUSH_AND_CONVERT_RUNTIME;
 
 use super::{
     ALERTS_ROOT_DIRECTORY, MANIFEST_FILE, ObjectStorageError, ObjectStoreFormat,
@@ -1084,29 +1083,20 @@ async fn process_parquet_files(
     let object_store = PARSEABLE.storage().get_object_store();
 
     // collect all parquet files to upload
-    let parquet_paths = {
-        let mut guard = ACTIVE_OBJECT_STORE_SYNC_FILES.write().await;
-
-        let parquet_paths: Vec<PathBuf> = upload_context
-            .stream
-            .parquet_files()
-            .into_par_iter()
-            .filter(|p| !guard.contains_key(p))
-            .collect();
-
-        let mut ret = Vec::with_capacity(parquet_paths.len());
-        ret.clone_from(&parquet_paths);
-        for path in parquet_paths {
-            guard.insert(
-                path,
-                SyncFileEntry {
-                    tracked_instant: Instant::now(),
-                    tracked_utc: Utc::now(),
-                },
-            );
-        }
-        ret
-    };
+    let parquet_paths: Vec<PathBuf> = upload_context
+        .stream
+        .parquet_files()
+        .into_par_iter()
+        .filter_map(
+            |path| match ACTIVE_OBJECT_STORE_SYNC_FILES.entry(path.clone()) {
+                Entry::Vacant(entry) => {
+                    entry.insert(Instant::now());
+                    Some(path)
+                }
+                Entry::Occupied(_) => None,
+            },
+        )
+        .collect();
 
     let mut total_size: u64 = 0;
     let mut min_dt: Option<chrono::DateTime<Utc>> = None;
@@ -1203,18 +1193,12 @@ async fn collect_upload_results(
                         "Parquet file upload size validation failed for {:?}, preserving in staging for retry",
                         upload_result.file_path
                     );
-                    {
-                        let mut guard = ACTIVE_OBJECT_STORE_SYNC_FILES.write().await;
-                        guard.remove(&upload_result.file_path);
-                    }
+                    ACTIVE_OBJECT_STORE_SYNC_FILES.remove(&upload_result.file_path);
                 }
             }
             Ok(Err((path, e))) => {
                 error!("Error uploading parquet file: {e}");
-                {
-                    let mut guard = ACTIVE_OBJECT_STORE_SYNC_FILES.write().await;
-                    guard.remove(&path);
-                }
+                ACTIVE_OBJECT_STORE_SYNC_FILES.remove(&path);
                 return Err(e);
             }
             Err(e) => {
@@ -1279,42 +1263,24 @@ async fn calculate_stats_for_uploaded_files(
 }
 
 async fn cleanup_uploaded_staged_files(uploaded_files: Vec<UploadedParquetFile>) {
-    let paths: Vec<_> = uploaded_files
-        .into_iter()
-        .map(|uploaded_file| uploaded_file.file_path)
-        .collect();
-
-    {
-        let mut guard = ACTIVE_OBJECT_STORE_SYNC_FILES.write().await;
-        for path in paths.iter() {
-            guard.remove(path);
-        }
-
-        // Use monotonic time to ensure the 5-minute eviction window is immune to system clock adjustments.
-        let now = Instant::now();
-        guard.retain(|path, entry| {
-            let elapsed = now.duration_since(entry.tracked_instant);
-            // 5 min eviction window
-            if elapsed >= Duration::from_secs(300) {
-                // Added log for observability and debugging
-                warn!(
-                    "Removing stale sync file: {} (elapsed: {}s, tracked_at: {})",
-                    path.display(),
-                    elapsed.as_secs(),
-                    entry.tracked_utc.to_rfc3339(),
-                );
-                false
-            } else {
-                true
-            }
-        });
+    // successfully uploaded files, remove from DashMap
+    for uploaded_parquet_file in uploaded_files.iter() {
+        ACTIVE_OBJECT_STORE_SYNC_FILES.remove(&uploaded_parquet_file.file_path);
     }
 
-    paths.into_par_iter().for_each(|path| {
-        if let Err(e) = remove_file(&path) {
-            warn!("Failed to remove staged file: {e}");
-        }
+    // Use monotonic time to ensure the 5-minute eviction window(cleanup) is immune to system clock adjustments.
+    let now = Instant::now();
+    ACTIVE_OBJECT_STORE_SYNC_FILES.retain(|_, tracked_instant| {
+        now.duration_since(*tracked_instant) < Duration::from_secs(300)
     });
+
+    uploaded_files
+        .into_par_iter()
+        .for_each(|uploaded_parquet_file| {
+            if let Err(e) = remove_file(&uploaded_parquet_file.file_path) {
+                warn!("Failed to remove staged file: {e}");
+            }
+        });
 }
 
 /// Processes schema files

--- a/src/storage/object_storage.rs
+++ b/src/storage/object_storage.rs
@@ -16,10 +16,32 @@
  *
  */
 
+use crate::catalog::{self, snapshot::Snapshot};
+use crate::event::format::LogSource;
+use crate::event::format::LogSourceEntry;
+use crate::handlers::DatasetTag;
+use crate::handlers::http::fetch_schema;
+use crate::handlers::http::modal::ingest_server::INGESTOR_EXPECT;
+use crate::handlers::http::modal::ingest_server::INGESTOR_META;
+use crate::handlers::http::users::{FILTER_DIR, USERS_ROOT_DIR};
+use crate::metrics::increment_parquets_stored_by_date;
+use crate::metrics::increment_parquets_stored_size_by_date;
+use crate::metrics::{EVENTS_STORAGE_SIZE_DATE, LIFETIME_EVENTS_STORAGE_SIZE, STORAGE_SIZE};
+use crate::option::Mode;
+use crate::parseable::DEFAULT_TENANT;
+use crate::parseable::{LogStream, PARSEABLE, Stream};
+use crate::stats::FullStats;
+use crate::storage::SETTINGS_ROOT_DIRECTORY;
+use crate::storage::TARGETS_ROOT_DIRECTORY;
+use crate::storage::field_stats::DATASET_STATS_STREAM_NAME;
+use crate::storage::field_stats::calculate_field_stats;
+use crate::storage::field_stats::extract_datetime_from_parquet_path_regex;
+use crate::sync::ACTIVE_OBJECT_STORE_SYNC_FILES;
 use arrow_schema::Schema;
 use async_trait::async_trait;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
+use dashmap::mapref::entry::Entry;
 use datafusion::{datasource::listing::ListingTableUrl, execution::runtime_env::RuntimeEnvBuilder};
 use itertools::Itertools;
 use object_store::ListResult;
@@ -42,28 +64,6 @@ use std::time::Instant;
 use tokio::task::JoinSet;
 use tracing::{Instrument, error, info, info_span, warn};
 use ulid::Ulid;
-
-use crate::catalog::{self, snapshot::Snapshot};
-use crate::event::format::LogSource;
-use crate::event::format::LogSourceEntry;
-use crate::handlers::DatasetTag;
-use crate::handlers::http::fetch_schema;
-use crate::handlers::http::modal::ingest_server::INGESTOR_EXPECT;
-use crate::handlers::http::modal::ingest_server::INGESTOR_META;
-use crate::handlers::http::users::{FILTER_DIR, USERS_ROOT_DIR};
-use crate::metrics::increment_parquets_stored_by_date;
-use crate::metrics::increment_parquets_stored_size_by_date;
-use crate::metrics::{EVENTS_STORAGE_SIZE_DATE, LIFETIME_EVENTS_STORAGE_SIZE, STORAGE_SIZE};
-use crate::option::Mode;
-use crate::parseable::DEFAULT_TENANT;
-use crate::parseable::{LogStream, PARSEABLE, Stream};
-use crate::stats::FullStats;
-use crate::storage::SETTINGS_ROOT_DIRECTORY;
-use crate::storage::TARGETS_ROOT_DIRECTORY;
-use crate::storage::field_stats::DATASET_STATS_STREAM_NAME;
-use crate::storage::field_stats::calculate_field_stats;
-use crate::storage::field_stats::extract_datetime_from_parquet_path_regex;
-use crate::sync::{ACTIVE_OBJECT_STORE_SYNC_FILES, SyncFileEntry};
 
 use super::{
     ALERTS_ROOT_DIRECTORY, MANIFEST_FILE, ObjectStorageError, ObjectStoreFormat,
@@ -1071,29 +1071,20 @@ async fn process_parquet_files(
     let object_store = PARSEABLE.storage().get_object_store();
 
     // collect all parquet files to upload
-    let parquet_paths = {
-        let mut guard = ACTIVE_OBJECT_STORE_SYNC_FILES.write().await;
-
-        let parquet_paths: Vec<PathBuf> = upload_context
-            .stream
-            .parquet_files()
-            .into_par_iter()
-            .filter(|p| !guard.contains_key(p))
-            .collect();
-
-        let mut ret = Vec::with_capacity(parquet_paths.len());
-        ret.clone_from(&parquet_paths);
-        for path in parquet_paths {
-            guard.insert(
-                path,
-                SyncFileEntry {
-                    tracked_instant: Instant::now(),
-                    tracked_utc: Utc::now(),
-                },
-            );
-        }
-        ret
-    };
+    let parquet_paths: Vec<PathBuf> = upload_context
+        .stream
+        .parquet_files()
+        .into_par_iter()
+        .filter_map(
+            |path| match ACTIVE_OBJECT_STORE_SYNC_FILES.entry(path.clone()) {
+                Entry::Vacant(entry) => {
+                    entry.insert(Instant::now());
+                    Some(path)
+                }
+                Entry::Occupied(_) => None,
+            },
+        )
+        .collect();
 
     let mut total_size: u64 = 0;
     let mut min_dt: Option<chrono::DateTime<Utc>> = None;
@@ -1192,18 +1183,12 @@ async fn collect_upload_results(
                         "Parquet file upload size validation failed for {:?}, preserving in staging for retry",
                         upload_result.file_path
                     );
-                    {
-                        let mut guard = ACTIVE_OBJECT_STORE_SYNC_FILES.write().await;
-                        guard.remove(&upload_result.file_path);
-                    }
+                    ACTIVE_OBJECT_STORE_SYNC_FILES.remove(&upload_result.file_path);
                 }
             }
             Ok(Err((path, e))) => {
                 error!("Error uploading parquet file: {e}");
-                {
-                    let mut guard = ACTIVE_OBJECT_STORE_SYNC_FILES.write().await;
-                    guard.remove(&path);
-                }
+                ACTIVE_OBJECT_STORE_SYNC_FILES.remove(&path);
                 return Err(e);
             }
             Err(e) => {
@@ -1213,32 +1198,15 @@ async fn collect_upload_results(
         }
     }
 
-    // successfully uploaded files, remove from in-mem hashset
-    {
-        let mut guard = ACTIVE_OBJECT_STORE_SYNC_FILES.write().await;
-        for (path, _) in uploaded_files.iter() {
-            guard.remove(path);
-        }
-
-        // Use monotonic time to ensure the 5-minute eviction window is immune to system clock adjustments.
-        let now = Instant::now();
-        guard.retain(|path, entry| {
-            let elapsed = now.duration_since(entry.tracked_instant);
-            // 5 min eviction window
-            if elapsed >= Duration::from_secs(300) {
-                // Added log for observability and debugging
-                warn!(
-                    "Removing stale sync file: {} (elapsed: {}s, tracked_at: {})",
-                    path.display(),
-                    elapsed.as_secs(),
-                    entry.tracked_utc.to_rfc3339(),
-                );
-                false
-            } else {
-                true
-            }
-        });
+    // successfully uploaded files, remove from DashMap
+    for (path, _) in uploaded_files.iter() {
+        ACTIVE_OBJECT_STORE_SYNC_FILES.remove(path);
     }
+    // Use monotonic time to ensure the 5-minute eviction window(cleanup) is immune to system clock adjustments.
+    let now = Instant::now();
+    ACTIVE_OBJECT_STORE_SYNC_FILES.retain(|_, tracked_instant| {
+        now.duration_since(*tracked_instant) < Duration::from_secs(300)
+    });
     let manifest_files: Vec<_> = uploaded_files
         .into_par_iter()
         .map(|(path, manifest_file)| {

--- a/src/storage/object_storage.rs
+++ b/src/storage/object_storage.rs
@@ -63,7 +63,7 @@ use crate::storage::TARGETS_ROOT_DIRECTORY;
 use crate::storage::field_stats::DATASET_STATS_STREAM_NAME;
 use crate::storage::field_stats::calculate_field_stats;
 use crate::storage::field_stats::extract_datetime_from_parquet_path_regex;
-use crate::sync::ACTIVE_OBJECT_STORE_SYNC_FILES;
+use crate::sync::{ACTIVE_OBJECT_STORE_SYNC_FILES, SyncFileEntry};
 use crate::sync::FLUSH_AND_CONVERT_RUNTIME;
 
 use super::{
@@ -1090,14 +1090,21 @@ async fn process_parquet_files(
         let parquet_paths: Vec<PathBuf> = upload_context
             .stream
             .parquet_files()
-            .into_iter()
-            .filter(|p| !guard.contains(p))
+            .into_par_iter()
+            .filter(|p| !guard.contains_key(p))
             .collect();
 
         let mut ret = Vec::with_capacity(parquet_paths.len());
         ret.clone_from(&parquet_paths);
-        guard.extend(parquet_paths);
-        tracing::info!(ACTIVE_OBJECT_STORE_SYNC_FILES=?ACTIVE_OBJECT_STORE_SYNC_FILES);
+        for path in parquet_paths {
+            guard.insert(
+                path,
+                SyncFileEntry {
+                    tracked_instant: Instant::now(),
+                    tracked_utc: Utc::now(),
+                },
+            );
+        }
         ret
     };
 
@@ -1283,11 +1290,23 @@ async fn cleanup_uploaded_staged_files(uploaded_files: Vec<UploadedParquetFile>)
             guard.remove(path);
         }
 
-        // check if file has been in hashset for more than 5 minutes
-        let now = Utc::now();
-        guard.retain(|f| {
-            !extract_datetime_from_parquet_path_regex(f)
-                .is_ok_and(|ts| (now - ts).num_minutes() >= 5)
+        // Use monotonic time to ensure the 5-minute eviction window is immune to system clock adjustments.
+        let now = Instant::now();
+        guard.retain(|path, entry| {
+            let elapsed = now.duration_since(entry.tracked_instant);
+            // 5 min eviction window
+            if elapsed >= Duration::from_secs(300) {
+                // Added log for observability and debugging
+                warn!(
+                    "Removing stale sync file: {} (elapsed: {}s, tracked_at: {})",
+                    path.display(),
+                    elapsed.as_secs(),
+                    entry.tracked_utc.to_rfc3339(),
+                );
+                false
+            } else {
+                true
+            }
         });
     }
 

--- a/src/storage/object_storage.rs
+++ b/src/storage/object_storage.rs
@@ -63,7 +63,7 @@ use crate::storage::TARGETS_ROOT_DIRECTORY;
 use crate::storage::field_stats::DATASET_STATS_STREAM_NAME;
 use crate::storage::field_stats::calculate_field_stats;
 use crate::storage::field_stats::extract_datetime_from_parquet_path_regex;
-use crate::sync::ACTIVE_OBJECT_STORE_SYNC_FILES;
+use crate::sync::{ACTIVE_OBJECT_STORE_SYNC_FILES, SyncFileEntry};
 
 use super::{
     ALERTS_ROOT_DIRECTORY, MANIFEST_FILE, ObjectStorageError, ObjectStoreFormat,
@@ -1078,12 +1078,20 @@ async fn process_parquet_files(
             .stream
             .parquet_files()
             .into_par_iter()
-            .filter(|p| !guard.contains(p))
+            .filter(|p| !guard.contains_key(p))
             .collect();
 
         let mut ret = Vec::with_capacity(parquet_paths.len());
         ret.clone_from(&parquet_paths);
-        guard.extend(parquet_paths);
+        for path in parquet_paths {
+            guard.insert(
+                path,
+                SyncFileEntry {
+                    tracked_instant: Instant::now(),
+                    tracked_utc: Utc::now(),
+                },
+            );
+        }
         ret
     };
 
@@ -1212,11 +1220,23 @@ async fn collect_upload_results(
             guard.remove(path);
         }
 
-        // check if file has been in hashset for more than 5 minutes
-        let now = Utc::now();
-        guard.retain(|f| {
-            !extract_datetime_from_parquet_path_regex(f)
-                .is_ok_and(|ts| (now - ts).num_minutes() >= 5)
+        // Use monotonic time to ensure the 5-minute eviction window is immune to system clock adjustments.
+        let now = Instant::now();
+        guard.retain(|path, entry| {
+            let elapsed = now.duration_since(entry.tracked_instant);
+            // 5 min eviction window
+            if elapsed >= Duration::from_secs(300) {
+                // Added log for observability and debugging
+                warn!(
+                    "Removing stale sync file: {} (elapsed: {}s, tracked_at: {})",
+                    path.display(),
+                    elapsed.as_secs(),
+                    entry.tracked_utc.to_rfc3339(),
+                );
+                false
+            } else {
+                true
+            }
         });
     }
     let manifest_files: Vec<_> = uploaded_files

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -16,8 +16,7 @@
  *
  */
 
-use chrono::{TimeDelta, Timelike};
-use datafusion::common::HashSet;
+use chrono::{DateTime, TimeDelta, Timelike, Utc};
 use futures::FutureExt;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
@@ -39,8 +38,17 @@ pub static FLUSH_AND_CONVERT_RUNTIME: Lazy<Runtime> =
 static LOCAL_SYNC_RUNNING: AtomicBool = AtomicBool::new(false);
 static REMOTE_SYNC_RUNNING: AtomicBool = AtomicBool::new(false);
 
-pub static ACTIVE_OBJECT_STORE_SYNC_FILES: Lazy<Arc<RwLock<HashSet<PathBuf>>>> =
-    Lazy::new(|| Arc::new(RwLock::new(HashSet::new())));
+// tracks metadata for files being synced to object storage
+#[derive(Clone, Debug)]
+pub struct SyncFileEntry {
+    // Monotonic instant when file was added to tracking
+    pub tracked_instant: std::time::Instant,
+    // Wall-clock UTC timestamp for observability
+    pub tracked_utc: DateTime<Utc>,
+}
+
+pub static ACTIVE_OBJECT_STORE_SYNC_FILES: Lazy<Arc<RwLock<HashMap<PathBuf, SyncFileEntry>>>> =
+    Lazy::new(|| Arc::new(RwLock::new(HashMap::new())));
 /// RAII guard that clears a sync-running flag on drop, so a panic inside the
 /// sync body cannot leave the flag stuck at `true` and wedge future ticks.
 struct SyncRunningGuard(&'static AtomicBool);

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -16,17 +16,17 @@
  *
  */
 
-use chrono::{DateTime, TimeDelta, Timelike, Utc};
+use chrono::{TimeDelta, Timelike};
+use dashmap::DashMap;
 use futures::FutureExt;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::future::Future;
 use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::runtime::Runtime;
-use tokio::sync::{RwLock, mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinSet;
 use tokio::time::{Duration, Instant, interval_at, sleep};
 use tokio::{select, task};
@@ -38,17 +38,8 @@ pub static FLUSH_AND_CONVERT_RUNTIME: Lazy<Runtime> =
 static LOCAL_SYNC_RUNNING: AtomicBool = AtomicBool::new(false);
 static REMOTE_SYNC_RUNNING: AtomicBool = AtomicBool::new(false);
 
-// tracks metadata for files being synced to object storage
-#[derive(Clone, Debug)]
-pub struct SyncFileEntry {
-    // Monotonic instant when file was added to tracking
-    pub tracked_instant: std::time::Instant,
-    // Wall-clock UTC timestamp for observability
-    pub tracked_utc: DateTime<Utc>,
-}
-
-pub static ACTIVE_OBJECT_STORE_SYNC_FILES: Lazy<Arc<RwLock<HashMap<PathBuf, SyncFileEntry>>>> =
-    Lazy::new(|| Arc::new(RwLock::new(HashMap::new())));
+pub static ACTIVE_OBJECT_STORE_SYNC_FILES: Lazy<DashMap<PathBuf, std::time::Instant>> =
+    Lazy::new(DashMap::new);
 /// RAII guard that clears a sync-running flag on drop, so a panic inside the
 /// sync body cannot leave the flag stuck at `true` and wedge future ticks.
 struct SyncRunningGuard(&'static AtomicBool);

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -16,16 +16,16 @@
  *
  */
 
-use chrono::{DateTime, TimeDelta, Timelike, Utc};
+use chrono::{TimeDelta, Timelike};
+use dashmap::DashMap;
 use futures::FutureExt;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::future::Future;
 use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use tokio::sync::{RwLock, mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinSet;
 use tokio::time::{Duration, Instant, interval_at, sleep};
 use tokio::{select, task};
@@ -34,17 +34,8 @@ use tracing::{Instrument, error, info, info_span, trace, warn};
 static LOCAL_SYNC_RUNNING: AtomicBool = AtomicBool::new(false);
 static REMOTE_SYNC_RUNNING: AtomicBool = AtomicBool::new(false);
 
-// tracks metadata for files being synced to object storage
-#[derive(Clone, Debug)]
-pub struct SyncFileEntry {
-    // Monotonic instant when file was added to tracking
-    pub tracked_instant: std::time::Instant,
-    // Wall-clock UTC timestamp for observability
-    pub tracked_utc: DateTime<Utc>,
-}
-
-pub static ACTIVE_OBJECT_STORE_SYNC_FILES: Lazy<Arc<RwLock<HashMap<PathBuf, SyncFileEntry>>>> =
-    Lazy::new(|| Arc::new(RwLock::new(HashMap::new())));
+pub static ACTIVE_OBJECT_STORE_SYNC_FILES: Lazy<DashMap<PathBuf, std::time::Instant>> =
+    Lazy::new(DashMap::new);
 /// RAII guard that clears a sync-running flag on drop, so a panic inside the
 /// sync body cannot leave the flag stuck at `true` and wedge future ticks.
 struct SyncRunningGuard(&'static AtomicBool);

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -16,8 +16,7 @@
  *
  */
 
-use chrono::{TimeDelta, Timelike};
-use datafusion::common::HashSet;
+use chrono::{DateTime, TimeDelta, Timelike, Utc};
 use futures::FutureExt;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
@@ -35,8 +34,17 @@ use tracing::{Instrument, error, info, info_span, trace, warn};
 static LOCAL_SYNC_RUNNING: AtomicBool = AtomicBool::new(false);
 static REMOTE_SYNC_RUNNING: AtomicBool = AtomicBool::new(false);
 
-pub static ACTIVE_OBJECT_STORE_SYNC_FILES: Lazy<Arc<RwLock<HashSet<PathBuf>>>> =
-    Lazy::new(|| Arc::new(RwLock::new(HashSet::new())));
+// tracks metadata for files being synced to object storage
+#[derive(Clone, Debug)]
+pub struct SyncFileEntry {
+    // Monotonic instant when file was added to tracking
+    pub tracked_instant: std::time::Instant,
+    // Wall-clock UTC timestamp for observability
+    pub tracked_utc: DateTime<Utc>,
+}
+
+pub static ACTIVE_OBJECT_STORE_SYNC_FILES: Lazy<Arc<RwLock<HashMap<PathBuf, SyncFileEntry>>>> =
+    Lazy::new(|| Arc::new(RwLock::new(HashMap::new())));
 /// RAII guard that clears a sync-running flag on drop, so a panic inside the
 /// sync body cannot leave the flag stuck at `true` and wedge future ticks.
 struct SyncRunningGuard(&'static AtomicBool);


### PR DESCRIPTION

***

Fixes #1634

### Description
**Goal:** Fix silent upload stalls occurring during historical event ingestion with time partitions. The goal is to ensure files are evicted from the active sync tracking list based on how long they have been in the upload queue, rather than how old the data inside them is.

### Possible Solutions and Chosen Rationale
The issue stemmed from a conceptual mismatch: data age (when the event occurred) is fundamentally different from tracking age (how long the file has been in the queue). For real-time ingestion, these are nearly identical, so the bug went undetected. For historical ingestion (e.g., Nov 2025 events ingested in May 2026), they diverge by months or years.

The previous solution parsed the data timestamp from the parquet filename via regex and compared it against a 5-minute threshold to determine staleness. The chosen solution changes the tracking structure from a globally locked active-file set to a `DashMap<PathBuf, Instant>`, recording the exact insertion time for each queued file using a monotonic `Instant`. This makes cleanup duration-based and timestamp-agnostic. Using `Instant` specifically guarantees that the 5-minute eviction window is immune to OS clock adjustments or NTP drift.

`DashMap` was chosen over `RwLock<HashMap<...>>` because this structure is used as a per-file reservation table. It allows unrelated file paths to be reserved and removed concurrently through internal sharding, avoiding a single global write lock. The reservation logic uses DashMap’s entry API to preserve the “reserve once” invariant and avoid `contains_key` + `insert` races.

### Key Changes Made in the Patch

**`src/sync.rs`**
* Changed `ACTIVE_OBJECT_STORE_SYNC_FILES` from a globally locked set/map to `DashMap<PathBuf, Instant>`.
* Removed the extra tracking struct and wall-clock timestamp because stale eviction only needs monotonic insertion time.

**`src/storage/object_storage.rs`**
* Updated `process_parquet_files()` to reserve paths using DashMap’s entry API and record `Instant::now()` when a path enters active sync tracking.
* Updated upload failure and validation failure cleanup to remove paths directly from DashMap.
* Updated successful upload cleanup to remove uploaded paths directly from DashMap.
* Updated stale eviction to compare elapsed time from the stored `Instant` instead of regex-parsing the data timestamp from the filename.

<hr>

This PR has:
- [x] been tested to ensure log ingestion and log query works.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Refactor**
  * Improved tracking for active object-store sync files to prevent stale entries from lingering.
  * Updated cleanup logic to use more reliable timing, reducing the chance of incorrect eviction.
  * Ensures active-tracking entries are properly cleared after failed or errored sync attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->