### PR TITLE
perf: remove two redundant object-store calls in datasets metadata fetch

### DIFF
--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -763,14 +763,6 @@ pub async fn get_manifest_list(
     time_range: &TimeRange,
     tenant_id: &Option<String>,
 ) -> Result<Vec<Manifest>, QueryError> {
-    // get object store
-    let object_store_format: ObjectStoreFormat = serde_json::from_slice(
-        &PARSEABLE
-            .metastore
-            .get_stream_json(stream_name, false, tenant_id, false)
-            .await?,
-    )?;
-
     // all the manifests will go here
     let mut merged_snapshot: Snapshot = Snapshot::default();
 
@@ -791,6 +783,14 @@ pub async fn get_manifest_list(
             }
         }
     } else {
+        // Only needed here: Query/Prism mode merges every ingestor's stream.json
+        // above instead and never reads the base file.
+        let object_store_format: ObjectStoreFormat = serde_json::from_slice(
+            &PARSEABLE
+                .metastore
+                .get_stream_json(stream_name, false, tenant_id, false)
+                .await?,
+        )?;
         merged_snapshot = object_store_format.snapshot;
     }
 

--- a/src/storage/object_storage.rs
+++ b/src/storage/object_storage.rs
@@ -931,13 +931,11 @@ pub trait ObjectStorage: Debug + Send + Sync + 'static {
         let min_date = &parsed_dates[0].1;
         let max_date = &parsed_dates[parsed_dates.len() - 1].1;
 
-        // Extract timestamps for min and max dates
-        let first_timestamp = self
-            .extract_timestamp_for_date(stream_name, min_date, true, tenant_id)
-            .await?;
-        let latest_timestamp = self
-            .extract_timestamp_for_date(stream_name, max_date, false, tenant_id)
-            .await?;
+        // Extract timestamps for min and max dates concurrently; independent reads, no shared state
+        let (first_timestamp, latest_timestamp) = tokio::try_join!(
+            self.extract_timestamp_for_date(stream_name, min_date, true, tenant_id),
+            self.extract_timestamp_for_date(stream_name, max_date, false, tenant_id)
+        )?;
 
         let first_event_at = first_timestamp.map(|ts| ts.to_rfc3339());
         let latest_event_at = latest_timestamp.map(|ts| ts.to_rfc3339());


### PR DESCRIPTION
## Summary

Two small, low-risk fixes in the object-store I/O behind `POST /api/prism/v1/datasets`, which has been observed taking 50s+ to respond on multi-TB, multi-day deployments even on a 44 vCPU / 192GB query node.

- `get_manifest_list` (`src/query/mod.rs`) unconditionally fetched the base `stream.json` via `get_stream_json`, but on `Mode::Query`/`Mode::Prism` nodes that result is never read (those modes merge every ingestor's `stream.json` instead via `get_all_stream_jsons`). Moved the fetch into the `else` branch that actually needs it (`Mode::All`).
- `get_first_and_latest_event_from_storage` (`src/storage/object_storage.rs`) awaited its two independent `extract_timestamp_for_date` calls sequentially. Replaced with `tokio::try_join!` to run them concurrently, matching the existing `tokio::join!` pattern already used one call up the stack in `get_prism_logstream_info`.

Both changes are behavior-preserving on the success path (same I/O, fewer/faster round trips). Two notes worth flagging for review:
- The `get_manifest_list` change means a failed/corrupt base `stream.json` on a Query-mode node no longer short-circuits the whole call — it now proceeds to `get_all_stream_jsons` instead, which can succeed where the old code would fail. This seems like a desirable side effect but is a real change in failure-path behavior, not just a speedup.
- These are part of a larger investigation into `/datasets` latency (bundles stats/retention/hottier/info/counts/query per stream); the dominant cost — a manifest-list scan that's unbounded by stream history when no retention policy is configured — needs a larger catalog-level change and is intentionally not part of this PR. Happy to open a separate issue for that once there's an associated tracking issue for this one (the Parseable team mentioned they'd be opening one).

## Test plan

- [x] `cargo test --lib` — 426 passed, 0 failed (full existing suite, no regressions)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --lib` — clean
- [ ] Validate against a real multi-TB test cluster (in progress, pending network access)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved storage processing by retrieving earliest and latest event timestamps concurrently.
* **Bug Fixes**
  * Refined manifest loading so each query mode uses the appropriate stream data and snapshot information.
  * Preserved error handling when retrieving event timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->