### PR TITLE
fix: commit schema bug

### DIFF
--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -86,19 +86,22 @@ impl Event {
             }
         }
 
+        let stream = PARSEABLE.get_or_create_stream(&self.stream_name, &self.tenant_id);
+
         if self.is_first_event {
             commit_schema(&self.stream_name, self.rb.schema(), &self.tenant_id)?;
+            if !stream.get_static_schema_flag() {
+                stream.stage_schema_file(stream.get_schema().as_ref().clone())?;
+            }
         }
 
-        PARSEABLE
-            .get_or_create_stream(&self.stream_name, &self.tenant_id)
-            .push(
-                &key,
-                &self.rb,
-                self.parsed_timestamp,
-                &self.custom_partition_values,
-                self.stream_type,
-            )?;
+        stream.push(
+            &key,
+            &self.rb,
+            self.parsed_timestamp,
+            &self.custom_partition_values,
+            self.stream_type,
+        )?;
 
         let tenant = self.tenant_id.as_deref().unwrap_or(DEFAULT_TENANT);
         update_stats(

--- a/src/parseable/staging/mod.rs
+++ b/src/parseable/staging/mod.rs
@@ -40,4 +40,6 @@ pub enum StagingError {
     TenantNotFound(#[from] TenantNotFound),
     #[error("{0}")]
     PoisonError(#[from] PoisonError<String>),
+    #[error("JSON Error {0}")]
+    Json(#[from] serde_json::Error),
 }

--- a/src/parseable/staging/writer.rs
+++ b/src/parseable/staging/writer.rs
@@ -42,8 +42,9 @@ use crate::{
 
 use super::StagingError;
 
+const DISK_WRITE_BATCH_MAX_AGE_SECS_VAR: &str = "DISK_WRITE_BATCH_MAX_AGE_SECS";
 static DISK_WRITE_BATCH_MAX_AGE_SECS: Lazy<i64> = Lazy::new(|| {
-    if let Ok(var) = std::env::var("P_DISK_WRITE_BATCH_MAX_AGE_SECS")
+    if let Ok(var) = std::env::var(DISK_WRITE_BATCH_MAX_AGE_SECS_VAR)
         && let Ok(var) = var.parse::<i64>()
     {
         var

--- a/src/parseable/staging/writer.rs
+++ b/src/parseable/staging/writer.rs
@@ -29,8 +29,9 @@ use arrow_array::RecordBatch;
 use arrow_ipc::writer::StreamWriter;
 use arrow_schema::Schema;
 use arrow_select::concat::concat_batches;
-use chrono::Utc;
+use chrono::{TimeDelta, Utc};
 use itertools::Itertools;
+use once_cell::sync::Lazy;
 use rand::distributions::{Alphanumeric, DistString};
 use tracing::error;
 
@@ -41,7 +42,15 @@ use crate::{
 
 use super::StagingError;
 
-const DISK_WRITE_BATCH_ROWS: usize = 32_768;
+static DISK_WRITE_BATCH_MAX_AGE_SECS: Lazy<i64> = Lazy::new(|| {
+    if let Ok(var) = std::env::var("P_DISK_WRITE_BATCH_MAX_AGE_SECS")
+        && let Ok(var) = var.parse::<i64>()
+    {
+        var
+    } else {
+        1
+    }
+});
 
 #[derive(Default)]
 pub struct Writer {
@@ -58,13 +67,18 @@ impl Writer {
         rb: &RecordBatch,
         file_path: PathBuf,
         range: TimeRange,
+        batch_rows: usize,
     ) -> Result<(), StagingError> {
+        let now = Utc::now();
         let pending = self.disk_pending.entry(filename.clone()).or_default();
         pending.rows += rb.num_rows();
         pending.range.get_or_insert(range);
+        pending.first_seen.get_or_insert(now);
         pending.batches.push(rb.clone());
 
-        if pending.rows >= DISK_WRITE_BATCH_ROWS {
+        let should_flush = pending.rows >= batch_rows.max(1)
+            || pending.is_older_than(now, TimeDelta::seconds(*DISK_WRITE_BATCH_MAX_AGE_SECS));
+        if should_flush {
             self.flush_pending_disk(&filename, file_path)?;
         }
 
@@ -104,8 +118,12 @@ impl Writer {
 
         let mut flushable_pending = HashMap::new();
         let old_pending = std::mem::take(&mut self.disk_pending);
+        let now = Utc::now();
         for (filename, pending) in old_pending {
-            if !forced && pending.is_current() {
+            if !forced
+                && pending.is_current()
+                && !pending.is_older_than(now, TimeDelta::seconds(*DISK_WRITE_BATCH_MAX_AGE_SECS))
+            {
                 self.disk_pending.insert(filename, pending);
             } else {
                 flushable_pending.insert(filename, pending);
@@ -164,6 +182,7 @@ struct PendingDiskBatch {
     rows: usize,
     batches: Vec<RecordBatch>,
     range: Option<TimeRange>,
+    first_seen: Option<chrono::DateTime<Utc>>,
 }
 
 impl PendingDiskBatch {
@@ -171,6 +190,11 @@ impl PendingDiskBatch {
         self.range
             .as_ref()
             .is_some_and(|range| range.contains(Utc::now()))
+    }
+
+    fn is_older_than(&self, now: chrono::DateTime<Utc>, age: TimeDelta) -> bool {
+        self.first_seen
+            .is_some_and(|first_seen| now.signed_duration_since(first_seen) >= age)
     }
 }
 

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -497,27 +497,34 @@ impl Stream {
         // check if there is already a schema file in staging pertaining to this stream
         // if yes, then merge them and save
 
-        if let Some(mut schema) = schema {
+        if let Some(schema) = schema {
             let static_schema_flag = self.get_static_schema_flag();
             if !static_schema_flag {
-                // schema is dynamic, read from staging and merge if present
-
-                // need to add something before .schema to make the file have an extension of type `schema`
-                let path = RelativePathBuf::from_iter([format!("{}.schema", self.stream_name)])
-                    .to_path(&self.data_path);
-
-                let staging_schemas = self.get_schemas_if_present();
-                if let Some(mut staging_schemas) = staging_schemas {
-                    staging_schemas.push(schema);
-                    schema = Schema::try_merge(staging_schemas)?;
-                }
-
-                // save the merged schema on staging disk
-                // the path should be stream/.ingestor.{id}.schema
-                info!("writing schema to path - {path:?}");
-                write(path, to_bytes(&schema))?;
+                self.stage_schema_file(schema)?;
             }
         }
+
+        Ok(())
+    }
+
+    pub fn stage_schema_file(&self, mut schema: Schema) -> Result<(), StagingError> {
+        // schema is dynamic, read from staging and merge if present
+        fs::create_dir_all(&self.data_path)?;
+
+        // need to add something before .schema to make the file have an extension of type `schema`
+        let path = RelativePathBuf::from_iter([format!("{}.schema", self.stream_name)])
+            .to_path(&self.data_path);
+
+        let staging_schemas = self.get_schemas_if_present();
+        if let Some(mut staging_schemas) = staging_schemas {
+            staging_schemas.push(schema);
+            schema = Schema::try_merge(staging_schemas)?;
+        }
+
+        // save the merged schema on staging disk
+        // the path should be stream/.ingestor.{id}.schema
+        info!("writing schema to path - {path:?}");
+        write(path, to_bytes(&schema))?;
 
         Ok(())
     }

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -23,6 +23,7 @@ use arrow_schema::{Field, Fields, Schema};
 use chrono::{NaiveDateTime, Timelike, Utc};
 use derive_more::derive::{Deref, DerefMut};
 use itertools::Itertools;
+use once_cell::sync::Lazy;
 use parquet::{
     arrow::ArrowWriter,
     basic::Encoding,
@@ -68,6 +69,16 @@ use super::{
     ARROW_FILE_EXTENSION, LogStream, PART_FILE_EXTENSION,
     staging::{StagingError, reader::MergedReverseRecordReader, writer::Writer},
 };
+
+static DISK_WRITE_BATCH_ROWS: Lazy<usize> = Lazy::new(|| {
+    if let Ok(var) = std::env::var("P_DISK_WRITE_BATCH_ROWS")
+        && let Ok(var) = var.parse::<usize>()
+    {
+        var
+    } else {
+        1
+    }
+});
 
 const INPROCESS_DIR_PREFIX: &str = "processing_";
 const METRIC_ROW_GROUP_PREP_IN_FLIGHT: usize = 1;
@@ -115,6 +126,7 @@ pub struct Stream {
     pub data_path: PathBuf,
     pub options: Arc<Options>,
     pub writer: Mutex<Writer>,
+    schema_writer: Mutex<()>,
     pub ingestor_id: Option<String>,
 }
 impl Stream {
@@ -134,6 +146,7 @@ impl Stream {
             data_path,
             options,
             writer: Mutex::new(Writer::default()),
+            schema_writer: Mutex::new(()),
             ingestor_id,
         })
     }
@@ -181,7 +194,7 @@ impl Stream {
             );
             let file_path = self.data_path.join(&filename);
 
-            guard.push_disk(filename, record, file_path, range)?;
+            guard.push_disk(filename, record, file_path, range, *DISK_WRITE_BATCH_ROWS)?;
         }
 
         guard.mem.push(schema_key, record)?;
@@ -435,9 +448,9 @@ impl Stream {
             .collect()
     }
 
-    pub fn get_schemas_if_present(&self) -> Option<Vec<Schema>> {
+    pub fn get_schemas_if_present(&self) -> Result<Vec<Schema>, StagingError> {
         let Ok(dir) = self.data_path.read_dir() else {
-            return None;
+            return Ok(vec![]);
         };
 
         let mut schemas: Vec<Schema> = Vec::new();
@@ -448,19 +461,11 @@ impl Stream {
             {
                 let file = File::open(file.path()).expect("Schema File should exist");
 
-                let schema = match serde_json::from_reader(file) {
-                    Ok(schema) => schema,
-                    Err(_) => continue,
-                };
-                schemas.push(schema);
+                schemas.push(serde_json::from_reader(file)?);
             }
         }
 
-        if !schemas.is_empty() {
-            Some(schemas)
-        } else {
-            None
-        }
+        Ok(schemas)
     }
 
     /// Converts arrow files in staging into parquet files, does so only for past minutes when run with `!shutdown_signal`
@@ -508,15 +513,28 @@ impl Stream {
     }
 
     pub fn stage_schema_file(&self, mut schema: Schema) -> Result<(), StagingError> {
+        let _schema_writer = self.schema_writer.lock().map_err(|poisoned| {
+            StagingError::PoisonError(PoisonError::new(format!(
+                "Schema writer lock poisoned while staging schema for stream {} - {}",
+                self.stream_name, poisoned
+            )))
+        })?;
+
         // schema is dynamic, read from staging and merge if present
         fs::create_dir_all(&self.data_path)?;
 
         // need to add something before .schema to make the file have an extension of type `schema`
-        let path = RelativePathBuf::from_iter([format!("{}.schema", self.stream_name)])
-            .to_path(&self.data_path);
+        let file_name = self
+            .ingestor_id
+            .as_ref()
+            .map(|id| format!(".ingestor.{id}.schema"))
+            .unwrap_or_else(|| ".schema".to_owned());
+        let path = RelativePathBuf::from_iter([file_name]).to_path(&self.data_path);
+        let tmp_path = path.with_extension("schema.tmp");
 
-        let staging_schemas = self.get_schemas_if_present();
-        if let Some(mut staging_schemas) = staging_schemas {
+        let staging_schemas = self.get_schemas_if_present()?;
+        if !staging_schemas.is_empty() {
+            let mut staging_schemas = staging_schemas;
             staging_schemas.push(schema);
             schema = Schema::try_merge(staging_schemas)?;
         }
@@ -524,7 +542,8 @@ impl Stream {
         // save the merged schema on staging disk
         // the path should be stream/.ingestor.{id}.schema
         info!("writing schema to path - {path:?}");
-        write(path, to_bytes(&schema))?;
+        write(&tmp_path, to_bytes(&schema))?;
+        fs::rename(tmp_path, path)?;
 
         Ok(())
     }

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -70,8 +70,9 @@ use super::{
     staging::{StagingError, reader::MergedReverseRecordReader, writer::Writer},
 };
 
+const DISK_WRITE_BATCH_ROWS_VAR: &str = "DISK_WRITE_BATCH_ROWS";
 static DISK_WRITE_BATCH_ROWS: Lazy<usize> = Lazy::new(|| {
-    if let Ok(var) = std::env::var("P_DISK_WRITE_BATCH_ROWS")
+    if let Ok(var) = std::env::var(DISK_WRITE_BATCH_ROWS_VAR)
         && let Ok(var) = var.parse::<usize>()
     {
         var
@@ -449,9 +450,7 @@ impl Stream {
     }
 
     pub fn get_schemas_if_present(&self) -> Result<Vec<Schema>, StagingError> {
-        let Ok(dir) = self.data_path.read_dir() else {
-            return Ok(vec![]);
-        };
+        let dir = self.data_path.read_dir()?;
 
         let mut schemas: Vec<Schema> = Vec::new();
 
@@ -459,7 +458,7 @@ impl Stream {
             if let Some(ext) = file.path().extension()
                 && ext.eq("schema")
             {
-                let file = File::open(file.path()).expect("Schema File should exist");
+                let file = File::open(file.path())?;
 
                 schemas.push(serde_json::from_reader(file)?);
             }
@@ -524,11 +523,10 @@ impl Stream {
         fs::create_dir_all(&self.data_path)?;
 
         // need to add something before .schema to make the file have an extension of type `schema`
-        let file_name = self
-            .ingestor_id
-            .as_ref()
-            .map(|id| format!(".ingestor.{id}.schema"))
-            .unwrap_or_else(|| ".schema".to_owned());
+        let file_name = self.ingestor_id.as_ref().map_or_else(
+            || ".schema".to_owned(),
+            |id| format!(".ingestor.{id}.schema"),
+        );
         let path = RelativePathBuf::from_iter([file_name]).to_path(&self.data_path);
         let tmp_path = path.with_extension("schema.tmp");
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Parseable enterprise failed Quest test due to schema not being present in metastore as soon as possible

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved event processing and schema staging flow for atomic, serialized schema updates to avoid conflicts.

* **Bug Fixes**
  * Schema JSON/parse failures are now surfaced instead of being ignored.
  * Disk write flushing is now configurable and time-aware to ensure timely and reliable batch persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->