### PR TITLE
deprecate: GET /role api

### DIFF
--- a/src/handlers/http/modal/ingest_server.rs
+++ b/src/handlers/http/modal/ingest_server.rs
@@ -146,8 +146,6 @@ impl IngestServer {
     // get the role webscope
     pub fn get_user_role_webscope() -> Scope {
         web::scope("/role")
-            // GET Role List
-            .service(web::resource("").route(web::get().to(role::list).authorize(Action::ListRole)))
             .service(
                 // PUT and GET Default Role
                 web::resource("/default")

--- a/src/handlers/http/modal/query_server.rs
+++ b/src/handlers/http/modal/query_server.rs
@@ -179,8 +179,6 @@ impl QueryServer {
     // get the role webscope
     pub fn get_user_role_webscope() -> Scope {
         web::scope("/role")
-            // GET Role List
-            .service(resource("").route(web::get().to(role::list).authorize(Action::ListRole)))
             .service(
                 // PUT and GET Default Role
                 resource("/default")

--- a/src/handlers/http/role.rs
+++ b/src/handlers/http/role.rs
@@ -107,7 +107,7 @@ pub async fn get(req: HttpRequest, name: web::Path<String>) -> Result<impl Respo
     Ok(web::Json(role))
 }
 
-// Handler for GET /api/v1/role
+// Handler for GET /api/v1/roles
 // Fetch all roles in the system
 pub async fn list(req: HttpRequest) -> Result<impl Responder, RoleError> {
     let tenant_id = get_tenant_id_from_request(&req);


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the role-list endpoint from ingestor and query web scopes.
  - Default-role and individual-role routes remain available.

- **Documentation**
  - Corrected the role-list handler documentation to reference the `/roles` route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->