### PR TITLE
minor migration update

### DIFF
--- a/src/enterprise/utils.rs
+++ b/src/enterprise/utils.rs
@@ -99,7 +99,7 @@ pub async fn fetch_parquet_file_paths(
 
     let obs = PARSEABLE
         .metastore
-        .get_all_stream_jsons(stream, None, tenant_id)
+        .get_all_stream_jsons(stream, None, tenant_id, false)
         .await;
     if let Ok(obs) = obs {
         for ob in obs {

--- a/src/handlers/http/cluster/mod.rs
+++ b/src/handlers/http/cluster/mod.rs
@@ -872,7 +872,7 @@ pub async fn fetch_stats_from_ingestors(
 ) -> Result<Vec<utils::QueriedStats>, StreamError> {
     let obs = PARSEABLE
         .metastore
-        .get_all_stream_jsons(stream_name, Some(Mode::Ingest), tenant_id)
+        .get_all_stream_jsons(stream_name, Some(Mode::Ingest), tenant_id, false)
         .await?;
 
     let mut ingestion_size = 0u64;

--- a/src/handlers/http/modal/query/querier_logstream.rs
+++ b/src/handlers/http/modal/query/querier_logstream.rs
@@ -197,7 +197,7 @@ pub async fn get_stats(
         if !date_value.is_empty() {
             let obs = PARSEABLE
                 .metastore
-                .get_all_stream_jsons(&stream_name, None, &tenant_id)
+                .get_all_stream_jsons(&stream_name, None, &tenant_id, false)
                 .await?;
 
             let mut stream_jsons = Vec::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub mod handlers;
 pub mod hottier;
 pub mod interactive;
 mod livetail;
-mod metadata;
+pub mod metadata;
 pub mod metastore;
 pub mod metrics;
 pub mod migration;

--- a/src/metastore/metastore_traits.rs
+++ b/src/metastore/metastore_traits.rs
@@ -247,6 +247,7 @@ pub trait Metastore: std::fmt::Debug + Send + Sync {
         stream_name: &str,
         mode: Option<Mode>,
         tenant_id: &Option<String>,
+        is_migration: bool
     ) -> Result<Vec<Bytes>, MetastoreError>;
 
     /// Fetch manifests only for the explicitly requested date keys

--- a/src/metastore/metastores/object_store_metastore.rs
+++ b/src/metastore/metastores/object_store_metastore.rs
@@ -892,6 +892,7 @@ impl Metastore for ObjectStoreMetastore {
         stream_name: &str,
         mode: Option<Mode>,
         tenant_id: &Option<String>,
+        _is_migration: bool
     ) -> Result<Vec<Bytes>, MetastoreError> {
         let root = tenant_id.as_deref().unwrap_or("");
         let path = RelativePathBuf::from_iter([root, stream_name, STREAM_ROOT_DIRECTORY]);

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -272,6 +272,14 @@ async fn migration_stream(
     let schema = storage
         .create_schema_from_metastore(stream, tenant_id)
         .await?;
+
+    if PARSEABLE.options.mode == Mode::Prism {
+        // read stream jsons once
+        PARSEABLE
+            .metastore
+            .get_all_stream_jsons(stream, None, tenant_id, true)
+            .await?;
+    }
     let stream_metadata = fetch_or_create_stream_metadata(stream, storage, tenant_id).await?;
 
     let mut stream_meta_found = true;
@@ -327,7 +335,7 @@ async fn fetch_or_create_stream_metadata(
     }
 }
 
-async fn migrate_stream_metadata(
+pub async fn migrate_stream_metadata(
     mut stream_metadata_value: Value,
     stream: &str,
     schema: &Bytes,
@@ -432,7 +440,7 @@ async fn migrate_stream_metadata(
     Ok(stream_metadata_value)
 }
 
-async fn setup_logstream_metadata(
+pub async fn setup_logstream_metadata(
     stream: &str,
     arrow_schema: &mut Schema,
     stream_metadata_value: Value,

--- a/src/prism/home/mod.rs
+++ b/src/prism/home/mod.rs
@@ -212,7 +212,7 @@ pub async fn generate_home_response(
 async fn get_stream_metadata(stream: String, tenant_id: &Option<String>) -> StreamMetadataResponse {
     let obs = PARSEABLE
         .metastore
-        .get_all_stream_jsons(&stream, None, tenant_id)
+        .get_all_stream_jsons(&stream, None, tenant_id, false)
         .await?;
     let mut stream_jsons = Vec::new();
     for ob in obs {

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -769,7 +769,7 @@ pub async fn get_manifest_list(
     if PARSEABLE.options.mode == Mode::Query || PARSEABLE.options.mode == Mode::Prism {
         let obs = PARSEABLE
             .metastore
-            .get_all_stream_jsons(stream_name, None, tenant_id)
+            .get_all_stream_jsons(stream_name, None, tenant_id, false)
             .await;
         if let Ok(obs) = obs {
             for ob in obs {

--- a/src/query/stream_schema_provider.rs
+++ b/src/query/stream_schema_provider.rs
@@ -566,7 +566,7 @@ impl TableProvider for StandardTableProvider {
         if PARSEABLE.options.mode == Mode::Query || PARSEABLE.options.mode == Mode::Prism {
             let obs = PARSEABLE
                 .metastore
-                .get_all_stream_jsons(&self.stream, None, &self.tenant_id)
+                .get_all_stream_jsons(&self.stream, None, &self.tenant_id, false)
                 .await;
             if let Ok(obs) = obs {
                 for ob in obs {

--- a/src/storage/object_storage.rs
+++ b/src/storage/object_storage.rs
@@ -746,7 +746,7 @@ pub trait ObjectStorage: Debug + Send + Sync + 'static {
 
         if let Some(stream_metadata_obs) = PARSEABLE
             .metastore
-            .get_all_stream_jsons(stream_name, Some(Mode::Ingest), tenant_id)
+            .get_all_stream_jsons(stream_name, Some(Mode::Ingest), tenant_id, false)
             .await
             .into_iter()
             .next()
@@ -837,7 +837,7 @@ pub trait ObjectStorage: Debug + Send + Sync + 'static {
         let mut all_log_sources: Vec<LogSourceEntry> = Vec::new();
         let stream_metas = PARSEABLE
             .metastore
-            .get_all_stream_jsons(stream_name, None, tenant_id)
+            .get_all_stream_jsons(stream_name, None, tenant_id, false)
             .await;
         if let Ok(stream_metas) = stream_metas {
             for stream_meta in stream_metas.iter() {


### PR DESCRIPTION
if mode is Prism, it will read all stream jsons once

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stream metadata lookups now use a consistent updated request path across queries, stats, storage, and dashboard views.
  * Improved handling during migration-related workflows, helping metadata loading stay reliable in Prism mode.

* **New Features**
  * Made metadata utilities available through the public API for broader reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->