### PR TITLE
make concurrent object store calls configurable

### DIFF
--- a/src/otel/metrics.rs
+++ b/src/otel/metrics.rs
@@ -521,10 +521,9 @@ pub fn flatten_metrics_record(
     let (mut data_points, metric_type) = match &metrics_record.data {
         Some(metric::Data::Gauge(gauge)) => (flatten_gauge(gauge, flatten_exemplars), "gauge"),
         Some(metric::Data::Sum(sum)) => (flatten_sum(sum, flatten_exemplars), "sum"),
-        Some(metric::Data::Histogram(histogram)) => (
-            flatten_histogram(histogram, flatten_exemplars),
-            "histogram",
-        ),
+        Some(metric::Data::Histogram(histogram)) => {
+            (flatten_histogram(histogram, flatten_exemplars), "histogram")
+        }
         Some(metric::Data::ExponentialHistogram(exp_histogram)) => (
             flatten_exp_histogram(exp_histogram, flatten_exemplars),
             "exponential_histogram",

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -86,6 +86,7 @@ static DISK_WRITE_BATCH_ROWS: Lazy<usize> = Lazy::new(|| {
 });
 
 const INPROCESS_DIR_PREFIX: &str = "processing_";
+const METRIC_NAME_BLOOM_FILTER_NDV: u64 = 32768;
 const METRIC_ROW_GROUP_PREP_IN_FLIGHT_VAR: &str = "METRIC_ROW_GROUP_PREP_IN_FLIGHT";
 /// Caps how many arrow files feed a single parquet conversion group. A
 /// minute with heavy schema-key churn can stage thousands of small arrow
@@ -732,6 +733,16 @@ impl Stream {
                 descending: false,
                 nulls_first: false,
             });
+
+            // Bloom filter on the same column. The sort already narrows per-page
+            // min/max, but that only prunes pages within a row group the reader
+            // has opened; a row group whose metric range merely brackets the
+            // queried name still gets read. The bloom answers membership exactly,
+            // so a row group that never saw the metric is rejected outright.
+            let column_path = ColumnPath::new(vec!["metric_name".to_string()]);
+            props = props
+                .set_column_bloom_filter_enabled(column_path.clone(), true)
+                .set_column_bloom_filter_ndv(column_path, METRIC_NAME_BLOOM_FILTER_NDV);
         }
         sorting_column_vec.push(SortingColumn {
             column_idx: time_partition_idx as i32,

--- a/src/storage/azure_blob.rs
+++ b/src/storage/azure_blob.rs
@@ -18,6 +18,7 @@
 
 use std::{
     collections::HashSet,
+    num::NonZeroUsize,
     ops::Range,
     path::{Path, PathBuf},
     sync::Arc,
@@ -136,7 +137,7 @@ pub struct AzureBlobConfig {
         value_name = "number",
         default_value_t = DEFAULT_MAX_OBJECT_STORE_REQUESTS
     )]
-    pub max_object_store_requests: usize,
+    pub max_object_store_requests: NonZeroUsize,
 }
 
 impl AzureBlobConfig {
@@ -182,7 +183,7 @@ impl ObjectStorageProvider for AzureBlobConfig {
     fn get_datafusion_runtime(&self) -> RuntimeEnvBuilder {
         let azure = self.get_default_builder().build().unwrap();
         // limit objectstore to a concurrent request limit
-        let azure = LimitStore::new(azure, self.max_object_store_requests);
+        let azure = LimitStore::new(azure, self.max_object_store_requests.get());
         let azure = MetricLayer::new(azure, "azure_blob");
 
         let object_store_registry = DefaultObjectStoreRegistry::new();
@@ -196,7 +197,7 @@ impl ObjectStorageProvider for AzureBlobConfig {
     fn construct_client(&self) -> Arc<dyn super::ObjectStorage> {
         let azure = self.get_default_builder().build().unwrap();
         // limit objectstore to a concurrent request limit
-        let azure = LimitStore::new(azure, self.max_object_store_requests);
+        let azure = LimitStore::new(azure, self.max_object_store_requests.get());
         let azure = MetricLayer::new(azure, "azure_blob");
         Arc::new(BlobStore {
             client: Arc::new(azure),

--- a/src/storage/azure_blob.rs
+++ b/src/storage/azure_blob.rs
@@ -59,10 +59,10 @@ use crate::{
 };
 
 use super::{
-    CONNECT_TIMEOUT_SECS, ObjectStorage, ObjectStorageError, ObjectStorageProvider,
-    PARSEABLE_ROOT_DIRECTORY, REQUEST_TIMEOUT_SECS, STREAM_METADATA_FILE_NAME,
-    metrics_layer::MetricLayer, object_storage::parseable_json_path, partial_path,
-    to_object_store_path,
+    CONNECT_TIMEOUT_SECS, DEFAULT_MAX_OBJECT_STORE_REQUESTS, ObjectStorage, ObjectStorageError,
+    ObjectStorageProvider, PARSEABLE_ROOT_DIRECTORY, REQUEST_TIMEOUT_SECS,
+    STREAM_METADATA_FILE_NAME, metrics_layer::MetricLayer, object_storage::parseable_json_path,
+    partial_path, to_object_store_path,
 };
 
 #[derive(Debug, Clone, clap::Args)]
@@ -128,6 +128,15 @@ pub struct AzureBlobConfig {
         required = true
     )]
     pub container: String,
+
+    /// Cap on concurrent in-flight requests to the object store.
+    #[arg(
+        long,
+        env = "P_MAX_OBJECT_STORE_REQUESTS",
+        value_name = "number",
+        default_value_t = DEFAULT_MAX_OBJECT_STORE_REQUESTS
+    )]
+    pub max_object_store_requests: usize,
 }
 
 impl AzureBlobConfig {
@@ -173,7 +182,7 @@ impl ObjectStorageProvider for AzureBlobConfig {
     fn get_datafusion_runtime(&self) -> RuntimeEnvBuilder {
         let azure = self.get_default_builder().build().unwrap();
         // limit objectstore to a concurrent request limit
-        let azure = LimitStore::new(azure, super::MAX_OBJECT_STORE_REQUESTS);
+        let azure = LimitStore::new(azure, self.max_object_store_requests);
         let azure = MetricLayer::new(azure, "azure_blob");
 
         let object_store_registry = DefaultObjectStoreRegistry::new();
@@ -187,7 +196,7 @@ impl ObjectStorageProvider for AzureBlobConfig {
     fn construct_client(&self) -> Arc<dyn super::ObjectStorage> {
         let azure = self.get_default_builder().build().unwrap();
         // limit objectstore to a concurrent request limit
-        let azure = LimitStore::new(azure, super::MAX_OBJECT_STORE_REQUESTS);
+        let azure = LimitStore::new(azure, self.max_object_store_requests);
         let azure = MetricLayer::new(azure, "azure_blob");
         Arc::new(BlobStore {
             client: Arc::new(azure),

--- a/src/storage/gcs.rs
+++ b/src/storage/gcs.rs
@@ -58,10 +58,10 @@ use tokio::{fs::OpenOptions, io::AsyncReadExt};
 use tracing::error;
 
 use super::{
-    CONNECT_TIMEOUT_SECS, ObjectStorage, ObjectStorageError, ObjectStorageProvider,
-    PARSEABLE_ROOT_DIRECTORY, REQUEST_TIMEOUT_SECS, STREAM_METADATA_FILE_NAME,
-    metrics_layer::MetricLayer, object_storage::parseable_json_path, partial_path,
-    to_object_store_path,
+    CONNECT_TIMEOUT_SECS, DEFAULT_MAX_OBJECT_STORE_REQUESTS, ObjectStorage, ObjectStorageError,
+    ObjectStorageProvider, PARSEABLE_ROOT_DIRECTORY, REQUEST_TIMEOUT_SECS,
+    STREAM_METADATA_FILE_NAME, metrics_layer::MetricLayer, object_storage::parseable_json_path,
+    partial_path, to_object_store_path,
 };
 
 #[derive(Debug, Clone, clap::Args)]
@@ -101,6 +101,15 @@ pub struct GcsConfig {
         default_value = "false"
     )]
     pub skip_tls: bool,
+
+    /// Cap on concurrent in-flight requests to the object store.
+    #[arg(
+        long,
+        env = "P_MAX_OBJECT_STORE_REQUESTS",
+        value_name = "number",
+        default_value_t = DEFAULT_MAX_OBJECT_STORE_REQUESTS
+    )]
+    pub max_object_store_requests: usize,
 }
 
 impl GcsConfig {
@@ -136,7 +145,7 @@ impl ObjectStorageProvider for GcsConfig {
         let gcs = self.get_default_builder().build().unwrap();
 
         // limit objectstore to a concurrent request limit
-        let gcs = LimitStore::new(gcs, super::MAX_OBJECT_STORE_REQUESTS);
+        let gcs = LimitStore::new(gcs, self.max_object_store_requests);
         let gcs = MetricLayer::new(gcs, "gcs");
 
         let object_store_registry = DefaultObjectStoreRegistry::new();
@@ -151,7 +160,7 @@ impl ObjectStorageProvider for GcsConfig {
     fn construct_client(&self) -> Arc<dyn ObjectStorage> {
         let gcs = self.get_default_builder().build().unwrap();
         // limit objectstore to a concurrent request limit
-        let gcs = LimitStore::new(gcs, super::MAX_OBJECT_STORE_REQUESTS);
+        let gcs = LimitStore::new(gcs, self.max_object_store_requests);
         let gcs = MetricLayer::new(gcs, "gcs");
         Arc::new(Gcs {
             client: Arc::new(gcs),

--- a/src/storage/gcs.rs
+++ b/src/storage/gcs.rs
@@ -18,6 +18,7 @@
 
 use std::{
     collections::HashSet,
+    num::NonZeroUsize,
     ops::Range,
     path::{Path, PathBuf},
     sync::Arc,
@@ -109,7 +110,7 @@ pub struct GcsConfig {
         value_name = "number",
         default_value_t = DEFAULT_MAX_OBJECT_STORE_REQUESTS
     )]
-    pub max_object_store_requests: usize,
+    pub max_object_store_requests: NonZeroUsize,
 }
 
 impl GcsConfig {
@@ -145,7 +146,7 @@ impl ObjectStorageProvider for GcsConfig {
         let gcs = self.get_default_builder().build().unwrap();
 
         // limit objectstore to a concurrent request limit
-        let gcs = LimitStore::new(gcs, self.max_object_store_requests);
+        let gcs = LimitStore::new(gcs, self.max_object_store_requests.get());
         let gcs = MetricLayer::new(gcs, "gcs");
 
         let object_store_registry = DefaultObjectStoreRegistry::new();
@@ -160,7 +161,7 @@ impl ObjectStorageProvider for GcsConfig {
     fn construct_client(&self) -> Arc<dyn ObjectStorage> {
         let gcs = self.get_default_builder().build().unwrap();
         // limit objectstore to a concurrent request limit
-        let gcs = LimitStore::new(gcs, self.max_object_store_requests);
+        let gcs = LimitStore::new(gcs, self.max_object_store_requests.get());
         let gcs = MetricLayer::new(gcs, "gcs");
         Arc::new(Gcs {
             client: Arc::new(gcs),

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -108,8 +108,9 @@ pub const SETTINGS_ROOT_DIRECTORY: &str = ".settings";
 pub const TARGETS_ROOT_DIRECTORY: &str = ".targets";
 pub const MANIFEST_FILE: &str = "manifest.json";
 
-// max concurrent request allowed for datafusion object store
-const MAX_OBJECT_STORE_REQUESTS: usize = 1000;
+// max concurrent request allowed for datafusion object store, overridable per
+// backend with P_MAX_OBJECT_STORE_REQUESTS
+pub const DEFAULT_MAX_OBJECT_STORE_REQUESTS: usize = 1000;
 
 // all the supported permissions
 // const PERMISSIONS_READ: &str = "readonly";

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -37,6 +37,7 @@ use crate::{
 use chrono::Utc;
 
 use std::fmt::Debug;
+use std::num::NonZeroUsize;
 
 mod azure_blob;
 pub mod field_stats;
@@ -109,8 +110,12 @@ pub const TARGETS_ROOT_DIRECTORY: &str = ".targets";
 pub const MANIFEST_FILE: &str = "manifest.json";
 
 // max concurrent request allowed for datafusion object store, overridable per
-// backend with P_MAX_OBJECT_STORE_REQUESTS
-pub const DEFAULT_MAX_OBJECT_STORE_REQUESTS: usize = 1000;
+// backend with P_MAX_OBJECT_STORE_REQUESTS.
+//
+// NonZero because this becomes the permit count of the `LimitStore` semaphore:
+// at zero every object store request would await a permit that never arrives,
+// hanging the server silently rather than failing.
+pub const DEFAULT_MAX_OBJECT_STORE_REQUESTS: NonZeroUsize = NonZeroUsize::new(1000).unwrap();
 
 // all the supported permissions
 // const PERMISSIONS_READ: &str = "readonly";
@@ -404,4 +409,55 @@ pub fn partial_path(
     let mut buf = write_path.to_path_buf();
     buf.set_file_name(next);
     Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::{DEFAULT_MAX_OBJECT_STORE_REQUESTS, GcsConfig};
+
+    #[derive(Debug, Parser)]
+    struct TestArgs {
+        #[command(flatten)]
+        gcs: GcsConfig,
+    }
+
+    fn parse(args: &[&str]) -> Result<TestArgs, clap::Error> {
+        TestArgs::try_parse_from(args)
+    }
+
+    #[test]
+    fn max_object_store_requests_rejects_zero() {
+        // Zero would leave the LimitStore semaphore with no permits, so every
+        // object store request would await forever instead of failing.
+        let err = parse(&[
+            "test",
+            "--bucket-name",
+            "b",
+            "--max-object-store-requests",
+            "0",
+        ])
+        .expect_err("zero must not parse");
+        assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn max_object_store_requests_accepts_positive_and_defaults() {
+        let parsed = parse(&[
+            "test",
+            "--bucket-name",
+            "b",
+            "--max-object-store-requests",
+            "500",
+        ])
+        .expect("positive value must parse");
+        assert_eq!(parsed.gcs.max_object_store_requests.get(), 500);
+
+        let parsed = parse(&["test", "--bucket-name", "b"]).expect("default must parse");
+        assert_eq!(
+            parsed.gcs.max_object_store_requests,
+            DEFAULT_MAX_OBJECT_STORE_REQUESTS
+        );
+    }
 }

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -60,10 +60,10 @@ use crate::{
 };
 
 use super::{
-    CONNECT_TIMEOUT_SECS, ObjectStorage, ObjectStorageError, ObjectStorageProvider,
-    PARSEABLE_ROOT_DIRECTORY, REQUEST_TIMEOUT_SECS, STREAM_METADATA_FILE_NAME,
-    metrics_layer::MetricLayer, object_storage::parseable_json_path, partial_path,
-    to_object_store_path,
+    CONNECT_TIMEOUT_SECS, DEFAULT_MAX_OBJECT_STORE_REQUESTS, ObjectStorage, ObjectStorageError,
+    ObjectStorageProvider, PARSEABLE_ROOT_DIRECTORY, REQUEST_TIMEOUT_SECS,
+    STREAM_METADATA_FILE_NAME, metrics_layer::MetricLayer, object_storage::parseable_json_path,
+    partial_path, to_object_store_path,
 };
 
 // in bytes
@@ -166,6 +166,15 @@ pub struct S3Config {
         required = false
     )]
     pub metadata_endpoint: Option<String>,
+
+    /// Cap on concurrent in-flight requests to the object store.
+    #[arg(
+        long,
+        env = "P_MAX_OBJECT_STORE_REQUESTS",
+        value_name = "number",
+        default_value_t = DEFAULT_MAX_OBJECT_STORE_REQUESTS
+    )]
+    pub max_object_store_requests: usize,
 }
 
 /// This represents the server side encryption to be
@@ -343,7 +352,7 @@ impl ObjectStorageProvider for S3Config {
         let s3 = self.get_default_builder().build().unwrap();
 
         // limit objectstore to a concurrent request limit
-        let s3 = LimitStore::new(s3, super::MAX_OBJECT_STORE_REQUESTS);
+        let s3 = LimitStore::new(s3, self.max_object_store_requests);
         let s3 =
             MetricLayer::new(s3, "s3").with_cache_control_no_store(self.cache_control_no_store);
 
@@ -357,7 +366,7 @@ impl ObjectStorageProvider for S3Config {
     fn construct_client(&self) -> Arc<dyn ObjectStorage> {
         let s3 = self.get_default_builder().build().unwrap();
         // limit objectstore to a concurrent request limit
-        let s3 = LimitStore::new(s3, super::MAX_OBJECT_STORE_REQUESTS);
+        let s3 = LimitStore::new(s3, self.max_object_store_requests);
         let s3 =
             MetricLayer::new(s3, "s3").with_cache_control_no_store(self.cache_control_no_store);
         Arc::new(S3 {

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -19,6 +19,7 @@
 use std::{
     collections::HashSet,
     fmt::Display,
+    num::NonZeroUsize,
     ops::Range,
     path::{Path, PathBuf},
     str::FromStr,
@@ -174,7 +175,7 @@ pub struct S3Config {
         value_name = "number",
         default_value_t = DEFAULT_MAX_OBJECT_STORE_REQUESTS
     )]
-    pub max_object_store_requests: usize,
+    pub max_object_store_requests: NonZeroUsize,
 }
 
 /// This represents the server side encryption to be
@@ -352,7 +353,7 @@ impl ObjectStorageProvider for S3Config {
         let s3 = self.get_default_builder().build().unwrap();
 
         // limit objectstore to a concurrent request limit
-        let s3 = LimitStore::new(s3, self.max_object_store_requests);
+        let s3 = LimitStore::new(s3, self.max_object_store_requests.get());
         let s3 =
             MetricLayer::new(s3, "s3").with_cache_control_no_store(self.cache_control_no_store);
 
@@ -366,7 +367,7 @@ impl ObjectStorageProvider for S3Config {
     fn construct_client(&self) -> Arc<dyn ObjectStorage> {
         let s3 = self.get_default_builder().build().unwrap();
         // limit objectstore to a concurrent request limit
-        let s3 = LimitStore::new(s3, self.max_object_store_requests);
+        let s3 = LimitStore::new(s3, self.max_object_store_requests.get());
         let s3 =
             MetricLayer::new(s3, "s3").with_cache_control_no_store(self.cache_control_no_store);
         Arc::new(S3 {


### PR DESCRIPTION
add env P_MAX_OBJECT_STORE_REQUESTS default to 1000 
controls how many concurrent calls DF makes to object store

also, add metric_name bloom filter for otel-metrics



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable limits for concurrent object-storage requests across S3, GCS, and Azure Blob Storage.
  * Added the `P_MAX_OBJECT_STORE_REQUESTS` setting, with a default limit of 1,000 requests.
  * Improved metric-name filtering for OpenTelemetry metrics through Parquet bloom filters.

* **Bug Fixes**
  * Preserved consistent histogram metric flattening behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->