### PR TITLE
fix: user auth for datasets

### DIFF
--- a/src/alerts/alerts_utils.rs
+++ b/src/alerts/alerts_utils.rs
@@ -491,10 +491,7 @@ fn split_array_elements(value: &str) -> Result<Vec<&str>, String> {
                     .char_indices()
                     .nth(start)
                     .map_or(value.len(), |(b, _)| b);
-                let byte_end = value
-                    .char_indices()
-                    .nth(i)
-                    .map_or(value.len(), |(b, _)| b);
+                let byte_end = value.char_indices().nth(i).map_or(value.len(), |(b, _)| b);
                 elements.push(&value[byte_start..byte_end]);
                 start = i + 1;
             }
@@ -715,10 +712,7 @@ mod tests {
     #[test]
     fn test_sanitize_numeric_elements() {
         assert_eq!(sanitize_array_elements("1, 2, 3").unwrap(), "1, 2, 3");
-        assert_eq!(
-            sanitize_array_elements("3.14, 2.71").unwrap(),
-            "3.14, 2.71"
-        );
+        assert_eq!(sanitize_array_elements("3.14, 2.71").unwrap(), "3.14, 2.71");
     }
 
     #[test]
@@ -732,10 +726,7 @@ mod tests {
     #[test]
     fn test_sanitize_bare_string_elements() {
         assert_eq!(sanitize_array_elements("foo").unwrap(), "'foo'");
-        assert_eq!(
-            sanitize_array_elements("foo, bar").unwrap(),
-            "'foo', 'bar'"
-        );
+        assert_eq!(sanitize_array_elements("foo, bar").unwrap(), "'foo', 'bar'");
     }
 
     #[test]
@@ -775,8 +766,7 @@ mod tests {
 
     #[test]
     fn test_sanitize_multiple_quoted_with_commas() {
-        let result =
-            sanitize_array_elements("'hello, world', 'foo, bar'").unwrap();
+        let result = sanitize_array_elements("'hello, world', 'foo, bar'").unwrap();
         assert_eq!(result, "'hello, world', 'foo, bar'");
     }
 
@@ -852,50 +842,34 @@ mod tests {
 
     #[test]
     fn test_list_condition_expr_strips_outer_brackets() {
-        let result =
-            list_condition_expr("tags", &WhereConfigOperator::Equal, "[1, 2]").unwrap();
+        let result = list_condition_expr("tags", &WhereConfigOperator::Equal, "[1, 2]").unwrap();
         assert_eq!(result, "\"tags\" = ARRAY[1, 2]");
     }
 
     #[test]
     fn test_list_condition_expr_does_not_contain() {
-        let result = list_condition_expr(
-            "tags",
-            &WhereConfigOperator::DoesNotContain,
-            "foo",
-        )
-        .unwrap();
+        let result =
+            list_condition_expr("tags", &WhereConfigOperator::DoesNotContain, "foo").unwrap();
         assert_eq!(result, "NOT array_has_all(\"tags\", ARRAY['foo'])");
     }
 
     #[test]
     fn test_list_condition_expr_not_equal() {
-        let result =
-            list_condition_expr("tags", &WhereConfigOperator::NotEqual, "42").unwrap();
+        let result = list_condition_expr("tags", &WhereConfigOperator::NotEqual, "42").unwrap();
         assert_eq!(result, "\"tags\" != ARRAY[42]");
     }
 
     #[test]
     fn test_list_condition_expr_quoted_element_with_comma() {
-        let result = list_condition_expr(
-            "cities",
-            &WhereConfigOperator::Contains,
-            "'New York, NY'",
-        )
-        .unwrap();
-        assert_eq!(
-            result,
-            "array_has_all(\"cities\", ARRAY['New York, NY'])"
-        );
+        let result =
+            list_condition_expr("cities", &WhereConfigOperator::Contains, "'New York, NY'")
+                .unwrap();
+        assert_eq!(result, "array_has_all(\"cities\", ARRAY['New York, NY'])");
     }
 
     #[test]
     fn test_list_condition_expr_rejects_injection() {
-        let result = list_condition_expr(
-            "tags",
-            &WhereConfigOperator::Contains,
-            "1] OR 1=1 --",
-        );
+        let result = list_condition_expr("tags", &WhereConfigOperator::Contains, "1] OR 1=1 --");
         assert!(
             result.is_err(),
             "Injection via bracket characters must be rejected"
@@ -904,8 +878,7 @@ mod tests {
 
     #[test]
     fn test_list_condition_expr_unsupported_operator() {
-        let result =
-            list_condition_expr("tags", &WhereConfigOperator::GreaterThan, "1");
+        let result = list_condition_expr("tags", &WhereConfigOperator::GreaterThan, "1");
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("not supported"));
     }

--- a/src/users/filters.rs
+++ b/src/users/filters.rs
@@ -187,9 +187,13 @@ impl Filters {
                     }
                 } else if *filter_type == FilterType::Search || *filter_type == FilterType::Filter {
                     let dataset_name = &f.stream_name;
-                    if user_auth_for_datasets(&permissions, std::slice::from_ref(dataset_name), &tenant_id)
-                        .await
-                        .is_ok()
+                    if user_auth_for_datasets(
+                        &permissions,
+                        std::slice::from_ref(dataset_name),
+                        &tenant_id,
+                    )
+                    .await
+                    .is_ok()
                     {
                         _filters.push(f.clone())
                     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -175,7 +175,9 @@ pub async fn user_auth_for_datasets(
                     Action::Query,
                     Some(ParseableResourceType::Stream(stream)),
                 ) => {
-                    if !PARSEABLE.check_or_load_stream(stream, tenant_id).await {
+                    // `stream` is the role's resource selector and may be the
+                    // wildcard `*`; load the dataset being authorized instead.
+                    if !PARSEABLE.check_or_load_stream(table_name, tenant_id).await {
                         return Err(actix_web::error::ErrorUnauthorized(format!(
                             "Stream not found: {table_name}"
                         )));


### PR DESCRIPTION
reader of all datasets get permission "*"
user_auth_for_datasets treat this as literal stream hence query/counts api fail with error stream not found

fix: use stream name of request dataset from the request



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization checks for stream-based queries so access is validated against the stream actually being queried.
  * Preserved existing permission behavior for explicitly authorized streams, wildcard access, and internal streams.
  * Strengthened handling and validation of list-based filter expressions, including quoted values, comma-separated elements, and invalid bracket-based input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->