### PR TITLE
update registry to quay

### DIFF
--- a/.github/workflows/build-push-edge-debug.yaml
+++ b/.github/workflows/build-push-edge-debug.yaml
@@ -25,17 +25,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
+      - name: Login to Quay
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: parseable/parseable
+          images: quay.io/parseablehq/parseable
       
       - name: Clean up builder cache
         run: docker builder prune -f
@@ -46,5 +47,5 @@ jobs:
           context: .
           file: ./Dockerfile.debug
           push: true
-          tags: parseable/parseable:edge-debug
+          tags: quay.io/parseablehq/parseable:edge-debug
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build-push-edge-kafka.yaml
+++ b/.github/workflows/build-push-edge-kafka.yaml
@@ -25,17 +25,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
+      - name: Login to Quay
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: parseable/parseable
+          images: quay.io/parseablehq/parseable
 
       - name: Clean up builder cache
         run: docker builder prune -f
@@ -46,7 +47,7 @@ jobs:
           context: .
           file: ./Dockerfile.kafka
           push: true
-          tags: parseable/parseable:edge-kafka-amd64
+          tags: quay.io/parseablehq/parseable:edge-kafka-amd64
           platforms: linux/amd64
           build-args: |
             LIB_DIR=x86_64-linux-gnu
@@ -57,7 +58,7 @@ jobs:
           context: .
           file: ./Dockerfile.kafka
           push: true
-          tags: parseable/parseable:edge-kafka-arm64
+          tags: quay.io/parseablehq/parseable:edge-kafka-arm64
           platforms: linux/arm64
           build-args: |
             LIB_DIR=aarch64-linux-gnu

--- a/.github/workflows/build-push-edge.yaml
+++ b/.github/workflows/build-push-edge.yaml
@@ -25,17 +25,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
+      - name: Login to Quay
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: parseable/parseable
+          images: quay.io/parseablehq/parseable
       
       - name: Clean up builder cache
         run: docker builder prune -f
@@ -46,5 +47,5 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: parseable/parseable:edge
+          tags: quay.io/parseablehq/parseable:edge
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -361,17 +361,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
+      - name: Login to Quay
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: parseable/parseable
+          images: quay.io/parseablehq/parseable
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -379,7 +380,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: parseable/parseable:${{ github.ref_name }}
+          tags: quay.io/parseablehq/parseable:${{ github.ref_name }}
           platforms: linux/amd64,linux/arm64
       
       - name: Build and push kafka amd64
@@ -388,7 +389,7 @@ jobs:
           context: .
           file: ./Dockerfile.kafka
           push: true
-          tags: parseable/parseable:${{ github.ref_name }}-kafka-amd64
+          tags: quay.io/parseablehq/parseable:${{ github.ref_name }}-kafka-amd64
           platforms: linux/amd64
           build-args: |
             LIB_DIR=x86_64-linux-gnu
@@ -399,7 +400,7 @@ jobs:
           context: .
           file: ./Dockerfile.kafka
           push: true
-          tags: parseable/parseable:${{ github.ref_name }}-kafka-arm64
+          tags: quay.io/parseablehq/parseable:${{ github.ref_name }}-kafka-arm64
           platforms: linux/arm64
           build-args: |
             LIB_DIR=aarch64-linux-gnu


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker container images now published to Quay (`quay.io/parseablehq/parseable`) instead of Docker Hub for edge, edge-debug, edge-kafka, and release builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/parseablehq/parseable/pull/1659?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->