### PR TITLE
add optional P_OIDC_QUERY_PARAMS env var

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -631,11 +631,22 @@ pub struct Options {
         long = "oidc-scope",
         name = "oidc-scope",
         env = "P_OIDC_SCOPE",
-        default_value = "openid profile email offline_access",
+        default_value = "openid profile email",
         required = false,
-        help = "OIDC scope to request (default: openid profile email offline_access)"
+        help = "OIDC scope to request (default: openid profile email)"
     )]
     pub scope: String,
+
+    // additional query params for oidc auth url
+    #[arg(
+        long,
+        name = "oidc-query-params",
+        env = "P_OIDC_QUERY_PARAMS",
+        value_parser = validation::validate_query_params,
+        required = false,
+        help = "Additional query params to add to the auth url"
+    )]
+    pub oidc_query_params: Option<String>,
 
     // event's maximum chunk age in hours
     #[arg(

--- a/src/handlers/http/oidc.rs
+++ b/src/handlers/http/oidc.rs
@@ -96,7 +96,13 @@ pub async fn login(
             let scope = PARSEABLE.options.scope.to_string();
             let mut auth_url: String = client.read().await.auth_url(&scope, Some(redirect)).into();
 
-            auth_url.push_str("&access_type=offline");
+            if let Some(query_params) = PARSEABLE.options.oidc_query_params.as_ref() {
+                if !query_params.starts_with('&') {
+                    auth_url = format!("{auth_url}&{query_params}");
+                } else {
+                    auth_url.push_str(query_params.as_str());
+                }
+            }
             return Ok(HttpResponse::TemporaryRedirect()
                 .insert_header((actix_web::http::header::LOCATION, auth_url))
                 .finish());
@@ -153,7 +159,13 @@ pub async fn login(
                         .await
                         .auth_url(&scope, Some(redirect))
                         .into();
-                    auth_url.push_str("&access_type=offline");
+                    if let Some(query_params) = PARSEABLE.options.oidc_query_params.as_ref() {
+                        if !query_params.starts_with('&') {
+                            auth_url = format!("{auth_url}&{query_params}");
+                        } else {
+                            auth_url.push_str(query_params.as_str());
+                        }
+                    }
                     HttpResponse::TemporaryRedirect()
                         .insert_header((actix_web::http::header::LOCATION, auth_url))
                         .finish()

--- a/src/option.rs
+++ b/src/option.rs
@@ -209,6 +209,56 @@ pub mod validation {
         }
     }
 
+    pub fn validate_query_params(mut query: &str) -> Result<String, String> {
+        fn valid_component(value: &str) -> bool {
+            let bytes = value.as_bytes();
+            let mut i = 0;
+
+            while i < bytes.len() {
+                match bytes[i] {
+                    b'%' if i + 2 < bytes.len()
+                        && bytes[i + 1].is_ascii_hexdigit()
+                        && bytes[i + 2].is_ascii_hexdigit() =>
+                    {
+                        i += 3;
+                    }
+                    b if b.is_ascii_alphanumeric()
+                        || matches!(b, b'-' | b'.' | b'_' | b'~' | b'+') =>
+                    {
+                        i += 1;
+                    }
+                    _ => return false,
+                }
+            }
+
+            true
+        }
+
+        if query.is_empty() {
+            return Err("query string cannot be empty".into());
+        }
+        query = if let Some(query) = query.strip_prefix('&') {
+            query
+        } else {
+            query
+        };
+        for param in query.split('&') {
+            let (key, value) = param
+                .split_once('=')
+                .ok_or_else(|| format!("invalid parameter: {param}"))?;
+
+            if key.is_empty() {
+                return Err("parameter key cannot be empty".into());
+            }
+
+            if !valid_component(key) || !valid_component(value) {
+                return Err(format!("invalid characters in parameter: {param}"));
+            }
+        }
+
+        Ok(query.to_owned())
+    }
+
     pub fn validate_payload_size(s: &str) -> Result<usize, String> {
         const MIN_SIZE: usize = 100; // 100 bytes
         const MAX_SIZE: usize = 100 * 1024 * 1024; // 100 MB


### PR DESCRIPTION
Gives user the option to add query params to the auth url made during OAUTH logins. For example, in order to get a refresh_token from Google, they require `access_type=offline&prompt=consent` query params

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional setting for custom OIDC authorization query parameters.
  * Added validation to ensure query parameters use an accepted format before authorization begins.

* **Changes**
  * Updated the default OIDC scope to request standard identity information without automatically requesting offline access.
  * OIDC authorization links now include configured query parameters and no longer force offline access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->