### PR TITLE
fix: incorrect env var for base64 signature

### DIFF
--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -706,8 +706,8 @@ fn get_enterprise_base_prompts() -> Vec<EnvPrompt> {
             is_secret: false,
         },
         EnvPrompt {
-            env_var: "P_LICENSE_SIGNATURE_BASE64_FILE_PATH",
-            display_name: "License Signature Base64 File Path (priority)",
+            env_var: "P_LICENSE_SIGNATURE_BASE64",
+            display_name: "License Signature Base64 (priority)",
             required: false,
             is_secret: false,
         },


### PR DESCRIPTION
current env prompt - P_LICENSE_SIGNATURE_BASE64_FILE_PATH -- incorrect server never expects base64 file path

update to P_LICENSE_SIGNATURE_BASE64



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated enterprise setup to prompt for the license signature value directly.
  * Revised the displayed label for this setup prompt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->