### PR TITLE
dashboard: allow optional fields in dashboard json

### DIFF
--- a/src/handlers/http/users/dashboards.rs
+++ b/src/handlers/http/users/dashboards.rs
@@ -127,9 +127,7 @@ pub async fn update_dashboard(
 
     // Validate: either query params OR body, not both
     let has_query_params = !query_map.is_empty();
-    let has_body_update = dashboard.as_ref().is_some_and(|d| {
-        d.title != existing_dashboard.title || d.tiles.is_some() || d.other_fields.is_some()
-    });
+    let has_body_update = dashboard.is_some();
 
     if has_query_params && has_body_update {
         return Err(DashboardError::Metadata(

--- a/src/handlers/http/users/dashboards.rs
+++ b/src/handlers/http/users/dashboards.rs
@@ -127,9 +127,9 @@ pub async fn update_dashboard(
 
     // Validate: either query params OR body, not both
     let has_query_params = !query_map.is_empty();
-    let has_body_update = dashboard
-        .as_ref()
-        .is_some_and(|d| d.title != existing_dashboard.title || d.tiles.is_some());
+    let has_body_update = dashboard.as_ref().is_some_and(|d| {
+        d.title != existing_dashboard.title || d.tiles.is_some() || d.other_fields.is_some()
+    });
 
     if has_query_params && has_body_update {
         return Err(DashboardError::Metadata(

--- a/src/users/dashboards.rs
+++ b/src/users/dashboards.rs
@@ -68,6 +68,9 @@ pub struct Dashboard {
     dashboard_type: Option<DashboardType>,
     pub tiles: Option<Vec<Tile>>,
     pub tenant_id: Option<String>,
+    /// all other fields are variable and can be added as needed
+    #[serde(flatten)]
+    pub other_fields: Option<serde_json::Map<String, Value>>,
 }
 
 impl MetastoreObject for Dashboard {


### PR DESCRIPTION
currently we allow optional fields for each tile in the dashboard 
this change allows fields to be added from caller in the dashboard section also

useful when client adds more feature to dashboard like - settings, variables etc



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined dashboard update validation to properly handle additional field changes alongside existing parameters.

* **Refactor**
  * Improved data structure handling for dashboard tile serialization and deserialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->