### PR TITLE
Expose ParseableSchemaProvider trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2619,6 +2619,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-proto"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a387aaef949dc16bb6abc81bd1af850ec7449183aef011214f9724957495738"
+dependencies = [
+ "arrow",
+ "chrono",
+ "datafusion-catalog",
+ "datafusion-catalog-listing",
+ "datafusion-common",
+ "datafusion-datasource",
+ "datafusion-datasource-arrow",
+ "datafusion-datasource-csv",
+ "datafusion-datasource-json",
+ "datafusion-datasource-parquet",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions-table",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-proto-common",
+ "object_store",
+ "prost 0.14.1",
+ "rand 0.9.4",
+]
+
+[[package]]
+name = "datafusion-proto-common"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e614c7c53a9c304c6a850b821010bb492e57300311835f1180613f9d2c63d9"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "prost 0.14.1",
+]
+
+[[package]]
 name = "datafusion-pruning"
 version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4565,6 +4604,7 @@ dependencies = [
  "crossterm",
  "dashmap",
  "datafusion",
+ "datafusion-proto",
  "derive_more 1.0.0",
  "erased-serde",
  "fs_extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ arrow-json = "58.0.0"
 arrow-schema = { version = "58.0.0", features = ["serde"] }
 arrow-select = "58.0.0"
 datafusion = "53.0.0"
+datafusion-proto = "53.0.0"
 object_store = { version = "0.13.1", features = [
     "cloud",
     "aws",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -437,6 +437,14 @@ pub struct Options {
     )]
     pub flight_port: u16,
 
+    #[arg(
+        long,
+        env = "P_QUERY_GRPC_PORT",
+        default_value = "8003",
+        help = "Port for query gRPC server"
+    )]
+    pub query_grpc_port: u16,
+
     // Performance settings
     #[arg(
         long,

--- a/src/handlers/airplane.rs
+++ b/src/handlers/airplane.rs
@@ -332,7 +332,9 @@ pub fn server() -> impl Future<Output = Result<(), Box<dyn std::error::Error + S
             };
 
             server
-                .max_frame_size(16 * 1024 * 1024 - 2)
+                .initial_stream_window_size(16 * 1024 * 1024)
+                .initial_connection_window_size(32 * 1024 * 1024)
+                .http2_adaptive_window(Some(true))
                 .accept_http1(true)
                 .layer(cors)
                 .layer(GrpcWebLayer::new())
@@ -341,7 +343,9 @@ pub fn server() -> impl Future<Output = Result<(), Box<dyn std::error::Error + S
                 .map_err(err_map_fn)
         }
         None => Server::builder()
-            .max_frame_size(16 * 1024 * 1024 - 2)
+            .initial_stream_window_size(16 * 1024 * 1024)
+            .initial_connection_window_size(32 * 1024 * 1024)
+            .http2_adaptive_window(Some(true))
             .accept_http1(true)
             .layer(cors)
             .layer(GrpcWebLayer::new())

--- a/src/handlers/airplane.rs
+++ b/src/handlers/airplane.rs
@@ -321,7 +321,10 @@ pub fn server() -> impl Future<Output = Result<(), Box<dyn std::error::Error + S
     let config = identity.map(|id| ServerTlsConfig::new().identity(id));
 
     // rust is treating closures as different types
-    let err_map_fn = |err| Box::new(err) as Box<dyn std::error::Error + Send>;
+    let err_map_fn = move |err| {
+        tracing::error!("Unable to start Flight Server on addr- {:?}", addr);
+        Box::new(err) as Box<dyn std::error::Error + Send>
+    };
 
     // match on config to decide if we want to use tls or not
     match config {

--- a/src/handlers/http/modal/mod.rs
+++ b/src/handlers/http/modal/mod.rs
@@ -278,6 +278,7 @@ pub struct NodeMetadata {
     pub token: String,
     pub node_id: String,
     pub flight_port: String,
+    pub query_grpc_port: String,
     pub node_type: NodeType,
 }
 
@@ -301,6 +302,7 @@ impl NodeMetadata {
         password: &str,
         node_id: String,
         flight_port: String,
+        query_grpc_port: String,
         node_type: NodeType,
     ) -> Self {
         let token = base64::prelude::BASE64_STANDARD.encode(format!("{username}:{password}"));
@@ -313,6 +315,7 @@ impl NodeMetadata {
             token: format!("Basic {token}"),
             node_id,
             flight_port,
+            query_grpc_port,
             node_type,
         }
     }
@@ -502,6 +505,7 @@ impl NodeMetadata {
             &options.password,
             get_node_id(),
             options.flight_port.to_string(),
+            options.query_grpc_port.to_string(),
             node_type,
         )
     }
@@ -696,6 +700,7 @@ mod test {
             "admin",
             "ingestor_id".to_owned(),
             "8002".to_string(),
+            "8003".to_string(),
             NodeType::Ingestor,
         );
 
@@ -728,6 +733,7 @@ mod test {
             "admin",
             "ingestor_id".to_owned(),
             "8002".to_string(),
+            "8003".to_string(),
             NodeType::Ingestor,
         );
 

--- a/src/handlers/http/modal/mod.rs
+++ b/src/handlers/http/modal/mod.rs
@@ -278,7 +278,7 @@ pub struct NodeMetadata {
     pub token: String,
     pub node_id: String,
     pub flight_port: String,
-    pub query_grpc_port: String,
+    pub query_grpc_port: Option<String>,
     pub node_type: NodeType,
 }
 
@@ -302,7 +302,7 @@ impl NodeMetadata {
         password: &str,
         node_id: String,
         flight_port: String,
-        query_grpc_port: String,
+        query_grpc_port: Option<String>,
         node_type: NodeType,
     ) -> Self {
         let token = base64::prelude::BASE64_STANDARD.encode(format!("{username}:{password}"));
@@ -489,12 +489,14 @@ impl NodeMetadata {
         }
 
         let query_grpc_port = options.query_grpc_port.to_string();
-        if meta.query_grpc_port != query_grpc_port {
+        if let Some(port) = meta.query_grpc_port.as_ref()
+            && *port != query_grpc_port
+        {
             info!(
                 "Query gRPC Port was Updated. Old: {} New: {}",
-                meta.query_grpc_port, query_grpc_port
+                port, query_grpc_port
             );
-            meta.query_grpc_port = query_grpc_port;
+            meta.query_grpc_port = Some(query_grpc_port);
         }
 
         meta.node_type = node_type;
@@ -518,7 +520,7 @@ impl NodeMetadata {
             &options.password,
             get_node_id(),
             options.flight_port.to_string(),
-            options.query_grpc_port.to_string(),
+            Some(options.query_grpc_port.to_string()),
             node_type,
         )
     }
@@ -716,7 +718,7 @@ mod test {
             "admin",
             "ingestor_id".to_owned(),
             "8002".to_string(),
-            "8003".to_string(),
+            Some("8003".to_string()),
             NodeType::Ingestor,
         );
 
@@ -749,7 +751,7 @@ mod test {
             "admin",
             "ingestor_id".to_owned(),
             "8002".to_string(),
-            "8003".to_string(),
+            Some("8003".to_string()),
             NodeType::Ingestor,
         );
 

--- a/src/handlers/http/modal/mod.rs
+++ b/src/handlers/http/modal/mod.rs
@@ -720,7 +720,7 @@ mod test {
             NodeType::Ingestor,
         );
 
-        let rhs = serde_json::from_slice::<IngestorMetadata>(br#"{"version":"v4","port":"8000","domain_name":"https://localhost:8000","bucket_name":"somebucket","token":"Basic YWRtaW46YWRtaW4=","node_id": "ingestor_id","flight_port": "8002","node_type":"ingestor"}"#).unwrap();
+        let rhs = serde_json::from_slice::<IngestorMetadata>(br#"{"version":"v4","port":"8000","domain_name":"https://localhost:8000","bucket_name":"somebucket","token":"Basic YWRtaW46YWRtaW4=","node_id": "ingestor_id","flight_port": "8002","query_grpc_port": "8003","node_type":"ingestor"}"#).unwrap();
 
         assert_eq!(rhs, lhs);
     }
@@ -734,7 +734,7 @@ mod test {
 
     #[rstest]
     fn test_from_bytes_preserves_existing_flight_port() {
-        let json = br#"{"version":"v3","port":"8000","domain_name":"https://localhost:8000","bucket_name":"somebucket","token":"Basic YWRtaW46YWRtaW4=","ingestor_id":"ingestor_id","flight_port":"9000"}"#;
+        let json = br#"{"version":"v3","port":"8000","domain_name":"https://localhost:8000","bucket_name":"somebucket","token":"Basic YWRtaW46YWRtaW4=","ingestor_id":"ingestor_id","flight_port":"9000","query_grpc_port": "8003"}"#;
         let meta = IngestorMetadata::from_bytes(json, 8002, 8003).unwrap();
         assert_eq!(meta.flight_port, "9000");
     }
@@ -754,7 +754,7 @@ mod test {
         );
 
         let lhs = Bytes::from(serde_json::to_vec(&im).unwrap());
-        let rhs = br#"{"version":"v4","port":"8000","domain_name":"https://localhost:8000","bucket_name":"somebucket","token":"Basic YWRtaW46YWRtaW4=","node_id":"ingestor_id","flight_port":"8002","node_type":"ingestor"}"#
+        let rhs = br#"{"version":"v4","port":"8000","domain_name":"https://localhost:8000","bucket_name":"somebucket","token":"Basic YWRtaW46YWRtaW4=","node_id":"ingestor_id","flight_port":"8002","query_grpc_port":"8003","node_type":"ingestor"}"#
                 .try_into_bytes()
                 .unwrap();
 

--- a/src/handlers/http/modal/mod.rs
+++ b/src/handlers/http/modal/mod.rs
@@ -488,16 +488,7 @@ impl NodeMetadata {
             meta.flight_port = flight_port;
         }
 
-        let query_grpc_port = options.query_grpc_port.to_string();
-        if let Some(port) = meta.query_grpc_port.as_ref()
-            && *port != query_grpc_port
-        {
-            info!(
-                "Query gRPC Port was Updated. Old: {} New: {}",
-                port, query_grpc_port
-            );
-            meta.query_grpc_port = Some(query_grpc_port);
-        }
+        meta.query_grpc_port = Some(options.query_grpc_port.to_string());
 
         meta.node_type = node_type;
     }

--- a/src/handlers/http/modal/mod.rs
+++ b/src/handlers/http/modal/mod.rs
@@ -388,8 +388,12 @@ impl NodeMetadata {
         let mut metadata = vec![];
         if let Ok(obs) = obs {
             for object in obs {
-                //convert to NodeMetadata
-                match serde_json::from_slice::<NodeMetadata>(&object) {
+                // convert to NodeMetadata
+                match Self::from_bytes(
+                    &object,
+                    PARSEABLE.options.flight_port,
+                    PARSEABLE.options.query_grpc_port,
+                ) {
                     Ok(node_metadata) => metadata.push(node_metadata),
                     Err(e) => error!("Failed to deserialize NodeMetadata: {:?}", e),
                 }
@@ -428,7 +432,7 @@ impl NodeMetadata {
             }
 
             let bytes = std::fs::read(&path).expect("File should be present");
-            match Self::from_bytes(&bytes, options.flight_port) {
+            match Self::from_bytes(&bytes, options.flight_port, options.query_grpc_port) {
                 Ok(meta) => return Some(meta),
                 Err(e) => {
                     error!("Failed to extract {} metadata: {}", node_type_str, e);
@@ -484,6 +488,15 @@ impl NodeMetadata {
             meta.flight_port = flight_port;
         }
 
+        let query_grpc_port = options.query_grpc_port.to_string();
+        if meta.query_grpc_port != query_grpc_port {
+            info!(
+                "Query gRPC Port was Updated. Old: {} New: {}",
+                meta.query_grpc_port, query_grpc_port
+            );
+            meta.query_grpc_port = query_grpc_port;
+        }
+
         meta.node_type = node_type;
     }
 
@@ -531,7 +544,7 @@ impl NodeMetadata {
     }
 
     /// Updates json with `flight_port` field if not already present
-    fn from_bytes(bytes: &[u8], flight_port: u16) -> anyhow::Result<Self> {
+    fn from_bytes(bytes: &[u8], flight_port: u16, query_grpc_port: u16) -> anyhow::Result<Self> {
         let mut json: Map<String, Value> = serde_json::from_slice(bytes)?;
 
         // Check version
@@ -570,6 +583,9 @@ impl NodeMetadata {
         // Add flight_port if missing
         json.entry("flight_port")
             .or_insert_with(|| Value::String(flight_port.to_string()));
+
+        json.entry("query_grpc_port")
+            .or_insert_with(|| Value::String(query_grpc_port.to_string()));
 
         // Parse the JSON to our struct
         let metadata: Self = serde_json::from_value(Value::Object(json))?;
@@ -712,14 +728,14 @@ mod test {
     #[rstest]
     fn test_from_bytes_adds_flight_port() {
         let json = br#"{"version":"v3","port":"8000","domain_name":"https://localhost:8000","bucket_name":"somebucket","token":"Basic YWRtaW46YWRtaW4=","ingestor_id":"ingestor_id"}"#;
-        let meta = IngestorMetadata::from_bytes(json, 8002).unwrap();
+        let meta = IngestorMetadata::from_bytes(json, 8002, 8003).unwrap();
         assert_eq!(meta.flight_port, "8002");
     }
 
     #[rstest]
     fn test_from_bytes_preserves_existing_flight_port() {
         let json = br#"{"version":"v3","port":"8000","domain_name":"https://localhost:8000","bucket_name":"somebucket","token":"Basic YWRtaW46YWRtaW4=","ingestor_id":"ingestor_id","flight_port":"9000"}"#;
-        let meta = IngestorMetadata::from_bytes(json, 8002).unwrap();
+        let meta = IngestorMetadata::from_bytes(json, 8002, 8003).unwrap();
         assert_eq!(meta.flight_port, "9000");
     }
 

--- a/src/handlers/livetail.rs
+++ b/src/handlers/livetail.rs
@@ -216,6 +216,9 @@ pub fn server() -> impl Future<Output = Result<(), Box<dyn std::error::Error + S
             };
 
             server
+                .initial_stream_window_size(16 * 1024 * 1024)
+                .initial_connection_window_size(32 * 1024 * 1024)
+                .http2_adaptive_window(Some(true))
                 .accept_http1(true)
                 .layer(cors)
                 .layer(GrpcWebLayer::new())
@@ -224,6 +227,9 @@ pub fn server() -> impl Future<Output = Result<(), Box<dyn std::error::Error + S
                 .map_err(err_map_fn)
         }
         None => Server::builder()
+            .initial_stream_window_size(16 * 1024 * 1024)
+            .initial_connection_window_size(32 * 1024 * 1024)
+            .http2_adaptive_window(Some(true))
             .accept_http1(true)
             .layer(cors)
             .layer(GrpcWebLayer::new())

--- a/src/hottier.rs
+++ b/src/hottier.rs
@@ -547,7 +547,7 @@ impl HotTierManager {
         }
     }
 
-    pub(crate) fn disk_path(&self, manifest_path: &str) -> object_store::Result<PathBuf> {
+    pub fn disk_path(&self, manifest_path: &str) -> object_store::Result<PathBuf> {
         hot_tier_disk_path(self.hot_tier_path, manifest_path)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ use once_cell::sync::Lazy;
 pub use openid;
 use parseable::PARSEABLE;
 use reqwest::{Client, ClientBuilder};
+pub use rustls;
 pub use utils as parseable_utils;
 pub use {clap, tracing_actix_web, tracing_opentelemetry, tracing_subscriber};
 pub use {opentelemetry, opentelemetry_otlp, opentelemetry_proto, opentelemetry_sdk};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,12 @@ pub mod validator;
 use std::time::Duration;
 
 // Public re-exports of crates being used in enterprise
+pub use arrow_array;
+pub use arrow_flight;
+pub use arrow_ipc;
+pub use catalog as parseable_catalog;
 pub use datafusion;
+pub use datafusion_proto;
 pub use handlers::http::modal::{
     ParseableServer, ingest_server::IngestServer, query_server::QueryServer, server::Server,
 };
@@ -68,6 +73,7 @@ use once_cell::sync::Lazy;
 pub use openid;
 use parseable::PARSEABLE;
 use reqwest::{Client, ClientBuilder};
+pub use utils as parseable_utils;
 pub use {clap, tracing_actix_web, tracing_opentelemetry, tracing_subscriber};
 pub use {opentelemetry, opentelemetry_otlp, opentelemetry_proto, opentelemetry_sdk};
 

--- a/src/metastore/metastores/object_store_metastore.rs
+++ b/src/metastore/metastores/object_store_metastore.rs
@@ -914,7 +914,6 @@ impl Metastore for ObjectStoreMetastore {
         tenant_id: &Option<String>,
         dates: &[String],
     ) -> Result<BTreeMap<String, Vec<Manifest>>, MetastoreError> {
-        let total_start = std::time::Instant::now();
         let inventory_limit = Arc::new(tokio::sync::Semaphore::new(16));
         let date_futures = dates.iter().map(|date| {
             let stream = stream_name.to_string();
@@ -1009,14 +1008,7 @@ impl Metastore for ObjectStoreMetastore {
                 result_file_list.insert(date, manifests);
             }
         }
-        info!(
-            stream = %stream_name,
-            tenant = ?tenant_id,
-            dates = dates.len(),
-            populated = result_file_list.len(),
-            total_ms = total_start.elapsed().as_millis() as u64,
-            "get_manifest_files_for_dates done"
-        );
+
         Ok(result_file_list)
     }
 
@@ -1044,18 +1036,6 @@ impl Metastore for ObjectStoreMetastore {
             Err(ObjectStorageError::NoSuchKey(_)) => Ok(None),
             Err(err) => Err(MetastoreError::ObjectStorageError(err)),
         }
-        // let path = partition_path(stream_name, lower_bound, upper_bound);
-        // // // need a 'ends with `manifest.json` condition here'
-        // // let obs = self
-        // //     .storage
-        // //     .get_objects(
-        // //         path,
-        // //         Box::new(|file_name| file_name.ends_with("manifest.json")),
-        // //     )
-        // //     .await?;
-        // warn!(partition_path=?path);
-        // let path = manifest_path(path.as_str());
-        // warn!(manifest_path=?path);
     }
 
     /// Get the path for a specific `Manifest` file

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -806,6 +806,9 @@ fn custom_metrics(registry: &Registry) {
         .register(Box::new(TOTAL_FILES_SCANNED_IN_QUERY_BY_DATE.clone()))
         .expect("metric can be registered");
     registry
+        .register(Box::new(TOTAL_FILES_SCANNED_IN_HOTTIER_BY_DATE.clone()))
+        .expect("metric can be registered");
+    registry
         .register(Box::new(TOTAL_BYTES_SCANNED_IN_QUERY_BY_DATE.clone()))
         .expect("metric can be registered");
     registry

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -353,6 +353,18 @@ pub static TOTAL_QUERY_CALLS_BY_DATE: Lazy<IntCounterVec> = Lazy::new(|| {
     .expect("metric can be created")
 });
 
+pub static TOTAL_FILES_SCANNED_IN_HOTTIER_BY_DATE: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "total_files_scanned_in_hottier_by_date",
+            "Total files scanned in hottier by date",
+        )
+        .namespace(METRICS_NAMESPACE),
+        &["stream", "date", "tenant_id"],
+    )
+    .expect("metric can be created")
+});
+
 pub static TOTAL_FILES_SCANNED_IN_QUERY_BY_DATE: Lazy<IntCounterVec> = Lazy::new(|| {
     IntCounterVec::new(
         Opts::new(
@@ -996,6 +1008,17 @@ pub fn increment_query_calls_by_date(date: &str, tenant_id: &str) {
 pub fn increment_files_scanned_in_query_by_date(count: u64, date: &str, tenant_id: &str) {
     TOTAL_FILES_SCANNED_IN_QUERY_BY_DATE
         .with_label_values(&[date, tenant_id])
+        .inc_by(count);
+}
+
+pub fn increment_files_scanned_in_hottier_by_date(
+    count: u64,
+    date: &str,
+    tenant_id: &str,
+    stream_name: &str,
+) {
+    TOTAL_FILES_SCANNED_IN_HOTTIER_BY_DATE
+        .with_label_values(&[stream_name, date, tenant_id])
         .inc_by(count);
 }
 

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -339,7 +339,6 @@ impl Query {
 
         config.options_mut().explain.show_statistics = true;
 
-        SessionStateBuilder::new()
         let mut builder = SessionStateBuilder::new()
             .with_default_features()
             .with_config(config)

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -25,6 +25,7 @@ use arrow_schema::SchemaRef;
 use chrono::NaiveDateTime;
 use chrono::{DateTime, Duration, Utc};
 use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::catalog::SchemaProvider;
 use datafusion::common::tree_node::Transformed;
 use datafusion::execution::disk_manager::DiskManager;
 use datafusion::execution::{
@@ -45,7 +46,7 @@ use datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
 use futures::Stream;
 use futures::StreamExt;
 use itertools::Itertools;
-use once_cell::sync::Lazy;
+use once_cell::sync::{Lazy, OnceCell};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::ops::Bound;
@@ -72,7 +73,7 @@ use crate::handlers::http::query::QueryError;
 use crate::metrics::increment_bytes_scanned_in_query_by_date;
 use crate::option::Mode;
 use crate::parseable::{DEFAULT_TENANT, PARSEABLE};
-use crate::storage::{ObjectStorageProvider, ObjectStoreFormat};
+use crate::storage::{ObjectStorage, ObjectStorageProvider, ObjectStoreFormat};
 use crate::utils::time::{DATE_BIN_EPOCH_ANCHOR, TimeRange, count_api_bin_interval};
 
 /// Boxed record-batch stream used as the streaming half of query results.
@@ -81,6 +82,14 @@ type BoxedBatchStream = SendableRecordBatchStream;
 /// Result type returned by query execution: either collected batches or a streaming adapter, plus field names.
 type QueryResult = Result<(Either<Vec<RecordBatch>, BoxedBatchStream>, Vec<String>), ExecuteError>;
 const DEFAULT_COUNTS_TOP_K: usize = 10;
+
+pub static SCHEMA_PROVIDER: OnceCell<Box<dyn ParseableSchemaProvider>> = OnceCell::new();
+
+/// Additional physical optimizer rules registered by enterprise/plugins.
+/// Must be populated BEFORE `QUERY_SESSION_STATE` is first accessed.
+pub static ADDITIONAL_PHYSICAL_OPTIMIZER_RULES: Lazy<
+    RwLock<Vec<Arc<dyn datafusion::physical_optimizer::PhysicalOptimizerRule + Send + Sync>>>,
+> = Lazy::new(|| RwLock::new(Vec::new()));
 
 pub static QUERY_SESSION_STATE: Lazy<SessionState> =
     Lazy::new(|| Query::create_session_state(PARSEABLE.storage()));
@@ -95,6 +104,15 @@ pub static QUERY_SESSION: Lazy<InMemorySessionContext> = Lazy::new(|| {
         session_context: Arc::new(RwLock::new(ctx)),
     }
 });
+
+/// Trait to enable implementation of SchemaProvider
+pub trait ParseableSchemaProvider: Send + Sync {
+    fn new_provider(
+        &self,
+        storage: Option<Arc<dyn ObjectStorage>>,
+        tenant_id: &Option<String>,
+    ) -> Box<dyn SchemaProvider>;
+}
 
 pub struct InMemorySessionContext {
     session_context: Arc<RwLock<SessionContext>>,
@@ -117,18 +135,23 @@ impl InMemorySessionContext {
     }
 
     pub fn add_schema(&self, tenant_id: &str) {
+        let schema_provider = if let Some(provider) = SCHEMA_PROVIDER.get() {
+            provider.new_provider(
+                Some(PARSEABLE.storage().get_object_store()),
+                &Some(tenant_id.to_owned()),
+            )
+        } else {
+            Box::new(GlobalSchemaProvider {
+                storage: PARSEABLE.storage().get_object_store(),
+                tenant_id: Some(tenant_id.to_owned()),
+            })
+        };
         self.session_context
             .write()
             .expect("SessionContext should be writeable")
             .catalog("datafusion")
             .expect("Default catalog should be available")
-            .register_schema(
-                tenant_id,
-                Arc::new(GlobalSchemaProvider {
-                    storage: PARSEABLE.storage().get_object_store(),
-                    tenant_id: Some(tenant_id.to_owned()),
-                }),
-            )
+            .register_schema(tenant_id, schema_provider.into())
             .expect("Should be able to register new schema");
     }
 
@@ -216,29 +239,40 @@ impl Query {
             // register multiple schemas
             if let Some(tenants) = PARSEABLE.list_tenants() {
                 for t in tenants.iter() {
-                    let schema_provider = Arc::new(GlobalSchemaProvider {
-                        storage: storage.get_object_store(),
-                        tenant_id: Some(t.clone()),
-                    });
-                    let _ = catalog.register_schema(t, schema_provider);
+                    let schema_provider = if let Some(provider) = SCHEMA_PROVIDER.get() {
+                        provider.new_provider(
+                            Some(PARSEABLE.storage().get_object_store()),
+                            &Some(t.to_owned()),
+                        )
+                    } else {
+                        Box::new(GlobalSchemaProvider {
+                            storage: PARSEABLE.storage().get_object_store(),
+                            tenant_id: Some(t.to_owned()),
+                        })
+                    };
+                    let _ = catalog.register_schema(t, schema_provider.into());
                 }
             }
         } else {
             // register just one schema
-            let schema_provider = Arc::new(GlobalSchemaProvider {
-                storage: storage.get_object_store(),
-                tenant_id: None,
-            });
+            let schema_provider = if let Some(provider) = SCHEMA_PROVIDER.get() {
+                provider.new_provider(Some(PARSEABLE.storage().get_object_store()), &None)
+            } else {
+                Box::new(GlobalSchemaProvider {
+                    storage: PARSEABLE.storage().get_object_store(),
+                    tenant_id: None,
+                })
+            };
             let _ = catalog.register_schema(
                 &state.config_options().catalog.default_schema,
-                schema_provider,
+                schema_provider.into(),
             );
         }
 
         SessionContext::new_with_state(state)
     }
 
-    fn create_session_state(storage: Arc<dyn ObjectStorageProvider>) -> SessionState {
+    pub fn create_session_state(storage: Arc<dyn ObjectStorageProvider>) -> SessionState {
         let runtime_config = storage
             .get_datafusion_runtime()
             .with_disk_manager_builder(DiskManager::builder())
@@ -306,10 +340,19 @@ impl Query {
         config.options_mut().explain.show_statistics = true;
 
         SessionStateBuilder::new()
+        let mut builder = SessionStateBuilder::new()
             .with_default_features()
             .with_config(config)
-            .with_runtime_env(runtime)
-            .build()
+            .with_runtime_env(runtime);
+
+        // Append any additional physical optimizer rules (e.g., enterprise partial agg pushdown)
+        if let Ok(rules) = ADDITIONAL_PHYSICAL_OPTIMIZER_RULES.read() {
+            for rule in rules.iter() {
+                builder = builder.with_physical_optimizer_rule(Arc::clone(rule));
+            }
+        }
+
+        builder.build()
     }
 
     /// this function returns the result of the query
@@ -324,8 +367,8 @@ impl Query {
         )
     )]
     pub async fn execute(&self, is_streaming: bool, tenant_id: &Option<String>) -> QueryResult {
-        let df = QUERY_SESSION
-            .get_ctx()
+        let ctx = QUERY_SESSION.get_ctx();
+        let df = ctx
             .execute_logical_plan(self.final_logical_plan(tenant_id))
             .await?;
         let tenant = tenant_id.as_deref().unwrap_or(DEFAULT_TENANT);
@@ -341,14 +384,10 @@ impl Query {
             return Ok((Either::Left(vec![]), fields));
         }
 
-        let plan = QUERY_SESSION
-            .get_ctx()
-            .state()
-            .create_physical_plan(df.logical_plan())
-            .await?;
+        let plan = ctx.state().create_physical_plan(df.logical_plan()).await?;
 
         let results = if !is_streaming {
-            let task_ctx = QUERY_SESSION.get_ctx().task_ctx();
+            let task_ctx = ctx.task_ctx();
 
             let batches = collect_partitioned(plan.clone(), task_ctx.clone())
                 .await?
@@ -364,7 +403,7 @@ impl Query {
 
             Either::Left(batches)
         } else {
-            let task_ctx = QUERY_SESSION.get_ctx().task_ctx();
+            let task_ctx = ctx.task_ctx();
 
             let output_partitions = plan.output_partitioning().partition_count();
 

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -413,7 +413,7 @@ impl Query {
             });
 
             let partition_streams = execute_stream_partitioned(plan.clone(), task_ctx.clone())?;
-
+            tracing::warn!(num_partition_streams=partition_streams.len());
             let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<
                 Result<RecordBatch, datafusion::error::DataFusionError>,
             >();

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -114,6 +114,17 @@ pub trait ParseableSchemaProvider: Send + Sync {
     ) -> Box<dyn SchemaProvider>;
 }
 
+fn get_schema_provider(tenant_id: &Option<String>) -> Box<dyn SchemaProvider> {
+    if let Some(provider) = SCHEMA_PROVIDER.get() {
+        provider.new_provider(Some(PARSEABLE.storage().get_object_store()), tenant_id)
+    } else {
+        Box::new(GlobalSchemaProvider {
+            storage: PARSEABLE.storage().get_object_store(),
+            tenant_id: tenant_id.to_owned(),
+        })
+    }
+}
+
 pub struct InMemorySessionContext {
     session_context: Arc<RwLock<SessionContext>>,
 }
@@ -135,17 +146,7 @@ impl InMemorySessionContext {
     }
 
     pub fn add_schema(&self, tenant_id: &str) {
-        let schema_provider = if let Some(provider) = SCHEMA_PROVIDER.get() {
-            provider.new_provider(
-                Some(PARSEABLE.storage().get_object_store()),
-                &Some(tenant_id.to_owned()),
-            )
-        } else {
-            Box::new(GlobalSchemaProvider {
-                storage: PARSEABLE.storage().get_object_store(),
-                tenant_id: Some(tenant_id.to_owned()),
-            })
-        };
+        let schema_provider = get_schema_provider(&Some(tenant_id.to_owned()));
         self.session_context
             .write()
             .expect("SessionContext should be writeable")
@@ -239,30 +240,13 @@ impl Query {
             // register multiple schemas
             if let Some(tenants) = PARSEABLE.list_tenants() {
                 for t in tenants.iter() {
-                    let schema_provider = if let Some(provider) = SCHEMA_PROVIDER.get() {
-                        provider.new_provider(
-                            Some(PARSEABLE.storage().get_object_store()),
-                            &Some(t.to_owned()),
-                        )
-                    } else {
-                        Box::new(GlobalSchemaProvider {
-                            storage: PARSEABLE.storage().get_object_store(),
-                            tenant_id: Some(t.to_owned()),
-                        })
-                    };
+                    let schema_provider = get_schema_provider(&Some(t.to_owned()));
                     let _ = catalog.register_schema(t, schema_provider.into());
                 }
             }
         } else {
             // register just one schema
-            let schema_provider = if let Some(provider) = SCHEMA_PROVIDER.get() {
-                provider.new_provider(Some(PARSEABLE.storage().get_object_store()), &None)
-            } else {
-                Box::new(GlobalSchemaProvider {
-                    storage: PARSEABLE.storage().get_object_store(),
-                    tenant_id: None,
-                })
-            };
+            let schema_provider = get_schema_provider(&None);
             let _ = catalog.register_schema(
                 &state.config_options().catalog.default_schema,
                 schema_provider.into(),
@@ -412,7 +396,7 @@ impl Query {
             });
 
             let partition_streams = execute_stream_partitioned(plan.clone(), task_ctx.clone())?;
-            tracing::warn!(num_partition_streams=partition_streams.len());
+
             let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<
                 Result<RecordBatch, datafusion::error::DataFusionError>,
             >();

--- a/src/query/stream_schema_provider.rs
+++ b/src/query/stream_schema_provider.rs
@@ -132,12 +132,34 @@ pub fn build_parquet_scan_components(
     filters: &[Expr],
     state: &dyn Session,
 ) -> Result<(ParquetFormat, ParquetSource), DataFusionError> {
+    build_parquet_scan_components_with_filters(schema, exact_source_filters(filters), state)
+}
+
+/// Build Parquet scan components with every filter attached to the source.
+///
+/// Use this only when the caller still retains DataFusion's filter above the
+/// scan (for example, filters reported as `Inexact` by a table provider). The
+/// source predicate is then an additional, safe pruning/pushdown opportunity,
+/// while the retained filter remains responsible for exact query semantics.
+pub fn build_parquet_scan_components_with_full_filters(
+    schema: SchemaRef,
+    filters: &[Expr],
+    state: &dyn Session,
+) -> Result<(ParquetFormat, ParquetSource), DataFusionError> {
+    build_parquet_scan_components_with_filters(schema, filters.to_vec(), state)
+}
+
+fn build_parquet_scan_components_with_filters(
+    schema: SchemaRef,
+    source_filters: Vec<Expr>,
+    state: &dyn Session,
+) -> Result<(ParquetFormat, ParquetSource), DataFusionError> {
     let parquet_options = state.default_table_options().parquet;
     let file_format = ParquetFormat::default().with_options(parquet_options.clone());
     let mut file_source =
         ParquetSource::new(schema.clone()).with_table_parquet_options(parquet_options);
 
-    if let Some(expr) = conjunction(exact_source_filters(filters)) {
+    if let Some(expr) = conjunction(source_filters) {
         let table_df_schema = schema.as_ref().clone().to_dfschema()?;
         let predicate = create_physical_expr(&expr, &table_df_schema, state.execution_props())?;
         file_source = file_source.with_predicate(predicate);
@@ -1185,7 +1207,8 @@ mod tests {
 
     use super::{
         PartialTimeFilter, balanced_file_groups, build_parquet_scan_components,
-        exact_source_filters, extract_timestamp_bound, is_overlapping_query,
+        build_parquet_scan_components_with_full_filters, exact_source_filters,
+        extract_timestamp_bound, is_overlapping_query,
     };
 
     fn file(path: &str, size: u64) -> File {
@@ -1325,6 +1348,37 @@ mod tests {
         assert!(predicate.contains("p_timestamp"));
         assert!(!predicate.contains("job"));
         assert!(!predicate.contains("api"));
+    }
+
+    #[test]
+    fn full_filters_are_preinstalled_in_parquet_source_when_requested() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "p_timestamp",
+                DataType::Timestamp(arrow_schema::TimeUnit::Millisecond, None),
+                false,
+            ),
+            Field::new("job", DataType::Utf8, false),
+        ]));
+        let filters = vec![
+            Expr::Column("p_timestamp".into()).gt_eq(Expr::Literal(
+                ScalarValue::TimestampMillisecond(Some(1_672_531_200_000), None),
+                None,
+            )),
+            Expr::Column("job".into()).eq(Expr::Literal(
+                ScalarValue::Utf8(Some("api".to_owned())),
+                None,
+            )),
+        ];
+
+        let context = SessionContext::new();
+        let state = context.state();
+        let (_, source) = build_parquet_scan_components_with_full_filters(schema, &filters, &state)
+            .expect("components build");
+        let predicate = source.filter().expect("full predicate").to_string();
+        assert!(predicate.contains("p_timestamp"));
+        assert!(predicate.contains("job"));
+        assert!(predicate.contains("api"));
     }
 
     #[tokio::test]

--- a/src/query/stream_schema_provider.rs
+++ b/src/query/stream_schema_provider.rs
@@ -63,7 +63,10 @@ use crate::{
     },
     event::DEFAULT_TIMESTAMP_KEY,
     hottier::{GLOBAL_HOTTIER, HotTierManager},
-    metrics::{QUERY_CACHE_HIT, increment_files_scanned_in_query_by_date},
+    metrics::{
+        QUERY_CACHE_HIT, increment_files_scanned_in_hottier_by_date,
+        increment_files_scanned_in_query_by_date,
+    },
     option::Mode,
     parseable::{DEFAULT_TENANT, PARSEABLE, STREAM_EXISTS},
     storage::{ObjectStorage, ObjectStoreFormat},
@@ -246,6 +249,13 @@ impl StandardTableProvider {
             .await
             .map_err(|err| DataFusionError::External(Box::new(err)))?;
 
+        increment_files_scanned_in_hottier_by_date(
+            hot_tier_files.len() as u64,
+            &chrono::Utc::now().date_naive().to_string(),
+            self.tenant_id.as_deref().unwrap_or(DEFAULT_TENANT),
+            &self.stream,
+        );
+
         let hot_tier_files: Vec<File> = hot_tier_files
             .into_iter()
             .map(|mut file| {
@@ -406,103 +416,116 @@ impl StandardTableProvider {
         target_partitions: usize,
         _is_hot_tier: bool,
     ) -> (Vec<Vec<PartitionedFile>>, datafusion::common::Statistics) {
-        let file_groups = balanced_file_groups(manifest_files, target_partitions);
-        let mut partitioned_files = Vec::with_capacity(file_groups.len());
-        let mut column_statistics = HashMap::<String, Option<TypedStatistics>>::new();
-        let mut count = 0;
-        let mut file_count = 0u64;
-        for group in file_groups {
-            let mut partition = Vec::with_capacity(group.len());
-            for file in group {
-                #[allow(unused_mut)]
-                let File {
-                    mut file_path,
-                    num_rows,
-                    columns,
-                    file_size,
-                    ..
-                } = file;
-
-                // Track billing metrics for files scanned in query
-                file_count += 1;
-
-                // object_store::path::Path doesn't automatically deal with Windows path separators
-                // to do that, we are using from_absolute_path() which takes into consideration the underlying filesystem
-                // before sending the file path to PartitionedFile
-                // the github issue- https://github.com/parseablehq/parseable/issues/824
-                // For some reason, the `from_absolute_path()` doesn't work for macos, hence the ugly solution
-                // TODO: figure out an elegant solution to this
-                #[cfg(windows)]
-                {
-                    if !_is_hot_tier && PARSEABLE.storage.name() == "drive" {
-                        file_path = object_store::path::Path::from_absolute_path(file_path)
-                            .unwrap()
-                            .to_string();
-                    }
-                }
-                let pf = PartitionedFile::new(file_path, file_size);
-                partition.push(pf);
-
-                columns.into_iter().for_each(|col| {
-                    column_statistics
-                        .entry(col.name)
-                        .and_modify(|x| {
-                            if let Some((stats, col_stats)) =
-                                x.as_ref().cloned().zip(col.stats.clone())
-                            {
-                                // update() returns None on type mismatch (e.g. column
-                                // historically written as both Utf8 and Timestamp(ms)).
-                                // Dropping to None here makes the planner skip min/max
-                                // pushdown for this column instead of crashing the worker.
-                                *x = stats.update(col_stats);
-                            }
-                        })
-                        .or_insert_with(|| col.stats.as_ref().cloned());
-                });
-                count += num_rows;
-            }
-            partitioned_files.push(partition);
-        }
-        let statistics = self
-            .schema
-            .fields()
-            .iter()
-            .map(|field| {
-                column_statistics
-                    .get(field.name())
-                    .and_then(|stats| stats.as_ref())
-                    .and_then(|stats| stats.clone().min_max_as_scalar(field.data_type()))
-                    .map(|(min, max)| datafusion::common::ColumnStatistics {
-                        null_count: Precision::Absent,
-                        max_value: Precision::Exact(max),
-                        min_value: Precision::Exact(min),
-                        distinct_count: Precision::Absent,
-                        sum_value: Precision::Absent,
-                        byte_size: Precision::Absent,
-                    })
-                    .unwrap_or_default()
-            })
-            .collect();
-
-        let statistics = datafusion::common::Statistics {
-            num_rows: Precision::Exact(count as usize),
-            total_byte_size: Precision::Absent,
-            column_statistics: statistics,
-        };
-
-        // Track billing metrics for query scan
-        let current_date = chrono::Utc::now().date_naive().to_string();
-        increment_files_scanned_in_query_by_date(
-            file_count,
-            &current_date,
-            self.tenant_id.as_deref().unwrap_or(DEFAULT_TENANT),
-        );
-
-        (partitioned_files, statistics)
+        partitioned_files(
+            &self.schema,
+            &self.tenant_id,
+            manifest_files,
+            target_partitions,
+        )
     }
 }
 
-async fn collect_from_snapshot(
+#[inline(always)]
+pub fn partitioned_files(
+    schema: &SchemaRef,
+    tenant_id: &Option<String>,
+    manifest_files: Vec<File>,
+    target_partitions: usize,
+) -> (Vec<Vec<PartitionedFile>>, datafusion::common::Statistics) {
+    let file_groups = balanced_file_groups(manifest_files, target_partitions);
+    let mut partitioned_files = Vec::with_capacity(file_groups.len());
+    let mut column_statistics = HashMap::<String, Option<TypedStatistics>>::new();
+    let mut count = 0;
+    let mut file_count = 0u64;
+    for group in file_groups {
+        let mut partition = Vec::with_capacity(group.len());
+        for file in group {
+            #[allow(unused_mut)]
+            let File {
+                mut file_path,
+                num_rows,
+                columns,
+                file_size,
+                ..
+            } = file;
+
+            // Track billing metrics for files scanned in query
+            file_count += 1;
+
+            // object_store::path::Path doesn't automatically deal with Windows path separators
+            // to do that, we are using from_absolute_path() which takes into consideration the underlying filesystem
+            // before sending the file path to PartitionedFile
+            // the github issue- https://github.com/parseablehq/parseable/issues/824
+            // For some reason, the `from_absolute_path()` doesn't work for macos, hence the ugly solution
+            // TODO: figure out an elegant solution to this
+            #[cfg(windows)]
+            {
+                if !_is_hot_tier && PARSEABLE.storage.name() == "drive" {
+                    file_path = object_store::path::Path::from_absolute_path(file_path)
+                        .unwrap()
+                        .to_string();
+                }
+            }
+            let pf = PartitionedFile::new(file_path, file_size);
+            partition.push(pf);
+
+            columns.into_iter().for_each(|col| {
+                column_statistics
+                    .entry(col.name)
+                    .and_modify(|x| {
+                        if let Some((stats, col_stats)) = x.as_ref().cloned().zip(col.stats.clone())
+                        {
+                            // update() returns None on type mismatch (e.g. column
+                            // historically written as both Utf8 and Timestamp(ms)).
+                            // Dropping to None here makes the planner skip min/max
+                            // pushdown for this column instead of crashing the worker.
+                            *x = stats.update(col_stats);
+                        }
+                    })
+                    .or_insert_with(|| col.stats.as_ref().cloned());
+            });
+            count += num_rows;
+        }
+        partitioned_files.push(partition);
+    }
+    let statistics = schema
+        .fields()
+        .iter()
+        .map(|field| {
+            column_statistics
+                .get(field.name())
+                .and_then(|stats| stats.as_ref())
+                .and_then(|stats| stats.clone().min_max_as_scalar(field.data_type()))
+                .map(|(min, max)| datafusion::common::ColumnStatistics {
+                    null_count: Precision::Absent,
+                    max_value: Precision::Exact(max),
+                    min_value: Precision::Exact(min),
+                    distinct_count: Precision::Absent,
+                    sum_value: Precision::Absent,
+                    byte_size: Precision::Absent,
+                })
+                .unwrap_or_default()
+        })
+        .collect();
+
+    let statistics = datafusion::common::Statistics {
+        num_rows: Precision::Exact(count as usize),
+        total_byte_size: Precision::Absent,
+        column_statistics: statistics,
+    };
+
+    // Track billing metrics for query scan
+    let current_date = chrono::Utc::now().date_naive().to_string();
+    increment_files_scanned_in_query_by_date(
+        file_count,
+        &current_date,
+        tenant_id.as_deref().unwrap_or(DEFAULT_TENANT),
+    );
+
+    (partitioned_files, statistics)
+}
+
+pub async fn collect_from_snapshot(
     snapshot: &Snapshot,
     time_filters: &[PartialTimeFilter],
     filters: &[Expr],
@@ -777,7 +800,8 @@ impl TableProvider for StandardTableProvider {
     }
 }
 
-fn reversed_mem_table(
+#[inline(always)]
+pub fn reversed_mem_table(
     mut records: Vec<RecordBatch>,
     schema: Arc<Schema>,
 ) -> Result<MemTable, DataFusionError> {
@@ -796,7 +820,7 @@ pub enum PartialTimeFilter {
 }
 
 impl PartialTimeFilter {
-    fn try_from_expr(expr: &Expr, time_partition: &Option<String>) -> Option<Self> {
+    pub fn try_from_expr(expr: &Expr, time_partition: &Option<String>) -> Option<Self> {
         let Expr::BinaryExpr(binexpr) = expr else {
             return None;
         };
@@ -957,7 +981,7 @@ pub fn is_within_staging_window(time_filters: &[PartialTimeFilter]) -> bool {
     !has_upper_bound
 }
 
-fn expr_in_boundary(filter: &Expr) -> bool {
+pub fn expr_in_boundary(filter: &Expr) -> bool {
     let Expr::BinaryExpr(binexpr) = filter else {
         return false;
     };
@@ -975,7 +999,7 @@ fn expr_in_boundary(filter: &Expr) -> bool {
         )
 }
 
-fn extract_timestamp_bound(
+pub fn extract_timestamp_bound(
     binexpr: &BinaryExpr,
     time_partition: &Option<String>,
 ) -> Option<(Operator, NaiveDateTime)> {

--- a/src/query/stream_schema_provider.rs
+++ b/src/query/stream_schema_provider.rs
@@ -443,6 +443,7 @@ impl StandardTableProvider {
             &self.tenant_id,
             manifest_files,
             target_partitions,
+            _is_hot_tier,
         )
     }
 }
@@ -453,6 +454,7 @@ pub fn partitioned_files(
     tenant_id: &Option<String>,
     manifest_files: Vec<File>,
     target_partitions: usize,
+    _is_hot_tier: bool,
 ) -> (Vec<Vec<PartitionedFile>>, datafusion::common::Statistics) {
     let file_groups = balanced_file_groups(manifest_files, target_partitions);
     let mut partitioned_files = Vec::with_capacity(file_groups.len());

--- a/src/query/stream_schema_provider.rs
+++ b/src/query/stream_schema_provider.rs
@@ -119,7 +119,7 @@ struct StandardTableProvider {
     tenant_id: Option<String>,
 }
 
-fn exact_source_filters(filters: &[Expr]) -> Vec<Expr> {
+pub fn exact_source_filters(filters: &[Expr]) -> Vec<Expr> {
     filters
         .iter()
         .filter(|filter| expr_in_boundary(filter))
@@ -127,7 +127,7 @@ fn exact_source_filters(filters: &[Expr]) -> Vec<Expr> {
         .collect()
 }
 
-fn build_parquet_scan_components(
+pub fn build_parquet_scan_components(
     schema: SchemaRef,
     filters: &[Expr],
     state: &dyn Session,
@@ -146,7 +146,7 @@ fn build_parquet_scan_components(
     Ok((file_format, file_source))
 }
 
-fn balanced_file_groups(manifest_files: Vec<File>, target_partitions: usize) -> Vec<Vec<File>> {
+pub fn balanced_file_groups(manifest_files: Vec<File>, target_partitions: usize) -> Vec<Vec<File>> {
     let group_count = target_partitions.min(manifest_files.len());
     if group_count == 0 {
         return Vec::new();

--- a/src/storage/metrics_layer.rs
+++ b/src/storage/metrics_layer.rs
@@ -18,6 +18,7 @@
 
 use std::{
     ops::Range,
+    sync::atomic::{AtomicU64, Ordering},
     task::{Context, Poll},
     time,
 };
@@ -35,6 +36,162 @@ use crate::metrics::{
     STORAGE_READ_BYTES_TOTAL, STORAGE_READ_RANGES_TOTAL, STORAGE_REQUEST_RESPONSE_TIME,
     STORAGE_REQUESTS_INFLIGHT,
 };
+
+const READ_METHODS: [&str; 2] = ["GET", "GET_RANGES"];
+const STORAGE_STATUSES: [&str; 9] = [
+    "200", "304", "400", "401", "404", "409", "412", "500", "501",
+];
+
+/// Map the configured storage provider name to the label used by MetricLayer.
+pub fn storage_metrics_provider_label(provider_name: &str) -> Option<&'static str> {
+    match provider_name {
+        "gcs" => Some("gcs"),
+        "s3" => Some("s3"),
+        "blob-store" | "azure_blob" => Some("azure_blob"),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+struct StorageMetricSnapshot {
+    read_bytes: u64,
+    read_ranges: u64,
+    get_requests: u64,
+    get_ranges_requests: u64,
+    response_time_sum_seconds: f64,
+    response_time_count: u64,
+    non_2xx_requests: u64,
+    inflight: u64,
+}
+
+fn read_inflight(provider: &str) -> u64 {
+    READ_METHODS
+        .iter()
+        .map(|method| {
+            STORAGE_REQUESTS_INFLIGHT
+                .with_label_values(&[provider, method])
+                .get()
+                .max(0) as u64
+        })
+        .sum()
+}
+
+impl StorageMetricSnapshot {
+    fn capture(provider: &str) -> Self {
+        let mut snapshot = Self {
+            read_bytes: STORAGE_READ_BYTES_TOTAL
+                .with_label_values(&[provider])
+                .get(),
+            read_ranges: STORAGE_READ_RANGES_TOTAL
+                .with_label_values(&[provider])
+                .get(),
+            inflight: read_inflight(provider),
+            ..Self::default()
+        };
+        for method in READ_METHODS {
+            for status in STORAGE_STATUSES {
+                let histogram =
+                    STORAGE_REQUEST_RESPONSE_TIME.with_label_values(&[provider, method, status]);
+                let count = histogram.get_sample_count();
+                match method {
+                    "GET" => snapshot.get_requests += count,
+                    "GET_RANGES" => snapshot.get_ranges_requests += count,
+                    _ => unreachable!(),
+                }
+                snapshot.response_time_count += count;
+                snapshot.response_time_sum_seconds += histogram.get_sample_sum();
+                if !status.starts_with('2') {
+                    snapshot.non_2xx_requests += count;
+                }
+            }
+        }
+        snapshot
+    }
+
+    fn delta_to(&self, end: &Self, peak_inflight_sampled: u64) -> StorageMetricDelta {
+        StorageMetricDelta {
+            read_bytes: end.read_bytes.saturating_sub(self.read_bytes),
+            read_ranges: end.read_ranges.saturating_sub(self.read_ranges),
+            get_requests: end.get_requests.saturating_sub(self.get_requests),
+            get_ranges_requests: end
+                .get_ranges_requests
+                .saturating_sub(self.get_ranges_requests),
+            response_time_sum_seconds: (end.response_time_sum_seconds
+                - self.response_time_sum_seconds)
+                .max(0.0),
+            response_time_count: end
+                .response_time_count
+                .saturating_sub(self.response_time_count),
+            non_2xx_requests: end.non_2xx_requests.saturating_sub(self.non_2xx_requests),
+            peak_inflight_sampled,
+        }
+    }
+}
+
+/// Process-global storage metric deltas observed during a branch wall-clock
+/// window. Concurrent process activity is intentionally included.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct StorageMetricDelta {
+    pub read_bytes: u64,
+    pub read_ranges: u64,
+    pub get_requests: u64,
+    pub get_ranges_requests: u64,
+    pub response_time_sum_seconds: f64,
+    pub response_time_count: u64,
+    pub non_2xx_requests: u64,
+    pub peak_inflight_sampled: u64,
+}
+
+impl StorageMetricDelta {
+    pub fn response_time_average_ms(&self) -> f64 {
+        if self.response_time_count == 0 {
+            0.0
+        } else {
+            self.response_time_sum_seconds * 1000.0 / self.response_time_count as f64
+        }
+    }
+}
+
+/// Snapshot window over process-global storage metrics. `observe_peak` is
+/// intended for a low-frequency sampler; it does not instrument requests.
+#[derive(Debug)]
+pub struct StorageMetricWindow {
+    provider: String,
+    start: StorageMetricSnapshot,
+    peak_inflight_sampled: AtomicU64,
+}
+
+impl StorageMetricWindow {
+    pub fn start(provider: &str) -> Self {
+        let start = StorageMetricSnapshot::capture(provider);
+        Self {
+            provider: provider.to_string(),
+            peak_inflight_sampled: AtomicU64::new(start.inflight),
+            start,
+        }
+    }
+
+    pub fn provider(&self) -> &str {
+        &self.provider
+    }
+
+    pub fn observe_peak(&self) {
+        self.record_inflight(read_inflight(&self.provider));
+    }
+
+    fn record_inflight(&self, inflight: u64) {
+        self.peak_inflight_sampled
+            .fetch_max(inflight, Ordering::Relaxed);
+    }
+
+    pub fn delta(&self) -> StorageMetricDelta {
+        self.observe_peak();
+        self.start.delta_to(
+            &StorageMetricSnapshot::capture(&self.provider),
+            self.peak_inflight_sampled.load(Ordering::Relaxed),
+        )
+    }
+}
 
 /// RAII guard that increments the in-flight gauge on construction and
 /// decrements on drop. Handles early returns, panics, and dropped futures.
@@ -377,13 +534,23 @@ impl<T> Stream for StreamMetricWrapper<'_, T> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use object_store::{
         Attribute, Attributes, ObjectStore, ObjectStoreExt, PutPayload, memory::InMemory,
         path::Path,
     };
 
-    use super::MetricLayer;
-    use crate::metrics::{STORAGE_READ_BYTES_TOTAL, STORAGE_READ_RANGES_TOTAL};
+    use super::{MetricLayer, StorageMetricSnapshot, StorageMetricWindow};
+    use crate::metrics::{
+        STORAGE_READ_BYTES_TOTAL, STORAGE_READ_RANGES_TOTAL, STORAGE_REQUEST_RESPONSE_TIME,
+        STORAGE_REQUESTS_INFLIGHT,
+    };
+
+    // Process-global Prometheus vectors make snapshot-window tests inherently
+    // process-global. Tests touching them must hold this lock even when unique
+    // labels also isolate them from unrelated metric tests.
+    static PROCESS_GLOBAL_METRIC_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[tokio::test]
     async fn requested_read_bytes_and_ranges_are_counted_without_path_labels() {
@@ -421,6 +588,115 @@ mod tests {
                 - ranges_before,
             2
         );
+    }
+
+    #[test]
+    fn process_window_metric_delta_arithmetic_is_saturating_and_derives_average() {
+        let start = StorageMetricSnapshot {
+            read_bytes: 100,
+            read_ranges: 10,
+            get_requests: 4,
+            get_ranges_requests: 2,
+            response_time_sum_seconds: 1.0,
+            response_time_count: 6,
+            non_2xx_requests: 1,
+            inflight: 3,
+        };
+        let end = StorageMetricSnapshot {
+            read_bytes: 350,
+            read_ranges: 18,
+            get_requests: 9,
+            get_ranges_requests: 5,
+            response_time_sum_seconds: 2.6,
+            response_time_count: 14,
+            non_2xx_requests: 3,
+            inflight: 1,
+        };
+        let delta = start.delta_to(&end, 17);
+        assert_eq!(delta.read_bytes, 250);
+        assert_eq!(delta.read_ranges, 8);
+        assert_eq!(delta.get_requests, 5);
+        assert_eq!(delta.get_ranges_requests, 3);
+        assert_eq!(delta.response_time_count, 8);
+        assert!((delta.response_time_sum_seconds - 1.6).abs() < f64::EPSILON);
+        assert!((delta.response_time_average_ms() - 200.0).abs() < f64::EPSILON);
+        assert_eq!(delta.non_2xx_requests, 2);
+        assert_eq!(delta.peak_inflight_sampled, 17);
+
+        let reset = end.delta_to(&start, 1);
+        assert_eq!(reset.read_bytes, 0);
+        assert_eq!(reset.response_time_count, 0);
+        assert_eq!(reset.response_time_sum_seconds, 0.0);
+    }
+
+    #[test]
+    fn process_window_captures_metric_vectors_and_non_2xx() {
+        let _serial = PROCESS_GLOBAL_METRIC_TEST_LOCK.lock().unwrap();
+        // A unique provider label isolates this serialized process-global test
+        // from production labels such as `gcs`.
+        let provider = "process-window-metrics-test";
+        let window = StorageMetricWindow::start(provider);
+        STORAGE_READ_BYTES_TOTAL
+            .with_label_values(&[provider])
+            .inc_by(1_024);
+        STORAGE_READ_RANGES_TOTAL
+            .with_label_values(&[provider])
+            .inc_by(5);
+        STORAGE_REQUEST_RESPONSE_TIME
+            .with_label_values(&[provider, "GET", "200"])
+            .observe(0.1);
+        STORAGE_REQUEST_RESPONSE_TIME
+            .with_label_values(&[provider, "GET", "500"])
+            .observe(0.3);
+        STORAGE_REQUEST_RESPONSE_TIME
+            .with_label_values(&[provider, "GET_RANGES", "200"])
+            .observe(0.2);
+        let inflight = STORAGE_REQUESTS_INFLIGHT.with_label_values(&[provider, "GET"]);
+        inflight.add(7);
+        window.observe_peak();
+        inflight.sub(7);
+
+        let delta = window.delta();
+        assert_eq!(delta.read_bytes, 1_024);
+        assert_eq!(delta.read_ranges, 5);
+        assert_eq!(delta.get_requests, 2);
+        assert_eq!(delta.get_ranges_requests, 1);
+        assert_eq!(delta.response_time_count, 3);
+        assert!((delta.response_time_sum_seconds - 0.6).abs() < 1e-12);
+        assert!((delta.response_time_average_ms() - 200.0).abs() < 1e-9);
+        assert_eq!(delta.non_2xx_requests, 1);
+        assert_eq!(delta.peak_inflight_sampled, 7);
+    }
+
+    #[test]
+    fn process_window_peak_tracking_is_monotonic() {
+        let _serial = PROCESS_GLOBAL_METRIC_TEST_LOCK.lock().unwrap();
+        // This unit test updates only the window-local peak atomic, but it uses
+        // the same serialization rule as all StorageMetricWindow tests.
+        let window = StorageMetricWindow {
+            provider: "peak-unit-test".to_string(),
+            start: StorageMetricSnapshot::default(),
+            peak_inflight_sampled: 2.into(),
+        };
+        window.record_inflight(7);
+        window.record_inflight(4);
+        window.record_inflight(11);
+        assert_eq!(
+            window
+                .peak_inflight_sampled
+                .load(std::sync::atomic::Ordering::Relaxed),
+            11
+        );
+    }
+
+    #[test]
+    fn storage_provider_names_map_to_metric_layer_labels() {
+        assert_eq!(super::storage_metrics_provider_label("gcs"), Some("gcs"));
+        assert_eq!(
+            super::storage_metrics_provider_label("blob-store"),
+            Some("azure_blob")
+        );
+        assert_eq!(super::storage_metrics_provider_label("drive"), None);
     }
 
     #[test]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -46,6 +46,7 @@ mod localfs;
 #[cfg(test)]
 pub(crate) use localfs::LocalFS;
 mod metrics_layer;
+pub use metrics_layer::{StorageMetricDelta, StorageMetricWindow, storage_metrics_provider_label};
 pub mod object_storage;
 pub mod retention;
 mod s3;

--- a/src/utils/arrow/flight.rs
+++ b/src/utils/arrow/flight.rs
@@ -143,6 +143,31 @@ fn lit_timestamp_milli(time: i64) -> Expr {
     Expr::Literal(ScalarValue::TimestampMillisecond(Some(time), None), None)
 }
 
+/// Streaming variant of into_flight_data. Converts a DataFusion record batch
+/// stream directly into Flight data without materializing all batches in memory.
+pub fn into_flight_data_stream(
+    stream: datafusion::execution::SendableRecordBatchStream,
+) -> Result<Response<DoGetStream>, Box<Status>> {
+    let record_stream = stream.map_err(|e| {
+        arrow_flight::error::FlightError::Arrow(arrow_schema::ArrowError::ExternalError(Box::new(
+            e,
+        )))
+    });
+
+    let write_options = IpcWriteOptions::default()
+        .try_with_compression(Some(arrow_ipc::CompressionType(1)))
+        .map_err(|err| Status::failed_precondition(err.to_string()))?;
+
+    let flight_data_stream = FlightDataEncoderBuilder::new()
+        .with_max_flight_data_size(usize::MAX)
+        .with_options(write_options)
+        .build(record_stream);
+
+    let flight_data_stream = flight_data_stream.map_err(|err| Status::unknown(err.to_string()));
+
+    Ok(Response::new(Box::pin(flight_data_stream) as DoGetStream))
+}
+
 pub fn into_flight_data(records: Vec<RecordBatch>) -> Result<Response<DoGetStream>, Box<Status>> {
     let input_stream = futures::stream::iter(records.into_iter().map(Ok));
     let write_options = IpcWriteOptions::default()

--- a/src/utils/arrow/flight.rs
+++ b/src/utils/arrow/flight.rs
@@ -152,7 +152,6 @@ fn lit_timestamp_milli(time: i64) -> Expr {
 pub fn into_flight_data_stream(
     stream: datafusion::execution::SendableRecordBatchStream,
 ) -> Result<Response<DoGetStream>, Box<Status>> {
-    tracing::warn!("Streaming flight data");
     let record_stream = stream.map_err(|e| {
         arrow_flight::error::FlightError::Arrow(arrow_schema::ArrowError::ExternalError(Box::new(
             e,
@@ -174,7 +173,6 @@ pub fn into_flight_data_stream(
 }
 
 pub fn into_flight_data(records: Vec<RecordBatch>) -> Result<Response<DoGetStream>, Box<Status>> {
-    tracing::warn!("Non-Streaming flight data");
     let input_stream = futures::stream::iter(records.into_iter().map(Ok));
     let write_options = IpcWriteOptions::default()
         .try_with_compression(Some(arrow_ipc::CompressionType(1)))

--- a/src/utils/arrow/flight.rs
+++ b/src/utils/arrow/flight.rs
@@ -63,6 +63,10 @@ pub async fn run_do_get_rpc(
         .parse::<Uri>()
         .map_err(|_| Status::failed_precondition("Ingester metadata is courupted"))?;
     let channel = Channel::builder(url)
+        .initial_stream_window_size(16 * 1024 * 1024)
+        .initial_connection_window_size(32 * 1024 * 1024)
+        .http2_adaptive_window(true)
+        .tcp_nodelay(true)
         .connect()
         .await
         .map_err(|err| Status::failed_precondition(err.to_string()))?;
@@ -148,6 +152,7 @@ fn lit_timestamp_milli(time: i64) -> Expr {
 pub fn into_flight_data_stream(
     stream: datafusion::execution::SendableRecordBatchStream,
 ) -> Result<Response<DoGetStream>, Box<Status>> {
+    tracing::warn!("Streaming flight data");
     let record_stream = stream.map_err(|e| {
         arrow_flight::error::FlightError::Arrow(arrow_schema::ArrowError::ExternalError(Box::new(
             e,
@@ -159,7 +164,7 @@ pub fn into_flight_data_stream(
         .map_err(|err| Status::failed_precondition(err.to_string()))?;
 
     let flight_data_stream = FlightDataEncoderBuilder::new()
-        .with_max_flight_data_size(usize::MAX)
+        .with_max_flight_data_size(4 * 1024 * 1024)
         .with_options(write_options)
         .build(record_stream);
 
@@ -169,13 +174,14 @@ pub fn into_flight_data_stream(
 }
 
 pub fn into_flight_data(records: Vec<RecordBatch>) -> Result<Response<DoGetStream>, Box<Status>> {
+    tracing::warn!("Non-Streaming flight data");
     let input_stream = futures::stream::iter(records.into_iter().map(Ok));
     let write_options = IpcWriteOptions::default()
         .try_with_compression(Some(arrow_ipc::CompressionType(1)))
         .map_err(|err| Status::failed_precondition(err.to_string()))?;
 
     let flight_data_stream = FlightDataEncoderBuilder::new()
-        .with_max_flight_data_size(usize::MAX)
+        .with_max_flight_data_size(4 * 1024 * 1024)
         .with_options(write_options)
         // .with_schema(schema.into())
         .build(input_stream);


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

- Enables registering new `SchemaProviders`
- Adds a new env arg- `P_QUERY_GRPC_PORT`

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable query gRPC port via CLI and `P_QUERY_GRPC_PORT` (default: 8003).
  - Added hot-tier file scan and storage performance metrics.
- **Performance**
  - Improved gRPC and HTTP/2 throughput with adaptive flow control and tuned connection windows.
  - Limited Arrow Flight frames to 4 MiB for more stable large-query streaming.
- **Compatibility**
  - Metadata now carries an optional query gRPC port, with existing metadata automatically backfilled during migration and refresh.
- **Reliability**
  - Improved schema-provider handling and platform-specific file path support.
  - Improved streaming stability for large query results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->