### PR TITLE
remove prompt=consent from oidc scope

### DIFF
--- a/src/handlers/http/oidc.rs
+++ b/src/handlers/http/oidc.rs
@@ -96,7 +96,7 @@ pub async fn login(
             let scope = PARSEABLE.options.scope.to_string();
             let mut auth_url: String = client.read().await.auth_url(&scope, Some(redirect)).into();
 
-            auth_url.push_str("&access_type=offline&prompt=consent");
+            auth_url.push_str("&access_type=offline");
             return Ok(HttpResponse::TemporaryRedirect()
                 .insert_header((actix_web::http::header::LOCATION, auth_url))
                 .finish());
@@ -153,7 +153,7 @@ pub async fn login(
                         .await
                         .auth_url(&scope, Some(redirect))
                         .into();
-                    auth_url.push_str("&access_type=offline&prompt=consent");
+                    auth_url.push_str("&access_type=offline");
                     HttpResponse::TemporaryRedirect()
                         .insert_header((actix_web::http::header::LOCATION, auth_url))
                         .finish()


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #1750 

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OIDC authorization requests to support offline access without unnecessarily forcing a consent prompt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->