### PR TITLE
feat: throttling for query

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -451,9 +451,19 @@ pub struct Options {
         long,
         long = "query-mempool-size",
         env = "P_QUERY_MEMORY_LIMIT",
-        help = "Set a fixed memory limit for query in GiB"
+        help = "Set a fixed memory limit for query in Bytes"
     )]
     pub query_memory_pool_size: Option<usize>,
+
+    #[arg(
+        long,
+        long = "query-mem-threshold",
+        value_parser = validation::validate_percentage,
+        default_value = "80.0",
+        env = "P_QUERY_MEMORY_THRESHOLD",
+        help = "Set a threshold (percentage) for memory beyond which query will get queued for 60s to prevent OOM"
+    )]
+    pub query_mem_threshold: f32,
 
     #[arg(
         long,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -461,7 +461,7 @@ pub struct Options {
         value_parser = validation::validate_percentage,
         default_value = "80.0",
         env = "P_QUERY_MEMORY_THRESHOLD",
-        help = "Set a threshold (percentage) for memory beyond which query will get queued for 60s to prevent OOM"
+        help = "Set a threshold (percentage) for memory beyond which query will get queued for 10s to prevent OOM"
     )]
     pub query_mem_threshold: f32,
 

--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -730,7 +730,8 @@ Description: {0}"#
 impl actix_web::ResponseError for QueryError {
     fn status_code(&self) -> StatusCode {
         match self {
-            QueryError::Execute(_) | QueryError::JsonParse(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            QueryError::JsonParse(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            QueryError::Execute(e) => e.status_code(),
             QueryError::MetastoreError(e) => e.status_code(),
             _ => StatusCode::BAD_REQUEST,
         }

--- a/src/handlers/http/resource_check.rs
+++ b/src/handlers/http/resource_check.rs
@@ -63,8 +63,11 @@ pub fn spawn_resource_monitor(shutdown_rx: tokio::sync::oneshot::Receiver<()>) {
                     refresh_sys_info();
                     let (used_memory, total_memory, cpu_usage) = tokio::task::spawn_blocking(|| {
                         let sys = SYS_INFO.lock().unwrap();
-                        let used_memory = sys.used_memory() as f32;
-                        let total_memory = sys.total_memory() as f32;
+                        let (used_memory, total_memory) = if let Some(cgroup) = sys.cgroup_limits() {
+                            (cgroup.rss as f32,cgroup.total_memory as f32)
+                        } else {
+                            (sys.used_memory() as f32,sys.total_memory() as f32)
+                        };
                         let cpu_usage = sys.global_cpu_usage();
                         (used_memory, total_memory, cpu_usage)
                     }).await.unwrap();

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -158,7 +158,8 @@ async fn enough_available_memory() -> Result<(), ExecuteError> {
                     return;
                 }
             } else {
-                if (s.used_memory() as f64) < threshold * (s.available_memory() as f64) {
+                s.refresh_memory();
+                if (s.used_memory() as f64) < threshold * (s.total_memory() as f64) {
                     return;
                 }
             }
@@ -248,7 +249,11 @@ impl Query {
             None => {
                 let mut system = System::new();
                 system.refresh_memory();
-                let available_mem = system.available_memory();
+                let available_mem = if let Some(cgroup) = system.cgroup_limits() {
+                    cgroup.total_memory
+                } else {
+                    system.total_memory()
+                };
                 (available_mem as usize, 0.85)
             }
         };

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -53,7 +53,7 @@ use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 use std::task::{Context, Poll};
-use sysinfo::System;
+use sysinfo::{MemoryRefreshKind, RefreshKind, System};
 use tokio::runtime::Runtime;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::Instrument;
@@ -81,9 +81,6 @@ type BoxedBatchStream = SendableRecordBatchStream;
 /// Result type returned by query execution: either collected batches or a streaming adapter, plus field names.
 type QueryResult = Result<(Either<Vec<RecordBatch>, BoxedBatchStream>, Vec<String>), ExecuteError>;
 const DEFAULT_COUNTS_TOP_K: usize = 10;
-
-// pub static QUERY_SESSION: Lazy<SessionContext> =
-//     Lazy::new(|| Query::create_session_context(PARSEABLE.storage()));
 
 pub static QUERY_SESSION_STATE: Lazy<SessionState> =
     Lazy::new(|| Query::create_session_state(PARSEABLE.storage()));
@@ -147,10 +144,41 @@ impl InMemorySessionContext {
     }
 }
 
+async fn enough_available_memory() -> Result<(), ExecuteError> {
+    let mut s = System::new_with_specifics(
+        RefreshKind::nothing().with_memory(MemoryRefreshKind::everything()),
+    );
+    s.refresh_all();
+    let threshold = (PARSEABLE.options.query_mem_threshold / 100.0) as f64;
+
+    let f = async {
+        loop {
+            if let Some(cgroup) = s.cgroup_limits() {
+                if (cgroup.rss as f64) < threshold * (cgroup.total_memory as f64) {
+                    return;
+                }
+            } else {
+                if (s.used_memory() as f64) < threshold * (s.available_memory() as f64) {
+                    return;
+                }
+            }
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+    };
+    if let Err(e) = tokio::time::timeout(tokio::time::Duration::from_secs(10), f).await {
+        Err(ExecuteError::ServerBusy(e))
+    } else {
+        Ok(())
+    }
+}
+
 /// This function executes a query on the dedicated runtime, ensuring that the query is not isolated to a single thread/CPU
 /// at a time and has access to the entire thread pool, enabling better concurrent processing, and thus quicker results.
 pub async fn execute(query: Query, is_streaming: bool, tenant_id: &Option<String>) -> QueryResult {
     let id = tenant_id.clone();
+
+    // before executing query, check whether enough memory is available or not
+    enough_available_memory().await?;
     QUERY_RUNTIME
         .spawn(async move {
             tokio::time::timeout(
@@ -269,6 +297,8 @@ impl Query {
             .execution
             .parquet
             .schema_force_view_types = true;
+
+        config.options_mut().explain.show_statistics = true;
 
         SessionStateBuilder::new()
             .with_default_features()
@@ -958,6 +988,7 @@ pub fn flatten_objects_for_count(objects: Vec<Value>) -> Vec<Value> {
 
 pub mod error {
     use crate::{parseable::StreamNotFound, storage::ObjectStorageError};
+    use actix_web::http::{StatusCode, header::ContentType};
     use datafusion::error::DataFusionError;
     use tokio::time::error::Elapsed;
 
@@ -971,6 +1002,26 @@ pub mod error {
         StreamNotFound(#[from] StreamNotFound),
         #[error("{0}: {1}s")]
         Timeout(Elapsed, u64),
+        #[error("{0}: Not enough memory available to serve the request")]
+        ServerBusy(Elapsed),
+    }
+
+    impl actix_web::ResponseError for ExecuteError {
+        fn status_code(&self) -> StatusCode {
+            match self {
+                ExecuteError::ObjectStorage(_) => StatusCode::INTERNAL_SERVER_ERROR,
+                ExecuteError::Datafusion(_) => StatusCode::INTERNAL_SERVER_ERROR,
+                ExecuteError::StreamNotFound(_) => StatusCode::NOT_FOUND,
+                ExecuteError::Timeout(_, _) => StatusCode::REQUEST_TIMEOUT,
+                ExecuteError::ServerBusy(_) => StatusCode::SERVICE_UNAVAILABLE,
+            }
+        }
+
+        fn error_response(&self) -> actix_web::HttpResponse<actix_web::body::BoxBody> {
+            actix_web::HttpResponse::build(self.status_code())
+                .insert_header(ContentType::plaintext())
+                .body(self.to_string())
+        }
     }
 }
 


### PR DESCRIPTION
Incoming query will stay in queue till the server's memory is under a set threshold. The timeout is set to 10s, failing quickly is better than staying in limbo.

<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable query memory thresholds, including environment-based configuration.
  * Queries now wait for available memory before execution and return a busy response if resources remain unavailable.
  * Explain output now includes query statistics.

* **Bug Fixes**
  * Improved memory monitoring accuracy in containerized environments by using container limits and usage when available.
  * Execution errors now return their appropriate HTTP status codes.
  * Memory-related failures return `503 Service Unavailable` with a plain-text explanation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->