### PR TITLE
fix: tenant id validation

### DIFF
--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -22,7 +22,7 @@ use std::{
     num::NonZeroU32,
     path::PathBuf,
     str::FromStr,
-    sync::{Arc, RwLock},
+    sync::{Arc, LazyLock, RwLock},
 };
 
 use actix_web::http::{
@@ -34,6 +34,7 @@ use bytes::Bytes;
 use chrono::Utc;
 use clap::{Parser, error::ErrorKind};
 use once_cell::sync::{Lazy, OnceCell};
+use regex::Regex;
 use relative_path::RelativePathBuf;
 pub use staging::StagingError;
 use streams::StreamRef;
@@ -101,6 +102,23 @@ pub const STREAM_EXISTS: &str = "Stream exists";
 
 /// OnceCell to return metastore
 pub static METASTORE: OnceCell<Arc<dyn Metastore>> = OnceCell::new();
+
+/// LazyLock for tenant id regex
+pub static TENANT_ID_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    regex::RegexBuilder::new(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,35}$")
+        .build()
+        .expect("Unable to create tenant id validation regex")
+});
+
+pub fn validate_tenant_id(tenant_id: &str) -> Result<(), String> {
+    if !TENANT_ID_REGEX.is_match(&tenant_id) {
+        return Err("tenant ID should follow regex- ^[a-zA-Z0-9][a-zA-Z0-9_-]{0,35}$".into());
+    }
+    if tenant_id.eq(DEFAULT_TENANT) {
+        return Err(format!("tenant ID can't be {DEFAULT_TENANT}"));
+    }
+    Ok(())
+}
 
 /// For OTel log sources the telemetry_type is fully determined by the log_source.
 /// When the user explicitly sets x-p-telemetry-type and it disagrees with the
@@ -1260,6 +1278,8 @@ impl Parseable {
 
         // validate the possible presence of tenant storage metadata
         for tenant_id in dirs.into_iter() {
+            // check if tenantID is valid
+            validate_tenant_id(&tenant_id).map_err(|e| anyhow::anyhow!(e))?;
             if let Some(meta) = PARSEABLE
                 .metastore
                 .get_parseable_metadata(&Some(tenant_id.clone()))

--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -111,7 +111,7 @@ pub static TENANT_ID_REGEX: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 pub fn validate_tenant_id(tenant_id: &str) -> Result<(), String> {
-    if !TENANT_ID_REGEX.is_match(&tenant_id) {
+    if !TENANT_ID_REGEX.is_match(tenant_id) {
         return Err("tenant ID should follow regex- ^[a-zA-Z0-9][a-zA-Z0-9_-]{0,35}$".into());
     }
     if tenant_id.eq(DEFAULT_TENANT) {
@@ -1183,7 +1183,7 @@ impl Parseable {
         if !self.options.is_multi_tenant() {
             return Err(anyhow::Error::msg("P_MULTI_TENANCY is set to false"));
         }
-
+        validate_tenant_id(&tenant_id).map_err(|e| anyhow::anyhow!(e))?;
         let mut tenants = self.tenants.write().unwrap();
         if tenants.contains(&tenant_id) {
             return Err(anyhow::Error::msg(format!(
@@ -1278,14 +1278,14 @@ impl Parseable {
 
         // validate the possible presence of tenant storage metadata
         for tenant_id in dirs.into_iter() {
-            // check if tenantID is valid
-            validate_tenant_id(&tenant_id).map_err(|e| anyhow::anyhow!(e))?;
             if let Some(meta) = PARSEABLE
                 .metastore
                 .get_parseable_metadata(&Some(tenant_id.clone()))
                 .await?
                 && is_multi_tenant
             {
+                // check if tenantID is valid
+                validate_tenant_id(&tenant_id).map_err(|e| anyhow::anyhow!(e))?;
                 let metadata: StorageMetadata = serde_json::from_slice(&meta)?;
 
                 TENANT_METADATA.insert_tenant(tenant_id.clone(), metadata.clone());


### PR DESCRIPTION
Restrict `DEFAULT_TENANT`, and other values which can be trigger path manipulation as tenant id

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for tenant identifiers to ensure they follow the required format.
  * Invalid tenant directories are now rejected during tenant loading, including the reserved default tenant identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->