### PR TITLE
add optional ingestion quota to tenant metadata

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -93,7 +93,8 @@ pub use localfs::FSConfig;
 pub use object_storage::{ObjectStorage, ObjectStorageProvider};
 pub use s3::S3Config;
 pub use store_metadata::{
-    StorageMetadata, put_remote_metadata, put_staging_metadata, resolve_parseable_metadata,
+    IngestionQuota, IngestionQuotaType, QuotaPeriod, StorageMetadata, put_remote_metadata,
+    put_staging_metadata, resolve_parseable_metadata,
 };
 
 // metadata file names in a Stream prefix

--- a/src/storage/store_metadata.rs
+++ b/src/storage/store_metadata.rs
@@ -53,6 +53,28 @@ pub struct StaticStorageMetadata {
 
 // Type for serialization and deserialization
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IngestionQuota {
+    #[serde(rename = "type")]
+    pub quota_type: IngestionQuotaType,
+    pub limit: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum IngestionQuotaType {
+    SizeBytes,
+    EventCount,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum QuotaPeriod {
+    Monthly,
+    Yearly,
+    Lifetime,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct StorageMetadata {
     pub version: String,
     pub mode: String,
@@ -79,6 +101,10 @@ pub struct StorageMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plan: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ingestion_quota: Option<IngestionQuota>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quota_period: Option<QuotaPeriod>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub owner: Option<String>,
 }
 
@@ -102,6 +128,8 @@ impl Default for StorageMetadata {
             start_date: None,
             end_date: None,
             plan: None,
+            ingestion_quota: None,
+            quota_period: None,
             owner: None,
         }
     }

--- a/src/tenants/mod.rs
+++ b/src/tenants/mod.rs
@@ -66,6 +66,7 @@ impl TenantMetadata {
         self.tenants.get(tenant_id).map(|t| t.meta.clone())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn update_tenant_meta(
         &self,
         tenant_id: &str,

--- a/src/tenants/mod.rs
+++ b/src/tenants/mod.rs
@@ -23,7 +23,10 @@ use itertools::Itertools;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 
-use crate::{rbac::role::Action, storage::StorageMetadata};
+use crate::{
+    rbac::role::Action,
+    storage::{IngestionQuota, QuotaPeriod, StorageMetadata},
+};
 
 pub static TENANT_METADATA: Lazy<Arc<TenantMetadata>> =
     Lazy::new(|| Arc::new(TenantMetadata::default()));
@@ -70,12 +73,16 @@ impl TenantMetadata {
         start_date: Option<String>,
         end_date: Option<String>,
         plan: Option<String>,
+        ingestion_quota: Option<IngestionQuota>,
+        quota_period: Option<QuotaPeriod>,
     ) -> bool {
         if let Some(mut tenant) = self.tenants.get_mut(tenant_id) {
             tenant.meta.customer_name = customer_name;
             tenant.meta.start_date = start_date;
             tenant.meta.end_date = end_date;
             tenant.meta.plan = plan;
+            tenant.meta.ingestion_quota = ingestion_quota;
+            tenant.meta.quota_period = quota_period;
             true
         } else {
             false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ingestion quota management across metadata, including optional limits based on size-bytes or event-count with monthly, yearly, or lifetime periods.
  * Extended tenant metadata updates to accept and persist ingestion quota and quota period information.
* **Chores**
  * Updated public re-export formatting for storage metadata (no functional changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->