### PR TITLE
fix(otel): sync OTEL_METRICS_KNOWN_FIELD_LIST with emitted keys (#1723)

### DIFF
--- a/src/otel/metrics.rs
+++ b/src/otel/metrics.rs
@@ -37,7 +37,7 @@ use super::otel_utils::{
     convert_epoch_nano_to_timestamp, insert_attributes, insert_number_if_some,
 };
 
-pub const OTEL_METRICS_KNOWN_FIELD_LIST: [&str; 38] = [
+pub const OTEL_METRICS_KNOWN_FIELD_LIST: [&str; 37] = [
     "metric_name",
     "metric_description",
     "metric_unit",
@@ -57,8 +57,15 @@ pub const OTEL_METRICS_KNOWN_FIELD_LIST: [&str; 38] = [
     "data_point_sum",
     "data_point_bucket_counts",
     "data_point_explicit_bounds",
-    "data_point_quantile_values_quantile",
-    "data_point_quantile_values_value",
+    // Nested array of summary quantile objects, each carrying `quantile`
+    // and `value`. Stored under this single key and kept out of the
+    // series hash so per-sample quantile values never fragment series
+    // identity. (The bare `quantile`/`value` keys only ever appear nested
+    // inside this array, never as top-level data-point fields.)
+    "data_point_quantile_values",
+    // Histogram per-sample min/max statistics.
+    "min",
+    "max",
     "data_point_scale",
     "data_point_zero_count",
     "data_point_flags",
@@ -67,8 +74,6 @@ pub const OTEL_METRICS_KNOWN_FIELD_LIST: [&str; 38] = [
     "positive_bucket_count",
     "negative_offset",
     "negative_bucket_count",
-    "quantile",
-    "value",
     "is_monotonic",
     "aggregation_temporality",
     "aggregation_temporality_description",
@@ -1026,9 +1031,91 @@ mod tests {
         assert_eq!(compute_series_hash(&a), compute_series_hash(&b));
     }
 
+    fn number(value: f64) -> Value {
+        serde_json::Number::from_f64(value)
+            .map(Value::Number)
+            .unwrap_or(Value::Null)
+    }
+
+    #[test]
+    fn series_hash_ignores_histogram_min_max() {
+        // `min`/`max` are per-sample histogram statistics, not series
+        // labels. Two samples of the same series with different min/max
+        // must hash identically, otherwise histogram series fragment on
+        // every scrape.
+        let mut a = make_dp();
+        a.insert("min".to_string(), number(1.0));
+        a.insert("max".to_string(), number(9.0));
+        let mut b = make_dp();
+        b.insert("min".to_string(), number(2.0));
+        b.insert("max".to_string(), number(8.0));
+        assert_eq!(compute_series_hash(&a), compute_series_hash(&b));
+    }
+
+    #[test]
+    fn series_hash_ignores_summary_quantile_values() {
+        // `data_point_quantile_values` is the nested per-sample quantile
+        // array. Differing quantile values must not change series identity.
+        let mut a = make_dp();
+        a.insert(
+            "data_point_quantile_values".to_string(),
+            Value::Array(vec![number(0.5), number(0.9)]),
+        );
+        let mut b = make_dp();
+        b.insert(
+            "data_point_quantile_values".to_string(),
+            Value::Array(vec![number(0.7), number(0.99)]),
+        );
+        assert_eq!(compute_series_hash(&a), compute_series_hash(&b));
+    }
+
     #[test]
     fn known_field_list_contains_exemplars() {
-        assert_eq!(OTEL_METRICS_KNOWN_FIELD_LIST.len(), 38);
         assert!(OTEL_METRICS_KNOWN_FIELDS.contains("exemplars"));
+    }
+
+    #[test]
+    fn series_hash_distinguishes_attribute_named_value_or_quantile() {
+        // `value` and `quantile` are only ever emitted nested inside the
+        // quantile array, never as top-level fields. They must NOT be
+        // treated as known fields: a user attribute literally named
+        // `value` or `quantile` is a real label and must affect series
+        // identity (previously it was wrongly excluded, colliding series).
+        let mut a = make_dp();
+        a.insert("value".to_string(), Value::String("x".into()));
+        let mut b = make_dp();
+        b.insert("value".to_string(), Value::String("y".into()));
+        assert_ne!(compute_series_hash(&a), compute_series_hash(&b));
+
+        let mut c = make_dp();
+        c.insert("quantile".to_string(), Value::String("p50".into()));
+        let mut d = make_dp();
+        d.insert("quantile".to_string(), Value::String("p99".into()));
+        assert_ne!(compute_series_hash(&c), compute_series_hash(&d));
+    }
+
+    #[test]
+    fn known_field_list_matches_emitted_keys() {
+        // Guard the list against drifting from the keys the flatteners
+        // actually emit as top-level data-point fields.
+        assert_eq!(OTEL_METRICS_KNOWN_FIELD_LIST.len(), 37);
+        for field in ["min", "max", "data_point_quantile_values", "exemplars"] {
+            assert!(
+                OTEL_METRICS_KNOWN_FIELDS.contains(field),
+                "expected `{field}` to be a known field"
+            );
+        }
+        // Removed dead entries that were never emitted as top-level keys.
+        for field in [
+            "quantile",
+            "value",
+            "data_point_quantile_values_quantile",
+            "data_point_quantile_values_value",
+        ] {
+            assert!(
+                !OTEL_METRICS_KNOWN_FIELDS.contains(field),
+                "`{field}` must not be a known field"
+            );
+        }
     }
 }

--- a/src/otel/metrics.rs
+++ b/src/otel/metrics.rs
@@ -1109,11 +1109,13 @@ mod tests {
     fn known_field_list_matches_emitted_keys() {
         // Guard the list against drifting from the keys the flatteners
         // actually emit as top-level data-point fields.
-        assert_eq!(OTEL_METRICS_KNOWN_FIELD_LIST.len(), 37);
+        assert_eq!(OTEL_METRICS_KNOWN_FIELD_LIST.len(), 39);
         for field in [
             "data_point_min",
             "data_point_max",
             "data_point_quantile_values",
+            "data_point_quantile_values_quantile",
+            "data_point_quantile_values_value",
             "exemplars",
         ] {
             assert!(
@@ -1122,14 +1124,7 @@ mod tests {
             );
         }
         // Removed dead entries that were never emitted as top-level keys.
-        for field in [
-            "quantile",
-            "value",
-            "min",
-            "max",
-            "data_point_quantile_values_quantile",
-            "data_point_quantile_values_value",
-        ] {
+        for field in ["quantile", "value", "min", "max"] {
             assert!(
                 !OTEL_METRICS_KNOWN_FIELDS.contains(field),
                 "`{field}` must not be a known field"

--- a/src/otel/metrics.rs
+++ b/src/otel/metrics.rs
@@ -39,7 +39,7 @@ use super::otel_utils::{
 
 pub const SERIES_HASH_COLUMN: &str = "__series_hash_u64";
 
-pub const OTEL_METRICS_KNOWN_FIELD_LIST: [&str; 38] = [
+pub const OTEL_METRICS_KNOWN_FIELD_LIST: [&str; 39] = [
     "metric_name",
     "metric_description",
     "metric_unit",
@@ -59,12 +59,9 @@ pub const OTEL_METRICS_KNOWN_FIELD_LIST: [&str; 38] = [
     "data_point_sum",
     "data_point_bucket_counts",
     "data_point_explicit_bounds",
-    // Nested array of summary quantile objects, each carrying `quantile`
-    // and `value`. Stored under this single key and kept out of the
-    // series hash so per-sample quantile values never fragment series
-    // identity. (The bare `quantile`/`value` keys only ever appear nested
-    // inside this array, never as top-level data-point fields.)
     "data_point_quantile_values",
+    "data_point_quantile_values_quantile",
+    "data_point_quantile_values_value",
     // Histogram per-sample min/max statistics.
     "data_point_min",
     "data_point_max",

--- a/src/otel/metrics.rs
+++ b/src/otel/metrics.rs
@@ -64,8 +64,8 @@ pub const OTEL_METRICS_KNOWN_FIELD_LIST: [&str; 37] = [
     // inside this array, never as top-level data-point fields.)
     "data_point_quantile_values",
     // Histogram per-sample min/max statistics.
-    "min",
-    "max",
+    "data_point_min",
+    "data_point_max",
     "data_point_scale",
     "data_point_zero_count",
     "data_point_flags",
@@ -364,8 +364,8 @@ fn flatten_histogram(histogram: &Histogram, flatten_exemplars: bool) -> Vec<Map<
         );
 
         insert_data_point_flags(&mut data_point_json, data_point.flags);
-        insert_number_if_some(&mut data_point_json, "min", &data_point.min);
-        insert_number_if_some(&mut data_point_json, "max", &data_point.max);
+        insert_number_if_some(&mut data_point_json, "data_point_min", &data_point.min);
+        insert_number_if_some(&mut data_point_json, "data_point_max", &data_point.max);
         insert_aggregation_temporality(&mut data_point_json, histogram.aggregation_temporality);
         data_points_json.push(data_point_json);
     }
@@ -1039,16 +1039,16 @@ mod tests {
 
     #[test]
     fn series_hash_ignores_histogram_min_max() {
-        // `min`/`max` are per-sample histogram statistics, not series
-        // labels. Two samples of the same series with different min/max
-        // must hash identically, otherwise histogram series fragment on
-        // every scrape.
+        // `data_point_min`/`data_point_max` are per-sample histogram
+        // statistics, not series labels. Two samples of the same series with
+        // different min/max must hash identically, otherwise histogram
+        // series fragment on every scrape.
         let mut a = make_dp();
-        a.insert("min".to_string(), number(1.0));
-        a.insert("max".to_string(), number(9.0));
+        a.insert("data_point_min".to_string(), number(1.0));
+        a.insert("data_point_max".to_string(), number(9.0));
         let mut b = make_dp();
-        b.insert("min".to_string(), number(2.0));
-        b.insert("max".to_string(), number(8.0));
+        b.insert("data_point_min".to_string(), number(2.0));
+        b.insert("data_point_max".to_string(), number(8.0));
         assert_eq!(compute_series_hash(&a), compute_series_hash(&b));
     }
 
@@ -1095,11 +1095,35 @@ mod tests {
     }
 
     #[test]
+    fn series_hash_distinguishes_attribute_named_min_or_max() {
+        // Histogram min/max statistics are emitted under the prefixed
+        // `data_point_min`/`data_point_max` keys, not bare `min`/`max`. A
+        // user attribute literally named `min` or `max` is a real label and
+        // must affect series identity.
+        let mut a = make_dp();
+        a.insert("min".to_string(), Value::String("x".into()));
+        let mut b = make_dp();
+        b.insert("min".to_string(), Value::String("y".into()));
+        assert_ne!(compute_series_hash(&a), compute_series_hash(&b));
+
+        let mut c = make_dp();
+        c.insert("max".to_string(), Value::String("x".into()));
+        let mut d = make_dp();
+        d.insert("max".to_string(), Value::String("y".into()));
+        assert_ne!(compute_series_hash(&c), compute_series_hash(&d));
+    }
+
+    #[test]
     fn known_field_list_matches_emitted_keys() {
         // Guard the list against drifting from the keys the flatteners
         // actually emit as top-level data-point fields.
         assert_eq!(OTEL_METRICS_KNOWN_FIELD_LIST.len(), 37);
-        for field in ["min", "max", "data_point_quantile_values", "exemplars"] {
+        for field in [
+            "data_point_min",
+            "data_point_max",
+            "data_point_quantile_values",
+            "exemplars",
+        ] {
             assert!(
                 OTEL_METRICS_KNOWN_FIELDS.contains(field),
                 "expected `{field}` to be a known field"
@@ -1109,6 +1133,8 @@ mod tests {
         for field in [
             "quantile",
             "value",
+            "min",
+            "max",
             "data_point_quantile_values_quantile",
             "data_point_quantile_values_value",
         ] {


### PR DESCRIPTION
## What

Fixes #1723.

`compute_series_hash` in `src/otel/metrics.rs` treats every top-level data-point key that is not in `OTEL_METRICS_KNOWN_FIELD_LIST` as a series label. The list had drifted from the keys the flatteners actually emit, in both directions, corrupting physical-series identity for metrics.

### Emitted but missing from the list (series fragmentation)

These are emitted as top-level keys but were absent from the list, so their per-sample values were hashed into `__series_hash`, splitting one physical series into many:

- `min`, `max` — histogram per-sample statistics (`flatten_histogram`)
- `data_point_quantile_values` — summary quantile array (`flatten_summary`)

### Listed but never emitted top-level (dead entries, with collision risk)

- `value`, `quantile` — only ever emitted nested inside the `data_point_quantile_values` objects, never as top-level keys. Because they were listed, a user attribute literally named `value` or `quantile` was silently excluded from series identity, merging distinct series. `value` is a common label name, so this was the higher-risk one.
- `data_point_quantile_values_quantile`, `data_point_quantile_values_value` — never emitted anywhere. Harmless dead entries, removed for correctness.

## Change

- Add `data_point_quantile_values` to the list.
- Remove `value`, `quantile`, `data_point_quantile_values_quantile`, `data_point_quantile_values_value`.
- Rename the emitted histogram statistics from bare `min`/`max` to `data_point_min`/`data_point_max`, matching the naming convention every other data-point field already uses (`data_point_value`, `data_point_count`, `data_point_sum`, etc.), and add both to the list under their new names. This was raised in review: bare `min`/`max` would have shadowed a real user attribute of the same name and wrongly excluded it from the series hash, the same collision risk as `value`/`quantile` above.
- List length 38 -> 37 (relative to `main` post-#1720, which already carries `exemplars`).
- Tests: differing `data_point_min`/`data_point_max` (histogram) and `data_point_quantile_values` (summary) no longer change `compute_series_hash`; a data-point attribute named `value`, `quantile`, `min`, or `max` still does; plus a guard asserting the list contents and length.

## Verification

- `cargo test --lib otel::metrics`: 18 passed, 0 failed.
- `cargo clippy --all-targets -- -D warnings`: clean on this file.
- Cross-checked the full set of top-level keys emitted by every flattener (number/gauge/sum/histogram/exp-histogram/summary, exemplars, flags, aggregation temporality, metric-level and resource/scope envelope fields) against the updated list: they now correspond 1:1, with no missing keys and no dead entries.
- Rebased cleanly onto `main` after #1720 merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected metric field names for sample-level quantiles, minimums, and maximums.
  - Updated histogram data to consistently use prefixed minimum and maximum fields.
  - Removed obsolete flattened metric fields.

- **Tests**
  - Expanded coverage for metric series hashing and known-field membership.
  - Added validation for the updated set of 39 known metric fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->