### PR TITLE
sql performance improvements

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,7 +17,7 @@
  */
 
 use clap::{Parser, value_parser};
-use std::{env, fs, ops::Div, path::PathBuf};
+use std::{env, fs, ops::Mul, path::PathBuf};
 
 use url::Url;
 
@@ -36,6 +36,7 @@ pub const DEFAULT_USERNAME: &str = "admin";
 pub const DEFAULT_PASSWORD: &str = "admin";
 
 pub const DATASET_FIELD_COUNT_LIMIT: usize = 1000;
+const DEFAULT_PARQUET_METADATA_CACHE_SIZE: usize = 50 * 1024 * 1024; // 50 MB
 #[derive(Parser)]
 #[command(
     name = "parseable",
@@ -221,7 +222,7 @@ pub struct Options {
     #[arg(
         long,
         env = "P_DATAFUSION_TARGET_PARTITIONS",
-        default_value_t = num_cpus::get().div(2).max(1) as u64,
+        default_value_t = num_cpus::get().mul(4).max(1) as u64,
         value_parser = value_parser!(u64).range(1..),
         help = "Number of partitions for DF to split execution into"
     )]
@@ -443,6 +444,15 @@ pub struct Options {
         help = "Set a fixed memory limit for query in GiB"
     )]
     pub query_memory_pool_size: Option<usize>,
+
+    #[arg(
+        long,
+        env = "P_PARQUET_METADATA_CACHE_SIZE",
+        default_value_t = DEFAULT_PARQUET_METADATA_CACHE_SIZE,
+        help = "Maximum size in bytes of the DataFusion Parquet metadata cache"
+    )]
+    pub parquet_metadata_cache_size: usize,
+
     // reduced the max row group size from 1048576
     // smaller row groups help in faster query performance in multi threaded query
     #[arg(

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -25,9 +25,7 @@ use actix_web::Responder;
 use actix_web_prometheus::{PrometheusMetrics, PrometheusMetricsBuilder};
 use error::MetricsError;
 use once_cell::sync::Lazy;
-use prometheus::{
-    HistogramOpts, HistogramVec, IntCounterVec, IntGauge, IntGaugeVec, Opts, Registry,
-};
+use prometheus::{HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts, Registry};
 
 pub const METRICS_NAMESPACE: &str = env!("CARGO_PKG_NAME");
 
@@ -189,73 +187,6 @@ pub static QUERY_CACHE_HIT: Lazy<IntCounterVec> = Lazy::new(|| {
     IntCounterVec::new(
         Opts::new("QUERY_CACHE_HIT", "Full Cache hit").namespace(METRICS_NAMESPACE),
         &["stream", "tenant_id"],
-    )
-    .expect("metric can be created")
-});
-
-pub static PARQUET_METADATA_CACHE_ENTRIES: Lazy<IntGauge> = Lazy::new(|| {
-    IntGauge::with_opts(
-        Opts::new(
-            "parquet_metadata_cache_entries",
-            "Number of Parquet metadata entries currently retained",
-        )
-        .namespace(METRICS_NAMESPACE),
-    )
-    .expect("metric can be created")
-});
-
-pub static PARQUET_METADATA_CACHE_USED_BYTES: Lazy<IntGauge> = Lazy::new(|| {
-    IntGauge::with_opts(
-        Opts::new(
-            "parquet_metadata_cache_used_bytes",
-            "Logical memory used by retained Parquet metadata entries",
-        )
-        .namespace(METRICS_NAMESPACE),
-    )
-    .expect("metric can be created")
-});
-
-pub static PARQUET_METADATA_CACHE_LIMIT_BYTES: Lazy<IntGauge> = Lazy::new(|| {
-    IntGauge::with_opts(
-        Opts::new(
-            "parquet_metadata_cache_limit_bytes",
-            "Configured Parquet metadata cache memory limit",
-        )
-        .namespace(METRICS_NAMESPACE),
-    )
-    .expect("metric can be created")
-});
-
-pub static PARQUET_METADATA_CACHE_RETAINED_HITS: Lazy<IntGauge> = Lazy::new(|| {
-    IntGauge::with_opts(
-        Opts::new(
-            "parquet_metadata_cache_retained_hits",
-            "Cache hits recorded by entries that are currently retained",
-        )
-        .namespace(METRICS_NAMESPACE),
-    )
-    .expect("metric can be created")
-});
-
-pub static PARQUET_METADATA_CACHE_PAGE_INDEX_ENTRIES: Lazy<IntGauge> = Lazy::new(|| {
-    IntGauge::with_opts(
-        Opts::new(
-            "parquet_metadata_cache_page_index_entries",
-            "Retained Parquet metadata entries containing page indexes",
-        )
-        .namespace(METRICS_NAMESPACE),
-    )
-    .expect("metric can be created")
-});
-
-pub static PARQUET_METADATA_CACHE_ENTRY_SIZE_BYTES: Lazy<IntGaugeVec> = Lazy::new(|| {
-    IntGaugeVec::new(
-        Opts::new(
-            "parquet_metadata_cache_entry_size_bytes",
-            "Parquet metadata cache entry size distribution",
-        )
-        .namespace(METRICS_NAMESPACE),
-        &["stat"],
     )
     .expect("metric can be created")
 });
@@ -739,24 +670,6 @@ fn custom_metrics(registry: &Registry) {
         .register(Box::new(QUERY_CACHE_HIT.clone()))
         .expect("metric can be registered");
     registry
-        .register(Box::new(PARQUET_METADATA_CACHE_ENTRIES.clone()))
-        .expect("metric can be registered");
-    registry
-        .register(Box::new(PARQUET_METADATA_CACHE_USED_BYTES.clone()))
-        .expect("metric can be registered");
-    registry
-        .register(Box::new(PARQUET_METADATA_CACHE_LIMIT_BYTES.clone()))
-        .expect("metric can be registered");
-    registry
-        .register(Box::new(PARQUET_METADATA_CACHE_RETAINED_HITS.clone()))
-        .expect("metric can be registered");
-    registry
-        .register(Box::new(PARQUET_METADATA_CACHE_PAGE_INDEX_ENTRIES.clone()))
-        .expect("metric can be registered");
-    registry
-        .register(Box::new(PARQUET_METADATA_CACHE_ENTRY_SIZE_BYTES.clone()))
-        .expect("metric can be registered");
-    registry
         .register(Box::new(ALERTS_STATES.clone()))
         .expect("metric can be registered");
     // Register billing metrics
@@ -880,32 +793,6 @@ pub fn build_metrics_handler() -> PrometheusMetrics {
 
     prom_process_metrics(&prometheus);
     prometheus
-}
-
-pub fn set_parquet_metadata_cache_metrics(
-    entries: usize,
-    used_bytes: usize,
-    limit_bytes: usize,
-    retained_hits: usize,
-    page_index_entries: usize,
-    p50_entry_bytes: usize,
-    p95_entry_bytes: usize,
-    max_entry_bytes: usize,
-) {
-    PARQUET_METADATA_CACHE_ENTRIES.set(entries as i64);
-    PARQUET_METADATA_CACHE_USED_BYTES.set(used_bytes as i64);
-    PARQUET_METADATA_CACHE_LIMIT_BYTES.set(limit_bytes as i64);
-    PARQUET_METADATA_CACHE_RETAINED_HITS.set(retained_hits as i64);
-    PARQUET_METADATA_CACHE_PAGE_INDEX_ENTRIES.set(page_index_entries as i64);
-    PARQUET_METADATA_CACHE_ENTRY_SIZE_BYTES
-        .with_label_values(&["p50"])
-        .set(p50_entry_bytes as i64);
-    PARQUET_METADATA_CACHE_ENTRY_SIZE_BYTES
-        .with_label_values(&["p95"])
-        .set(p95_entry_bytes as i64);
-    PARQUET_METADATA_CACHE_ENTRY_SIZE_BYTES
-        .with_label_values(&["max"])
-        .set(max_entry_bytes as i64);
 }
 
 #[cfg(target_os = "linux")]

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -25,7 +25,9 @@ use actix_web::Responder;
 use actix_web_prometheus::{PrometheusMetrics, PrometheusMetricsBuilder};
 use error::MetricsError;
 use once_cell::sync::Lazy;
-use prometheus::{HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts, Registry};
+use prometheus::{
+    HistogramOpts, HistogramVec, IntCounterVec, IntGauge, IntGaugeVec, Opts, Registry,
+};
 
 pub const METRICS_NAMESPACE: &str = env!("CARGO_PKG_NAME");
 
@@ -187,6 +189,73 @@ pub static QUERY_CACHE_HIT: Lazy<IntCounterVec> = Lazy::new(|| {
     IntCounterVec::new(
         Opts::new("QUERY_CACHE_HIT", "Full Cache hit").namespace(METRICS_NAMESPACE),
         &["stream", "tenant_id"],
+    )
+    .expect("metric can be created")
+});
+
+pub static PARQUET_METADATA_CACHE_ENTRIES: Lazy<IntGauge> = Lazy::new(|| {
+    IntGauge::with_opts(
+        Opts::new(
+            "parquet_metadata_cache_entries",
+            "Number of Parquet metadata entries currently retained",
+        )
+        .namespace(METRICS_NAMESPACE),
+    )
+    .expect("metric can be created")
+});
+
+pub static PARQUET_METADATA_CACHE_USED_BYTES: Lazy<IntGauge> = Lazy::new(|| {
+    IntGauge::with_opts(
+        Opts::new(
+            "parquet_metadata_cache_used_bytes",
+            "Logical memory used by retained Parquet metadata entries",
+        )
+        .namespace(METRICS_NAMESPACE),
+    )
+    .expect("metric can be created")
+});
+
+pub static PARQUET_METADATA_CACHE_LIMIT_BYTES: Lazy<IntGauge> = Lazy::new(|| {
+    IntGauge::with_opts(
+        Opts::new(
+            "parquet_metadata_cache_limit_bytes",
+            "Configured Parquet metadata cache memory limit",
+        )
+        .namespace(METRICS_NAMESPACE),
+    )
+    .expect("metric can be created")
+});
+
+pub static PARQUET_METADATA_CACHE_RETAINED_HITS: Lazy<IntGauge> = Lazy::new(|| {
+    IntGauge::with_opts(
+        Opts::new(
+            "parquet_metadata_cache_retained_hits",
+            "Cache hits recorded by entries that are currently retained",
+        )
+        .namespace(METRICS_NAMESPACE),
+    )
+    .expect("metric can be created")
+});
+
+pub static PARQUET_METADATA_CACHE_PAGE_INDEX_ENTRIES: Lazy<IntGauge> = Lazy::new(|| {
+    IntGauge::with_opts(
+        Opts::new(
+            "parquet_metadata_cache_page_index_entries",
+            "Retained Parquet metadata entries containing page indexes",
+        )
+        .namespace(METRICS_NAMESPACE),
+    )
+    .expect("metric can be created")
+});
+
+pub static PARQUET_METADATA_CACHE_ENTRY_SIZE_BYTES: Lazy<IntGaugeVec> = Lazy::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            "parquet_metadata_cache_entry_size_bytes",
+            "Parquet metadata cache entry size distribution",
+        )
+        .namespace(METRICS_NAMESPACE),
+        &["stat"],
     )
     .expect("metric can be created")
 });
@@ -670,6 +739,24 @@ fn custom_metrics(registry: &Registry) {
         .register(Box::new(QUERY_CACHE_HIT.clone()))
         .expect("metric can be registered");
     registry
+        .register(Box::new(PARQUET_METADATA_CACHE_ENTRIES.clone()))
+        .expect("metric can be registered");
+    registry
+        .register(Box::new(PARQUET_METADATA_CACHE_USED_BYTES.clone()))
+        .expect("metric can be registered");
+    registry
+        .register(Box::new(PARQUET_METADATA_CACHE_LIMIT_BYTES.clone()))
+        .expect("metric can be registered");
+    registry
+        .register(Box::new(PARQUET_METADATA_CACHE_RETAINED_HITS.clone()))
+        .expect("metric can be registered");
+    registry
+        .register(Box::new(PARQUET_METADATA_CACHE_PAGE_INDEX_ENTRIES.clone()))
+        .expect("metric can be registered");
+    registry
+        .register(Box::new(PARQUET_METADATA_CACHE_ENTRY_SIZE_BYTES.clone()))
+        .expect("metric can be registered");
+    registry
         .register(Box::new(ALERTS_STATES.clone()))
         .expect("metric can be registered");
     // Register billing metrics
@@ -793,6 +880,32 @@ pub fn build_metrics_handler() -> PrometheusMetrics {
 
     prom_process_metrics(&prometheus);
     prometheus
+}
+
+pub fn set_parquet_metadata_cache_metrics(
+    entries: usize,
+    used_bytes: usize,
+    limit_bytes: usize,
+    retained_hits: usize,
+    page_index_entries: usize,
+    p50_entry_bytes: usize,
+    p95_entry_bytes: usize,
+    max_entry_bytes: usize,
+) {
+    PARQUET_METADATA_CACHE_ENTRIES.set(entries as i64);
+    PARQUET_METADATA_CACHE_USED_BYTES.set(used_bytes as i64);
+    PARQUET_METADATA_CACHE_LIMIT_BYTES.set(limit_bytes as i64);
+    PARQUET_METADATA_CACHE_RETAINED_HITS.set(retained_hits as i64);
+    PARQUET_METADATA_CACHE_PAGE_INDEX_ENTRIES.set(page_index_entries as i64);
+    PARQUET_METADATA_CACHE_ENTRY_SIZE_BYTES
+        .with_label_values(&["p50"])
+        .set(p50_entry_bytes as i64);
+    PARQUET_METADATA_CACHE_ENTRY_SIZE_BYTES
+        .with_label_values(&["p95"])
+        .set(p95_entry_bytes as i64);
+    PARQUET_METADATA_CACHE_ENTRY_SIZE_BYTES
+        .with_label_values(&["max"])
+        .set(max_entry_bytes as i64);
 }
 
 #[cfg(target_os = "linux")]

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -69,9 +69,7 @@ use crate::catalog::manifest::Manifest;
 use crate::catalog::snapshot::Snapshot;
 use crate::event::DEFAULT_TIMESTAMP_KEY;
 use crate::handlers::http::query::QueryError;
-use crate::metrics::{
-    increment_bytes_scanned_in_query_by_date, set_parquet_metadata_cache_metrics,
-};
+use crate::metrics::increment_bytes_scanned_in_query_by_date;
 use crate::option::Mode;
 use crate::parseable::{DEFAULT_TENANT, PARSEABLE};
 use crate::storage::{ObjectStorageProvider, ObjectStoreFormat};
@@ -328,7 +326,6 @@ impl Query {
             // Track billing metrics for query scan
             let current_date = chrono::Utc::now().date_naive().to_string();
             increment_bytes_scanned_in_query_by_date(actual_io_bytes, &current_date, tenant);
-            report_parquet_metadata_cache();
 
             Either::Left(batches)
         } else {
@@ -1060,65 +1057,8 @@ impl PartitionedMetricMonitor {
                 &current_date,
                 self.tenant_id.as_deref().unwrap_or(DEFAULT_TENANT),
             );
-            report_parquet_metadata_cache();
         }
     }
-}
-
-fn report_parquet_metadata_cache() {
-    let ctx = QUERY_SESSION.get_ctx();
-    let state = ctx.state();
-    let runtime = state.runtime_env();
-    let cache = runtime.cache_manager.get_file_metadata_cache();
-    let entries = cache.list_entries();
-
-    let mut entry_sizes: Vec<usize> = entries.values().map(|entry| entry.size_bytes).collect();
-    entry_sizes.sort_unstable();
-
-    let used_bytes = entry_sizes.iter().sum();
-    let limit_bytes = cache.cache_limit();
-    let retained_hits = entries.values().map(|entry| entry.hits).sum();
-    let page_index_entries = entries
-        .values()
-        .filter(|entry| {
-            entry
-                .extra
-                .get("page_index")
-                .is_some_and(|value| value == "true")
-        })
-        .count();
-    let percentile = |percent: usize| {
-        entry_sizes
-            .get(entry_sizes.len().saturating_sub(1) * percent / 100)
-            .copied()
-            .unwrap_or_default()
-    };
-    let p50_entry_bytes = percentile(50);
-    let p95_entry_bytes = percentile(95);
-    let max_entry_bytes = entry_sizes.last().copied().unwrap_or_default();
-
-    set_parquet_metadata_cache_metrics(
-        entries.len(),
-        used_bytes,
-        limit_bytes,
-        retained_hits,
-        page_index_entries,
-        p50_entry_bytes,
-        p95_entry_bytes,
-        max_entry_bytes,
-    );
-
-    tracing::warn!(
-        entries = entries.len(),
-        used_bytes,
-        limit_bytes,
-        retained_hits,
-        page_index_entries,
-        p50_entry_bytes,
-        p95_entry_bytes,
-        max_entry_bytes,
-        "parquet metadata cache stats"
-    );
 }
 
 #[cfg(test)]

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -69,7 +69,9 @@ use crate::catalog::manifest::Manifest;
 use crate::catalog::snapshot::Snapshot;
 use crate::event::DEFAULT_TIMESTAMP_KEY;
 use crate::handlers::http::query::QueryError;
-use crate::metrics::increment_bytes_scanned_in_query_by_date;
+use crate::metrics::{
+    increment_bytes_scanned_in_query_by_date, set_parquet_metadata_cache_metrics,
+};
 use crate::option::Mode;
 use crate::parseable::{DEFAULT_TENANT, PARSEABLE};
 use crate::storage::{ObjectStorageProvider, ObjectStoreFormat};
@@ -212,7 +214,9 @@ impl Query {
     fn create_session_state(storage: Arc<dyn ObjectStorageProvider>) -> SessionState {
         let runtime_config = storage
             .get_datafusion_runtime()
-            .with_disk_manager_builder(DiskManager::builder());
+            .with_disk_manager_builder(DiskManager::builder())
+            .with_metadata_cache_limit(PARSEABLE.options.parquet_metadata_cache_size);
+
         let (pool_size, fraction) = match PARSEABLE.options.query_memory_pool_size {
             Some(size) => (size, 1.),
             None => {
@@ -324,6 +328,7 @@ impl Query {
             // Track billing metrics for query scan
             let current_date = chrono::Utc::now().date_naive().to_string();
             increment_bytes_scanned_in_query_by_date(actual_io_bytes, &current_date, tenant);
+            report_parquet_metadata_cache();
 
             Either::Left(batches)
         } else {
@@ -1055,8 +1060,65 @@ impl PartitionedMetricMonitor {
                 &current_date,
                 self.tenant_id.as_deref().unwrap_or(DEFAULT_TENANT),
             );
+            report_parquet_metadata_cache();
         }
     }
+}
+
+fn report_parquet_metadata_cache() {
+    let ctx = QUERY_SESSION.get_ctx();
+    let state = ctx.state();
+    let runtime = state.runtime_env();
+    let cache = runtime.cache_manager.get_file_metadata_cache();
+    let entries = cache.list_entries();
+
+    let mut entry_sizes: Vec<usize> = entries.values().map(|entry| entry.size_bytes).collect();
+    entry_sizes.sort_unstable();
+
+    let used_bytes = entry_sizes.iter().sum();
+    let limit_bytes = cache.cache_limit();
+    let retained_hits = entries.values().map(|entry| entry.hits).sum();
+    let page_index_entries = entries
+        .values()
+        .filter(|entry| {
+            entry
+                .extra
+                .get("page_index")
+                .is_some_and(|value| value == "true")
+        })
+        .count();
+    let percentile = |percent: usize| {
+        entry_sizes
+            .get(entry_sizes.len().saturating_sub(1) * percent / 100)
+            .copied()
+            .unwrap_or_default()
+    };
+    let p50_entry_bytes = percentile(50);
+    let p95_entry_bytes = percentile(95);
+    let max_entry_bytes = entry_sizes.last().copied().unwrap_or_default();
+
+    set_parquet_metadata_cache_metrics(
+        entries.len(),
+        used_bytes,
+        limit_bytes,
+        retained_hits,
+        page_index_entries,
+        p50_entry_bytes,
+        p95_entry_bytes,
+        max_entry_bytes,
+    );
+
+    tracing::warn!(
+        entries = entries.len(),
+        used_bytes,
+        limit_bytes,
+        retained_hits,
+        page_index_entries,
+        p50_entry_bytes,
+        p95_entry_bytes,
+        max_entry_bytes,
+        "parquet metadata cache stats"
+    );
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- add env `P_PARQUET_METADATA_CACHE_SIZE` for max parquet metadata cache size 
    default 50 MB
- update env `P_DATAFUSION_TARGET_PARTITIONS` default to 4*num_cpu
- add metrics for parquet metadata cache reads



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a CLI option to configure the Parquet metadata cache size, with support for environment-variable configuration.
  - Updated the default query partition setting to improve parallel query execution.

- **Bug Fixes**
  - Removed inaccurate or unavailable Parquet metadata cache statistics from query reporting.
  - Retained existing bytes-scanned billing metrics after query completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->