### PR TITLE
bugfix: schema updation issue

### DIFF
--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -529,7 +529,11 @@ impl Stream {
 
         dir.flatten()
             .map(|file| file.path())
-            .filter(|file| file.extension().is_some_and(|ext| ext.eq("schema")))
+            .filter(|file| {
+                file.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.ends_with(".schema"))
+            })
             .collect()
     }
 
@@ -539,8 +543,11 @@ impl Stream {
         let mut schemas: Vec<Schema> = Vec::new();
 
         for file in dir.flatten() {
-            if let Some(ext) = file.path().extension()
-                && ext.eq("schema")
+            if file
+                .path()
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.ends_with(".schema"))
             {
                 let file = File::open(file.path())?;
 


### PR DESCRIPTION
in standalone mode, the `.schema` file from staging wasn't getting pushed to storage due to the improper usage of `path().extension()` function. It was always returning `None`. Instead of checking whether the extension is `schema`, check if the file path ends with `.schema`

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema file discovery by detecting staging schema files via their filename suffix (`.schema`) rather than relying on exact extension matching, resulting in more reliable schema loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->