### PR TITLE
helm: support tolerations (plural) and affinity in standalone deployment

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: parseable
 description: Helm chart for Parseable OSS version. Columnar data lake platform - purpose built for observability
 type: application
-version: 2.8.1
+version: 2.8.2
 appVersion: "v2.8.1"
 icon: "https://raw.githubusercontent.com/parseablehq/.github/main/images/logo.svg"
 

--- a/helm/templates/standalone-deployment.yaml
+++ b/helm/templates/standalone-deployment.yaml
@@ -165,8 +165,12 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.parseable.toleration }}
+      {{- with .Values.parseable.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.parseable.affinity }}
+      affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -159,7 +159,8 @@ parseable:
     httpGet:
       path: /api/v1/readiness
       port: 8000
-  toleration: []
+  tolerations: []
+  affinity: {}
   resources:
     limits:
       cpu: 500m
@@ -212,11 +213,9 @@ parseable:
     fsGroupChangePolicy: "Always"
   nameOverride: ""
   fullnameOverride: ""
-  affinity: {}
   podLabels:
     app: parseable
     component: query
-  tolerations: []
   ## Use this section to create ServiceMonitor object for
   ## this Parseable deployment. Read more on ServiceMonitor
   ## here: https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.ServiceMonitor


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Helm chart version bumped to 2.8.2.
  * Improved pod scheduling configuration: supports tolerations as a list, adds optional affinity support, and standardizes how scheduling settings are rendered and applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->