### PR TITLE
update: upsert email API

### DIFF
--- a/src/handlers/http/modal/query_server.rs
+++ b/src/handlers/http/modal/query_server.rs
@@ -25,7 +25,7 @@ use crate::handlers::http::logstream;
 use crate::handlers::http::max_event_payload_size;
 use crate::handlers::http::middleware::{DisAllowRootUser, RouteExt};
 use crate::handlers::http::modal::initialize_hot_tier_metadata_on_startup;
-use crate::handlers::http::rbac::put_email;
+use crate::handlers::http::rbac::patch_user;
 use crate::handlers::http::{base_path, prism_base_path};
 use crate::handlers::http::{rbac, role};
 use crate::hottier::GLOBAL_HOTTIER;
@@ -221,6 +221,11 @@ impl QueryServer {
                             .to(querier_rbac::delete_user)
                             .authorize(Action::DeleteUser),
                     )
+                    .route(
+                        web::patch()
+                            .to(patch_user)
+                            .authorize_for_user(Action::PatchUser),
+                    )
                     .wrap(DisAllowRootUser),
             )
             .service(
@@ -228,13 +233,6 @@ impl QueryServer {
                     web::get()
                         .to(rbac::get_role)
                         .authorize_for_user(Action::GetUserRoles),
-                ),
-            )
-            .service(
-                web::resource("/{userid}/email").route(
-                    web::put()
-                        .to(put_email)
-                        .authorize_for_user(Action::PutEmail),
                 ),
             )
             .service(

--- a/src/handlers/http/modal/query_server.rs
+++ b/src/handlers/http/modal/query_server.rs
@@ -25,6 +25,7 @@ use crate::handlers::http::logstream;
 use crate::handlers::http::max_event_payload_size;
 use crate::handlers::http::middleware::{DisAllowRootUser, RouteExt};
 use crate::handlers::http::modal::initialize_hot_tier_metadata_on_startup;
+use crate::handlers::http::rbac::put_email;
 use crate::handlers::http::{base_path, prism_base_path};
 use crate::handlers::http::{rbac, role};
 use crate::hottier::GLOBAL_HOTTIER;
@@ -227,6 +228,13 @@ impl QueryServer {
                     web::get()
                         .to(rbac::get_role)
                         .authorize_for_user(Action::GetUserRoles),
+                ),
+            )
+            .service(
+                web::resource("/{userid}/email").route(
+                    web::put()
+                        .to(put_email)
+                        .authorize_for_user(Action::PutEmail),
                 ),
             )
             .service(

--- a/src/handlers/http/modal/server.rs
+++ b/src/handlers/http/modal/server.rs
@@ -713,6 +713,13 @@ impl Server {
                     .wrap(DisAllowRootUser),
             )
             .service(
+                web::resource("/{userid}/email").route(
+                    web::put()
+                        .to(http::rbac::put_email)
+                        .authorize_for_user(Action::PutEmail),
+                ),
+            )
+            .service(
                 web::resource("/{userid}/role").route(
                     web::get()
                         .to(http::rbac::get_role)

--- a/src/handlers/http/modal/server.rs
+++ b/src/handlers/http/modal/server.rs
@@ -710,14 +710,12 @@ impl Server {
                             .to(http::rbac::delete_user)
                             .authorize(Action::DeleteUser),
                     )
+                    .route(
+                        web::patch()
+                            .to(http::rbac::patch_user)
+                            .authorize_for_user(Action::PatchUser),
+                    )
                     .wrap(DisAllowRootUser),
-            )
-            .service(
-                web::resource("/{userid}/email").route(
-                    web::put()
-                        .to(http::rbac::put_email)
-                        .authorize_for_user(Action::PutEmail),
-                ),
             )
             .service(
                 web::resource("/{userid}/role").route(

--- a/src/handlers/http/rbac.rs
+++ b/src/handlers/http/rbac.rs
@@ -24,7 +24,7 @@ use crate::{
         self, Users,
         map::{read_user_groups, roles, users},
         role::model::Role,
-        user::{self, UserEmail, UserType},
+        user::{self, UpdateUser, UserType},
         utils::to_prism_user,
     },
     storage::ObjectStorageError,
@@ -178,12 +178,12 @@ pub async fn post_user(
     Ok(password)
 }
 
-// Handler for PUT /api/v1/user/{userid}/email
-// Upsert email
-pub async fn put_email(
+// Handler for PATCH /api/v1/user/{userid}
+// Upsert user (e.g. email)
+pub async fn patch_user(
     req: HttpRequest,
     userid: web::Path<String>,
-    web::Json(email): web::Json<UserEmail>,
+    web::Json(update): web::Json<UpdateUser>,
 ) -> Result<impl Responder, RBACError> {
     let userid = userid.into_inner();
     let tenant_id = get_tenant_id_from_request(&req);
@@ -193,10 +193,8 @@ pub async fn put_email(
     {
         return Err(RBACError::ProtectedUser);
     };
-    if !email.is_valid() {
-        return Err(RBACError::Anyhow(anyhow::Error::msg("Invalid Email")));
-    }
-    Users.put_email(email.email, &tenant_id, &userid)?;
+
+    update.update(&userid, &tenant_id)?;
 
     Ok(HttpResponse::Ok())
 }

--- a/src/handlers/http/rbac.rs
+++ b/src/handlers/http/rbac.rs
@@ -24,7 +24,7 @@ use crate::{
         self, Users,
         map::{read_user_groups, roles, users},
         role::model::Role,
-        user::{self, UserType},
+        user::{self, UserEmail, UserType},
         utils::to_prism_user,
     },
     storage::ObjectStorageError,
@@ -176,6 +176,29 @@ pub async fn post_user(
         .await?;
     }
     Ok(password)
+}
+
+// Handler for PUT /api/v1/user/{userid}/email
+// Upsert email
+pub async fn put_email(
+    req: HttpRequest,
+    userid: web::Path<String>,
+    web::Json(email): web::Json<UserEmail>,
+) -> Result<impl Responder, RBACError> {
+    let userid = userid.into_inner();
+    let tenant_id = get_tenant_id_from_request(&req);
+
+    if let Some(p) = Users.is_protected(&userid, &tenant_id)
+        && p
+    {
+        return Err(RBACError::ProtectedUser);
+    };
+    if !email.is_valid() {
+        return Err(RBACError::Anyhow(anyhow::Error::msg("Invalid Email")));
+    }
+    Users.put_email(email.email, &tenant_id, &userid)?;
+
+    Ok(HttpResponse::Ok())
 }
 
 // Handler for POST /api/v1/user/{userid}/generate-new-password

--- a/src/handlers/http/rbac.rs
+++ b/src/handlers/http/rbac.rs
@@ -193,8 +193,22 @@ pub async fn patch_user(
     {
         return Err(RBACError::ProtectedUser);
     };
+    let _guard = UPDATE_LOCK.lock().await;
+    if let Some(updated_user) = update.update(&userid, &tenant_id)? {
+        let mut metadata = get_metadata(&tenant_id).await?;
+        if let Some(user) = metadata
+            .users
+            .iter_mut()
+            .find(|user| user.userid() == userid)
+        {
+            *user = updated_user;
+        } else {
+            // should be unreachable given state is always consistent
+            return Err(RBACError::UserDoesNotExist);
+        }
 
-    update.update(&userid, &tenant_id)?;
+        put_metadata(&metadata, &tenant_id).await?;
+    };
 
     Ok(HttpResponse::Ok())
 }

--- a/src/rbac/mod.rs
+++ b/src/rbac/mod.rs
@@ -32,6 +32,7 @@ use serde::Serialize;
 use url::Url;
 
 use crate::handlers::TENANT_ID;
+use crate::handlers::http::rbac::RBACError;
 use crate::parseable::DEFAULT_TENANT;
 use crate::rbac::map::{mut_sessions, mut_users, read_user_groups, roles, sessions, users};
 use crate::rbac::role::Action;
@@ -58,6 +59,24 @@ pub enum Response {
 pub struct Users;
 
 impl Users {
+    pub fn put_email(
+        &self,
+        email: String,
+        tenant_id: &Option<String>,
+        userid: &str,
+    ) -> Result<(), RBACError> {
+        // won't change permissions so don't refresh session
+        let tenant_id = tenant_id.as_deref().unwrap_or(DEFAULT_TENANT);
+        if let Some(tenant_users) = mut_users().get_mut(tenant_id)
+            && let Some(user) = tenant_users.get_mut(userid)
+        {
+            user.insert_email(email)?;
+            Ok(())
+        } else {
+            Err(RBACError::UserDoesNotExist)
+        }
+    }
+
     pub fn put_user(&self, user: User) {
         let tenant_id = user.tenant.as_deref().unwrap_or(DEFAULT_TENANT);
         mut_sessions().remove_user(user.userid(), tenant_id);

--- a/src/rbac/mod.rs
+++ b/src/rbac/mod.rs
@@ -382,7 +382,7 @@ pub struct UsersPrism {
     pub username: String,
     // oaith or native
     pub method: String,
-    // email only if method is oauth
+    // email if set
     pub email: Option<String>,
     // picture only if oauth
     pub picture: Option<Url>,

--- a/src/rbac/mod.rs
+++ b/src/rbac/mod.rs
@@ -64,14 +64,14 @@ impl Users {
         email: String,
         tenant_id: &Option<String>,
         userid: &str,
-    ) -> Result<(), RBACError> {
+    ) -> Result<User, RBACError> {
         // won't change permissions so don't refresh session
         let tenant_id = tenant_id.as_deref().unwrap_or(DEFAULT_TENANT);
         if let Some(tenant_users) = mut_users().get_mut(tenant_id)
             && let Some(user) = tenant_users.get_mut(userid)
         {
             user.insert_email(email)?;
-            Ok(())
+            Ok(user.clone())
         } else {
             Err(RBACError::UserDoesNotExist)
         }

--- a/src/rbac/role.rs
+++ b/src/rbac/role.rs
@@ -34,6 +34,7 @@ pub enum Action {
     GetStats,
     DeleteStream,
     GetRetention,
+    PutEmail,
     PutRetention,
     PutHotTierEnabled,
     GetHotTierEnabled,
@@ -117,6 +118,7 @@ impl RoleBuilder {
                 | Action::Metrics
                 | Action::PutUser
                 | Action::ListUser
+                | Action::PutEmail
                 | Action::PutUserRoles
                 | Action::GetUserRoles
                 | Action::DeleteUser
@@ -378,6 +380,7 @@ pub mod model {
                 Action::CreateDashboard,
                 Action::DeleteDashboard,
                 Action::GetUserRoles,
+                Action::PutEmail,
             ],
             resource_type: Some(ParseableResourceType::All),
         }
@@ -418,6 +421,7 @@ pub mod model {
                 Action::CreateFilter,
                 Action::DeleteFilter,
                 Action::GetUserRoles,
+                Action::PutEmail,
             ],
             resource_type: None,
         }
@@ -451,6 +455,7 @@ pub mod model {
                 Action::GetHotTierEnabled,
                 Action::GetStreamInfo,
                 Action::GetUserRoles,
+                Action::PutEmail,
                 Action::GetAlert,
             ],
             resource_type: None,

--- a/src/rbac/role.rs
+++ b/src/rbac/role.rs
@@ -34,7 +34,7 @@ pub enum Action {
     GetStats,
     DeleteStream,
     GetRetention,
-    PutEmail,
+    PatchUser,
     PutRetention,
     PutHotTierEnabled,
     GetHotTierEnabled,
@@ -118,7 +118,7 @@ impl RoleBuilder {
                 | Action::Metrics
                 | Action::PutUser
                 | Action::ListUser
-                | Action::PutEmail
+                | Action::PatchUser
                 | Action::PutUserRoles
                 | Action::GetUserRoles
                 | Action::DeleteUser
@@ -380,7 +380,7 @@ pub mod model {
                 Action::CreateDashboard,
                 Action::DeleteDashboard,
                 Action::GetUserRoles,
-                Action::PutEmail,
+                Action::PatchUser,
             ],
             resource_type: Some(ParseableResourceType::All),
         }
@@ -421,7 +421,7 @@ pub mod model {
                 Action::CreateFilter,
                 Action::DeleteFilter,
                 Action::GetUserRoles,
-                Action::PutEmail,
+                Action::PatchUser,
             ],
             resource_type: None,
         }
@@ -455,7 +455,7 @@ pub mod model {
                 Action::GetHotTierEnabled,
                 Action::GetStreamInfo,
                 Action::GetUserRoles,
-                Action::PutEmail,
+                Action::PatchUser,
                 Action::GetAlert,
             ],
             resource_type: None,

--- a/src/rbac/user.rs
+++ b/src/rbac/user.rs
@@ -37,6 +37,7 @@ use crate::{
     handlers::http::rbac::{InvalidUserGroupError, RBACError},
     parseable::{DEFAULT_TENANT, PARSEABLE},
     rbac::{
+        Users,
         map::{mut_sessions, read_user_groups, roles, users},
         role::model::RoleType,
         roles_to_permission,
@@ -49,13 +50,28 @@ static EMAIL_VALIDATOR_RE: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 #[derive(Debug, Deserialize)]
-pub struct UserEmail {
-    pub email: String,
+pub struct UpdateUser {
+    pub email: Option<String>,
 }
 
-impl UserEmail {
-    pub fn is_valid(&self) -> bool {
-        EMAIL_VALIDATOR_RE.is_match(&self.email)
+impl UpdateUser {
+    pub fn update(&self, userid: &str, tenant_id: &Option<String>) -> Result<(), RBACError> {
+        if let Some(email) = &self.email {
+            if self.is_valid_email() {
+                Users.put_email(email.clone(), tenant_id, userid)?;
+            } else {
+                return Err(RBACError::Anyhow(anyhow::Error::msg("Invalid Email")));
+            }
+        }
+
+        Ok(())
+    }
+    fn is_valid_email(&self) -> bool {
+        if let Some(email) = &self.email {
+            EMAIL_VALIDATOR_RE.is_match(email)
+        } else {
+            false
+        }
     }
 }
 

--- a/src/rbac/user.rs
+++ b/src/rbac/user.rs
@@ -44,8 +44,7 @@ use crate::{
 };
 
 static EMAIL_VALIDATOR_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^(?i)[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$
-")
+    Regex::new(r"^(?i)[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
         .expect("email validation regex is invalid")
 });
 

--- a/src/rbac/user.rs
+++ b/src/rbac/user.rs
@@ -16,7 +16,7 @@
  *
  */
 
-use std::collections::HashSet;
+use std::{collections::HashSet, sync::LazyLock};
 
 use argon2::{
     Argon2, PasswordHash, PasswordVerifier,
@@ -29,6 +29,8 @@ use rand::{
     RngCore,
     distributions::{Alphanumeric, DistString},
 };
+use regex::Regex;
+use serde::Deserialize;
 use ulid::Ulid;
 
 use crate::{
@@ -40,6 +42,23 @@ use crate::{
         roles_to_permission,
     },
 };
+
+static EMAIL_VALIDATOR_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^(?i)[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$
+")
+        .expect("email validation regex is invalid")
+});
+
+#[derive(Debug, Deserialize)]
+pub struct UserEmail {
+    pub email: String,
+}
+
+impl UserEmail {
+    pub fn is_valid(&self) -> bool {
+        EMAIL_VALIDATOR_RE.is_match(&self.email)
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(untagged)]
@@ -73,6 +92,7 @@ impl User {
                 ty: UserType::Native(Basic {
                     username,
                     password_hash: hash,
+                    email: None,
                 }),
                 roles: HashSet::new(),
                 user_groups: HashSet::new(),
@@ -128,6 +148,19 @@ impl User {
             tenant,
             protected,
         }
+    }
+
+    pub fn insert_email(&mut self, email: String) -> Result<(), RBACError> {
+        match self.ty {
+            UserType::Native(ref mut user) => user.email = Some(email),
+            UserType::OAuth(ref mut oauth) => oauth.user_info.email = Some(email),
+            _ => {
+                return Err(RBACError::Anyhow(anyhow::Error::msg(
+                    "Can't add email to API key",
+                )));
+            }
+        }
+        Ok(())
     }
 
     pub fn userid(&self) -> &str {
@@ -186,6 +219,7 @@ impl User {
 pub struct Basic {
     pub username: String,
     pub password_hash: String,
+    pub email: Option<String>,
 }
 
 impl Basic {
@@ -240,6 +274,7 @@ pub fn get_super_admin_user() -> User {
         ty: UserType::Native(Basic {
             username,
             password_hash: hashcode,
+            email: None,
         }),
         roles: ["super-admin".to_string()].into(),
         user_groups: HashSet::new(),

--- a/src/rbac/user.rs
+++ b/src/rbac/user.rs
@@ -55,16 +55,21 @@ pub struct UpdateUser {
 }
 
 impl UpdateUser {
-    pub fn update(&self, userid: &str, tenant_id: &Option<String>) -> Result<(), RBACError> {
+    pub fn update(
+        &self,
+        userid: &str,
+        tenant_id: &Option<String>,
+    ) -> Result<Option<User>, RBACError> {
+        let mut user = None;
         if let Some(email) = &self.email {
             if self.is_valid_email() {
-                Users.put_email(email.clone(), tenant_id, userid)?;
+                user = Some(Users.put_email(email.clone(), tenant_id, userid)?);
             } else {
                 return Err(RBACError::Anyhow(anyhow::Error::msg("Invalid Email")));
             }
         }
 
-        Ok(())
+        Ok(user)
     }
     fn is_valid_email(&self) -> bool {
         if let Some(email) = &self.email {

--- a/src/rbac/utils.rs
+++ b/src/rbac/utils.rs
@@ -33,7 +33,13 @@ use super::{
 pub fn to_prism_user(user: &User) -> UsersPrism {
     let tenant_id = user.tenant.as_deref().unwrap_or(DEFAULT_TENANT);
     let (id, username, method, email, picture) = match &user.ty {
-        UserType::Native(_) => (user.userid(), user.userid(), "native", None, None),
+        UserType::Native(basic) => (
+            user.userid(),
+            user.userid(),
+            "native",
+            basic.email.clone(),
+            None,
+        ),
         UserType::OAuth(oauth) => {
             let userid = user.userid();
             let display_name = oauth.user_info.name.as_deref().unwrap_or(userid);


### PR DESCRIPTION
```
PATCH /api/v1/user/{userid}
body- {email: "email@example.com"}
```
Users can upsert their email

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an authorized `PATCH /api/v1/user/{userid}` endpoint to update a user’s email.
  - Introduced a user email update privilege and included it in default role permissions.
  - Extended returned profile data so native users’ email is included when available.
- **Bug Fixes**
  - Added email validation and return errors for invalid updates.
  - Prevented updates to protected users and unsupported account types.
  - Improved response mapping so native users’ email is now sourced from the user record.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->