### PR TITLE
fix: api key security risk

### DIFF
--- a/src/handlers/http/middleware.rs
+++ b/src/handlers/http/middleware.rs
@@ -186,6 +186,10 @@ where
                         permissions,
                         &user.tenant,
                     );
+                    req.headers_mut().insert(
+                        HeaderName::from_static(TENANT_ID),
+                        HeaderValue::from_str(tenant).unwrap(),
+                    );
                     req.extensions_mut().insert(session_key);
                     Some(session_id)
                 }


### PR DESCRIPTION
add tenant id to the header when sent in the request 
otherwise server treats this as default tenant



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Requests authenticated with an API key now carry the correct tenant information through the rest of the request flow.
  * Downstream features that depend on tenant context now reliably use the tenant associated with the API key user, improving consistency when a tenant header is also provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->