### PR TITLE
  feat: add Parseable branding to metrics onboarding scripts

### DIFF
--- a/scripts/ingest.ps1
+++ b/scripts/ingest.ps1
@@ -85,17 +85,27 @@ function Write-SetupComplete {
 function Test-FluentBitRunning {
     if (Test-Path $PID_FILE) {
         $processId = Get-Content $PID_FILE
-        try {
-            $process = Get-Process -Id $processId -ErrorAction Stop
-            $actualPath = [System.IO.Path]::GetFullPath($process.Path)
-            $expectedPath = [System.IO.Path]::GetFullPath($FLUENT_BIT_EXE)
 
-            if ([System.StringComparer]::OrdinalIgnoreCase.Equals($actualPath, $expectedPath)) {
-                return $true
-            }
+        try {
+            $process = Get-CimInstance -ClassName Win32_Process -Filter "ProcessId = $processId" -ErrorAction Stop
         }
         catch {
-            # Treat missing or inaccessible processes as stale.
+            throw "Unable to inspect process $processId; PID file was preserved. $_"
+        }
+
+        if ($null -eq $process) {
+            Remove-Item $PID_FILE -ErrorAction SilentlyContinue
+            return $false
+        }
+
+        if ([string]::IsNullOrWhiteSpace($process.ExecutablePath)) {
+            throw "Unable to verify process $processId; PID file was preserved."
+        }
+
+        $actualPath = [System.IO.Path]::GetFullPath($process.ExecutablePath)
+        $expectedPath = [System.IO.Path]::GetFullPath($FLUENT_BIT_EXE)
+        if ([System.StringComparer]::OrdinalIgnoreCase.Equals($actualPath, $expectedPath)) {
+            return $true
         }
 
         Remove-Item $PID_FILE -ErrorAction SilentlyContinue

--- a/scripts/ingest.ps1
+++ b/scripts/ingest.ps1
@@ -86,14 +86,19 @@ function Test-FluentBitRunning {
     if (Test-Path $PID_FILE) {
         $processId = Get-Content $PID_FILE
         try {
-            $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
-            if ($process) {
+            $process = Get-Process -Id $processId -ErrorAction Stop
+            $actualPath = [System.IO.Path]::GetFullPath($process.Path)
+            $expectedPath = [System.IO.Path]::GetFullPath($FLUENT_BIT_EXE)
+
+            if ([System.StringComparer]::OrdinalIgnoreCase.Equals($actualPath, $expectedPath)) {
                 return $true
             }
         }
         catch {
-            return $false
+            # Treat missing or inaccessible processes as stale.
         }
+
+        Remove-Item $PID_FILE -ErrorAction SilentlyContinue
     }
     return $false
 }

--- a/scripts/ingest.ps1
+++ b/scripts/ingest.ps1
@@ -49,6 +49,39 @@ function Write-ErrorMsg {
     Write-Host "[ERROR] $Message" -ForegroundColor Red
 }
 
+function Write-ParseableBanner {
+    $accent = "$([char]27)[38;2;158;158;240m"
+    $reset = "$([char]27)[0m"
+    $logo = @(
+        ' ____   _    ____  ____  _____    _    ____  _     _____',
+        '|  _ \ / \  |  _ \/ ___|| ____|  / \  | __ )| |   | ____|',
+        '| |_) / _ \ | |_) \___ \|  _|   / _ \ |  _ \| |   |  _|',
+        '|  __/ ___ \|  _ < ___) | |___ / ___ \| |_) | |___| |___',
+        '|_| /_/   \_\_| \_\____/|_____/_/   \_\____/|_____|_____|'
+    )
+
+    Write-Host ""
+    $logo | ForEach-Object { Write-Host "$accent$_$reset" }
+    Write-Host ""
+    Write-Host "Host metrics setup" -ForegroundColor White
+    Write-Host "Installing and configuring the metrics agent for Parseable..."
+    Write-Host ""
+}
+
+function Write-SetupComplete {
+    param([string]$StreamName)
+
+    $accent = "$([char]27)[38;2;158;158;240m"
+    $ok = "$([char]27)[38;2;52;211;153m"
+    $reset = "$([char]27)[0m"
+    Write-Host ""
+    Write-Host "${ok}✓ You're all set!${reset}"
+    Write-Host "Host metrics are now being sent to Parseable."
+    Write-Host "Dataset: " -NoNewline
+    Write-Host "${accent}${StreamName}${reset}"
+    Write-Host "Return to Parseable and click Continue to verify your data."
+}
+
 function Test-FluentBitRunning {
     if (Test-Path $PID_FILE) {
         $processId = Get-Content $PID_FILE
@@ -282,6 +315,8 @@ function Setup-FluentBit {
         exit 1
     }
 
+    Write-ParseableBanner
+
     $tlsSetting = "On"
     $defaultPort = "443"
     if ($IngestorHost -like "https://*") {
@@ -360,6 +395,7 @@ function Setup-FluentBit {
     
     Write-Host ""
     Start-FluentBit
+    Write-SetupComplete -StreamName $StreamName
 }
 
 function Show-Help {

--- a/scripts/ingest.ps1
+++ b/scripts/ingest.ps1
@@ -75,7 +75,7 @@ function Write-SetupComplete {
     $ok = "$([char]27)[38;2;52;211;153m"
     $reset = "$([char]27)[0m"
     Write-Host ""
-    Write-Host "${ok}✓ You're all set!${reset}"
+    Write-Host "${ok}[OK] You're all set!${reset}"
     Write-Host "Host metrics are now being sent to Parseable."
     Write-Host "Dataset: " -NoNewline
     Write-Host "${accent}${StreamName}${reset}"
@@ -244,7 +244,7 @@ function Start-FluentBit {
         $processId = Get-Content $PID_FILE
         Write-Warning "Fluent Bit is already running (PID: $processId)"
         Write-Info "Use '$SCRIPT_CMD stop' to stop it first"
-        return
+        return $false
     }
     
     if (-not (Test-Path $CONFIG_FILE)) {
@@ -293,13 +293,14 @@ function Start-FluentBit {
         Write-Info "To check status: $SCRIPT_CMD status"
         Write-Info "To see logs: $SCRIPT_CMD logs"
         Write-Info "To stop: $SCRIPT_CMD stop"
+        return $true
     }
 }
 
 function Restart-FluentBit {
     Stop-FluentBit
     Start-Sleep -Seconds 2
-    Start-FluentBit
+    [void](Start-FluentBit)
 }
 
 function Setup-FluentBit {
@@ -392,10 +393,17 @@ function Setup-FluentBit {
     # Use UTF8 without BOM (important for Fluent Bit)
     $utf8NoBom = New-Object System.Text.UTF8Encoding $false
     [System.IO.File]::WriteAllText($CONFIG_FILE, $configContent, $utf8NoBom)
+
+    if (Test-FluentBitRunning) {
+        Write-Info "Restarting Fluent Bit to apply the updated configuration..."
+        Stop-FluentBit
+        Start-Sleep -Seconds 2
+    }
     
     Write-Host ""
-    Start-FluentBit
-    Write-SetupComplete -StreamName $StreamName
+    if (Start-FluentBit) {
+        Write-SetupComplete -StreamName $StreamName
+    }
 }
 
 function Show-Help {
@@ -447,7 +455,7 @@ switch ($Param1.ToLower()) {
         Restart-FluentBit
     }
     "start" {
-        Start-FluentBit
+        [void](Start-FluentBit)
     }
     "status" {
         Show-Status

--- a/scripts/ingest.sh
+++ b/scripts/ingest.sh
@@ -364,6 +364,12 @@ ${TENANT_HEADER}
 EOF
     chmod 600 "$CONFIG_FILE"
     sed "s/Header                    X-API-Key.*/Header                    X-API-Key [REDACTED]/" "$CONFIG_FILE"
+
+    if is_running; then
+        print_info "Restarting Fluent Bit to apply the updated configuration..."
+        stop_fluent_bit
+        sleep 2
+    fi
     
     # Start Fluent Bit
     echo ""

--- a/scripts/ingest.sh
+++ b/scripts/ingest.sh
@@ -14,6 +14,9 @@ set -e
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
+ACCENT='\033[38;2;158;158;240m' 
+OK='\033[38;2;52;211;153m'      
+BOLD='\033[1m'
 NC='\033[0m' # No Color
 
 # File locations
@@ -32,6 +35,29 @@ print_error() {
 
 print_warning() {
     echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_parseable_banner() {
+    echo ""
+    printf '%b%s%b\n' "$ACCENT" ' ____   _    ____  ____  _____    _    ____  _     _____' "$NC"
+    printf '%b%s%b\n' "$ACCENT" '|  _ \ / \  |  _ \/ ___|| ____|  / \  | __ )| |   | ____|' "$NC"
+    printf '%b%s%b\n' "$ACCENT" '| |_) / _ \ | |_) \___ \|  _|   / _ \ |  _ \| |   |  _|' "$NC"
+    printf '%b%s%b\n' "$ACCENT" '|  __/ ___ \|  _ < ___) | |___ / ___ \| |_) | |___| |___' "$NC"
+    printf '%b%s%b\n' "$ACCENT" '|_| /_/   \_\_| \_\____/|_____/_/   \_\____/|_____|_____|' "$NC"
+    echo ""
+    echo -e "${BOLD}Host metrics setup${NC}"
+    echo "Installing and configuring the metrics agent for Parseable..."
+    echo ""
+}
+
+print_setup_complete() {
+    local stream_name="$1"
+
+    echo ""
+    echo -e "${OK}${BOLD}✓ You're all set!${NC}"
+    echo "Host metrics are now being sent to Parseable."
+    echo -e "Dataset: ${BOLD}${stream_name}${NC}"
+    echo "Return to Parseable and click Continue to verify your data."
 }
 
 # Function to check if Fluent Bit is running
@@ -256,6 +282,8 @@ setup_fluent_bit() {
         exit 1
     fi
 
+    print_parseable_banner
+
     if [[ "$INGESTOR_HOST" =~ ^[Hh][Tt][Tt][Pp][Ss]:// ]]; then
         INGESTOR_HOST="${INGESTOR_HOST#*://}"
         TLS_SETTING="On"
@@ -340,6 +368,7 @@ EOF
     # Start Fluent Bit
     echo ""
     start_fluent_bit
+    print_setup_complete "$STREAM_NAME"
 }
 
 # Main script logic


### PR DESCRIPTION
 PR description:

  ## What changed

  - Added Parseable ASCII logo to macOS/Linux and Windows metrics installers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **User Experience**
  * Added colored setup banners for the Parseable metrics agent.
  * Added a completion message confirming Fluent Bit has started and displaying the configured stream name.
  * Improved visual feedback during metrics-agent setup across supported environments.

* **Bug Fixes**
  * Improved Fluent Bit process detection and recovery from stale process information.
  * Ensured running Fluent Bit instances restart when updated configuration is applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->