### PR TITLE
chore: add env flag for quest

### DIFF
--- a/docker-compose-distributed-test.yaml
+++ b/docker-compose-distributed-test.yaml
@@ -106,6 +106,8 @@ services:
     platform: linux/amd64
     image: quay.io/parseablehq/quest:main
     pull_policy: always
+    environment:
+      - QUEST_EDITION=oss
     command:
       [
         "load",

--- a/docker-compose-distributed-test.yaml
+++ b/docker-compose-distributed-test.yaml
@@ -28,7 +28,7 @@ services:
   parseable-query:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.debug
     platform: linux/amd64
     command: [ "parseable", "s3-store" ]
     ports:
@@ -65,7 +65,7 @@ services:
   parseable-ingest-one:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.debug
     platform: linux/amd64
     command: [ "parseable", "s3-store", ]
     ports:

--- a/docker-compose-distributed-test.yaml
+++ b/docker-compose-distributed-test.yaml
@@ -28,7 +28,7 @@ services:
   parseable-query:
     build:
       context: .
-      dockerfile: Dockerfile.debug
+      dockerfile: Dockerfile
     platform: linux/amd64
     command: [ "parseable", "s3-store" ]
     ports:
@@ -65,7 +65,7 @@ services:
   parseable-ingest-one:
     build:
       context: .
-      dockerfile: Dockerfile.debug
+      dockerfile: Dockerfile
     platform: linux/amd64
     command: [ "parseable", "s3-store", ]
     ports:

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -27,7 +27,7 @@ services:
   parseable:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.debug
     platform: linux/amd64
     command: [ "parseable", "s3-store", ]
     ports:

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -64,6 +64,8 @@ services:
     image: quay.io/parseablehq/quest:main
     platform: linux/amd64
     pull_policy: always
+    environment:
+      - QUEST_EDITION=oss
     command: [
       "load",
       "http://parseable:8000",

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -27,7 +27,7 @@ services:
   parseable:
     build:
       context: .
-      dockerfile: Dockerfile.debug
+      dockerfile: Dockerfile
     platform: linux/amd64
     command: [ "parseable", "s3-store", ]
     ports:


### PR DESCRIPTION
### Changes

- added new `oss` env flag for quest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated standard and distributed test environments to build Parseable services with the debug container configuration.
  - Explicitly configured Quest to run with the open-source edition in both test setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->