### PR TITLE
fix: create checksum

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -327,6 +327,8 @@ jobs:
     steps:
       - name: Download artifacts created
         uses: actions/download-artifact@v4.1.7
+        with:
+          pattern: Parseable_OSS_*
 
       - name: Run shasum command
         run: |


### PR DESCRIPTION
error log says -
```
2026-06-24T02:51:44.6764789Z Found 9 artifact(s)
2026-06-24T02:51:44.6766835Z No input name or pattern filtered specified, downloading all artifacts
2026-06-24T02:51:44.6768784Z An extra directory with the artifact name will be created for each download
2026-06-24T02:51:44.6771068Z Preparing to download the following artifacts:
2026-06-24T02:51:44.6772592Z - Parseable_OSS_x86_64-pc-windows-msvc.exe (ID: 7829062620, Size: 63567218)
2026-06-24T02:51:44.6774399Z - parseablehq~parseable~P3HWJ4.dockerbuild (ID: 7826604239, Size: 143859)
2026-06-24T02:51:44.6776158Z - parseablehq~parseable~ZRSGVU.dockerbuild (ID: 7826603492, Size: 80459)
2026-06-24T02:51:44.6777980Z - parseablehq~parseable~H1S8EH.dockerbuild (ID: 7826602840, Size: 82911)
2026-06-24T02:51:44.6780110Z - Parseable_OSS_aarch64-apple-darwin-kafka (ID: 7824801136, Size: 61255282)
2026-06-24T02:51:44.6781982Z - Parseable_OSS_x86_64-unknown-linux-gnu-kafka (ID: 7824782933, Size: 67270299)
2026-06-24T02:51:44.6783825Z - Parseable_OSS_x86_64-unknown-linux-gnu (ID: 7824392475, Size: 63793893)
2026-06-24T02:51:44.6785564Z - Parseable_OSS_aarch64-apple-darwin (ID: 7824174867, Size: 58240501)
2026-06-24T02:51:44.6787349Z - Parseable_OSS_aarch64-unknown-linux-gnu (ID: 7823892564, Size: 62219518)
2026-06-24T02:51:48.3033121Z Artifact download completed successfully.
2026-06-24T02:51:48.4990067Z Artifact download completed successfully.
2026-06-24T02:51:48.5846263Z Artifact download completed successfully.
2026-06-24T02:51:48.6834852Z Artifact download completed successfully.
2026-06-24T02:51:48.7339086Z Artifact download completed successfully.
2026-06-24T02:51:48.7879220Z Artifact download completed successfully.
2026-06-24T02:52:10.2001073Z ##[error]Unable to download artifact(s): Unable to download and extract artifact: Artifact download failed after 5 retries.
```

the download artifact step is failing to download the *.dockerbuild file which gets created by the softprops/action-gh-release but create checksum step should look at Parseable_OSS* binaries only

fix is to add a filter to download only Parseable_OSS_* files and skip other intermediate files like *.dockerbuild
because dockerbuild files download should not fail checksum job



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined release workflow artifact handling for improved checksum generation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->