### PR TITLE
add details to invalid api key error in middleware

### DIFF
--- a/src/handlers/http/middleware.rs
+++ b/src/handlers/http/middleware.rs
@@ -198,8 +198,10 @@ where
                     Some(session_id)
                 }
                 None => {
-                    let connection_info = req.connection_info();
-                    let source_ip = connection_info.realip_remote_addr().unwrap_or("unknown");
+                    let source_ip = req
+                        .peer_addr()
+                        .map(|address| address.ip().to_string())
+                        .unwrap_or_else(|| "unknown".to_string());
                     let endpoint = req.path();
                     let user_agent = req
                         .headers()

--- a/src/handlers/http/middleware.rs
+++ b/src/handlers/http/middleware.rs
@@ -198,7 +198,31 @@ where
                     Some(session_id)
                 }
                 None => {
-                    return Box::pin(async { Err(ErrorUnauthorized("Invalid API key")) });
+                    let connection_info = req.connection_info();
+                    let source_ip = connection_info.realip_remote_addr().unwrap_or("unknown");
+                    let user_agent = req
+                        .headers()
+                        .get(header::USER_AGENT)
+                        .and_then(|value| value.to_str().ok())
+                        .unwrap_or_default();
+                    let dataset = req
+                        .match_info()
+                        .get("logstream")
+                        .or_else(|| {
+                            req.headers()
+                                .get(STREAM_NAME_HEADER_KEY)
+                                .and_then(|value| value.to_str().ok())
+                        })
+                        .unwrap_or("unknown");
+
+                    let error_message = format!(
+                        "Invalid API key (source IP: {source_ip}, user agent: {user_agent}, dataset: {dataset})"
+                    );
+                    tracing::warn!(
+                        tenant = tenant_id.as_deref().unwrap_or(DEFAULT_TENANT),
+                        "{error_message}"
+                    );
+                    return Box::pin(async move { Err(ErrorUnauthorized(error_message)) });
                 }
             }
         } else {

--- a/src/handlers/http/middleware.rs
+++ b/src/handlers/http/middleware.rs
@@ -200,6 +200,7 @@ where
                 None => {
                     let connection_info = req.connection_info();
                     let source_ip = connection_info.realip_remote_addr().unwrap_or("unknown");
+                    let endpoint = req.path();
                     let user_agent = req
                         .headers()
                         .get(header::USER_AGENT)
@@ -217,6 +218,7 @@ where
 
                     tracing::warn!(
                         source_ip,
+                        endpoint,
                         user_agent,
                         dataset,
                         requested_tenant = tenant_id.as_deref().unwrap_or("unknown"),

--- a/src/handlers/http/middleware.rs
+++ b/src/handlers/http/middleware.rs
@@ -215,14 +215,14 @@ where
                         })
                         .unwrap_or("unknown");
 
-                    let error_message = format!(
-                        "Invalid API key (source IP: {source_ip}, user agent: {user_agent}, dataset: {dataset})"
-                    );
                     tracing::warn!(
-                        tenant = tenant_id.as_deref().unwrap_or(DEFAULT_TENANT),
-                        "{error_message}"
+                        source_ip,
+                        user_agent,
+                        dataset,
+                        requested_tenant = tenant_id.as_deref().unwrap_or("unknown"),
+                        "Invalid API key"
                     );
-                    return Box::pin(async move { Err(ErrorUnauthorized(error_message)) });
+                    return Box::pin(async { Err(ErrorUnauthorized("Invalid API key")) });
                 }
             }
         } else {

--- a/src/handlers/http/modal/utils/ingest_utils.rs
+++ b/src/handlers/http/modal/utils/ingest_utils.rs
@@ -412,12 +412,13 @@ pub fn get_custom_fields_from_header(req: &HttpRequest) -> HashMap<String, Strin
         .and_then(|a| a.to_str().ok())
         .unwrap_or_default();
 
-    let conn = req.connection_info().clone();
-
-    let source_ip = conn.realip_remote_addr().unwrap_or_default();
+    let source_ip = req
+        .peer_addr()
+        .map(|address| address.ip().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
     let mut p_custom_fields = HashMap::new();
     p_custom_fields.insert(USER_AGENT_KEY.to_string(), user_agent.to_string());
-    p_custom_fields.insert(SOURCE_IP_KEY.to_string(), source_ip.to_string());
+    p_custom_fields.insert(SOURCE_IP_KEY.to_string(), source_ip);
 
     // Iterate through headers and add custom fields
     for (header_name, header_value) in req.headers().iter() {

--- a/src/handlers/http/modal/utils/ingest_utils.rs
+++ b/src/handlers/http/modal/utils/ingest_utils.rs
@@ -593,6 +593,17 @@ mod tests {
 
         assert_eq!(custom_fields.len(), 2);
         assert_eq!(custom_fields.get(USER_AGENT_KEY).unwrap(), "");
-        assert_eq!(custom_fields.get(SOURCE_IP_KEY).unwrap(), "");
+        assert_eq!(custom_fields.get(SOURCE_IP_KEY).unwrap(), "unknown");
+    }
+
+    #[test]
+    fn test_get_custom_fields_from_header_with_peer_address() {
+        let req = TestRequest::default()
+            .peer_addr("192.0.2.1:8080".parse().unwrap())
+            .to_http_request();
+
+        let custom_fields = get_custom_fields_from_header(&req);
+
+        assert_eq!(custom_fields.get(SOURCE_IP_KEY).unwrap(), "192.0.2.1");
     }
 }


### PR DESCRIPTION
add user agent, src ip and  dataset name to the error



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized invalid API-key responses with a clear “Invalid API key” message.
  * Improved unauthorized-access diagnostics by recording relevant request context, including source address, endpoint, client details, dataset, and requested tenant when available.
  * Added consistent fallback values when request metadata is unavailable.
  * Improved source-address detection during data ingestion, including support for peer-address details and an “unknown” fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->