### PR TITLE
fix: make staging recovery crash-safe and refresh query schemas

### DIFF
--- a/src/handlers/http/query.rs
+++ b/src/handlers/http/query.rs
@@ -559,9 +559,6 @@ pub async fn create_streams_for_distributed(
     streams: Vec<String>,
     tenant_id: &Option<String>,
 ) -> Result<(), QueryError> {
-    if PARSEABLE.options.mode != Mode::Query && PARSEABLE.options.mode != Mode::Prism {
-        return Ok(());
-    }
     let mut join_set = JoinSet::new();
     for stream_name in streams {
         let id = tenant_id.to_owned();

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -180,19 +180,6 @@ pub static STAGING_FILES: Lazy<IntGaugeVec> = Lazy::new(|| {
     .expect("metric can be created")
 });
 
-/// Number of staging artifacts quarantined after validation failures.
-pub static STAGING_QUARANTINED_FILES: Lazy<IntCounterVec> = Lazy::new(|| {
-    IntCounterVec::new(
-        Opts::new(
-            "staging_quarantined_files",
-            "Staging files quarantined after validation or conversion failures",
-        )
-        .namespace(METRICS_NAMESPACE),
-        &["stream", "tenant_id"],
-    )
-    .expect("metric can be created")
-});
-
 pub static PROCESS_CPU_USAGE_PERCENT_AVG: Lazy<Gauge> = Lazy::new(|| {
     Gauge::with_opts(
         Opts::new(
@@ -783,9 +770,6 @@ fn custom_metrics(registry: &Registry) {
         .expect("metric can be registered");
     registry
         .register(Box::new(STAGING_FILES.clone()))
-        .expect("metric can be registered");
-    registry
-        .register(Box::new(STAGING_QUARANTINED_FILES.clone()))
         .expect("metric can be registered");
     registry
         .register(Box::new(PROCESS_CPU_USAGE_PERCENT_AVG.clone()))

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -180,6 +180,19 @@ pub static STAGING_FILES: Lazy<IntGaugeVec> = Lazy::new(|| {
     .expect("metric can be created")
 });
 
+/// Number of staging artifacts quarantined after validation failures.
+pub static STAGING_QUARANTINED_FILES: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "staging_quarantined_files",
+            "Staging files quarantined after validation or conversion failures",
+        )
+        .namespace(METRICS_NAMESPACE),
+        &["stream", "tenant_id"],
+    )
+    .expect("metric can be created")
+});
+
 pub static PROCESS_CPU_USAGE_PERCENT_AVG: Lazy<Gauge> = Lazy::new(|| {
     Gauge::with_opts(
         Opts::new(
@@ -770,6 +783,9 @@ fn custom_metrics(registry: &Registry) {
         .expect("metric can be registered");
     registry
         .register(Box::new(STAGING_FILES.clone()))
+        .expect("metric can be registered");
+    registry
+        .register(Box::new(STAGING_QUARANTINED_FILES.clone()))
         .expect("metric can be registered");
     registry
         .register(Box::new(PROCESS_CPU_USAGE_PERCENT_AVG.clone()))

--- a/src/parseable/mod.rs
+++ b/src/parseable/mod.rs
@@ -89,8 +89,14 @@ mod streams;
 /// File extension for arrow files in staging
 const ARROW_FILE_EXTENSION: &str = "arrows";
 
-/// File extension for incomplete arrow files
+/// Final extension segment for temporary staging files.
 const PART_FILE_EXTENSION: &str = "part";
+
+/// Filename suffix for incomplete Arrow IPC files.
+const ARROW_PART_FILE_SUFFIX: &str = ".arrows.part";
+
+/// Filename suffix for incomplete Parquet files.
+const PARQUET_PART_FILE_SUFFIX: &str = ".parquet.part";
 
 /// Name of a Stream
 /// NOTE: this used to be a struct, flattened out for simplicity

--- a/src/parseable/staging/reader.rs
+++ b/src/parseable/staging/reader.rs
@@ -26,8 +26,8 @@ use std::{
 };
 
 use arrow_array::{RecordBatch, TimestampMillisecondArray};
-use arrow_ipc::{MessageHeader, reader::StreamReader, root_as_message_unchecked};
-use arrow_schema::Schema;
+use arrow_ipc::{MessageHeader, reader::StreamReader, root_as_message};
+use arrow_schema::{ArrowError, Schema};
 use byteorder::{LittleEndian, ReadBytesExt};
 use itertools::kmerge_by;
 use tracing::{error, info_span};
@@ -40,12 +40,16 @@ use crate::{
 #[derive(Debug)]
 pub struct MergedReverseRecordReader {
     pub readers: Vec<StreamReader<BufReader<OffsetReader<File>>>>,
+    pub readable_files: Vec<PathBuf>,
+    pub invalid_files: Vec<PathBuf>,
 }
 
 impl MergedReverseRecordReader {
     pub fn try_new(file_paths: &[PathBuf]) -> Self {
         let _span = info_span!("open_arrow_files", file_count = file_paths.len()).entered();
         let mut readers = Vec::with_capacity(file_paths.len());
+        let mut readable_files = Vec::with_capacity(file_paths.len());
+        let mut invalid_files = Vec::new();
         for path in file_paths {
             match File::open(path) {
                 Err(err) => {
@@ -57,30 +61,47 @@ impl MergedReverseRecordReader {
                         Ok(r) => r,
                         Err(err) => {
                             error!("Invalid file detected, ignoring it: {path:?}; error = {err}");
+                            invalid_files.push(path.clone());
                             continue;
                         }
                     };
                     readers.push(reader);
+                    readable_files.push(path.clone());
                 }
             }
         }
 
-        Self { readers }
+        Self {
+            readers,
+            readable_files,
+            invalid_files,
+        }
     }
 
     pub fn merged_iter(
         self,
         schema: Arc<Schema>,
         time_partition: Option<String>,
-    ) -> impl Iterator<Item = RecordBatch> {
-        let adapted_readers = self.readers.into_iter().map(|reader| reader.flatten());
-        kmerge_by(adapted_readers, move |a: &RecordBatch, b: &RecordBatch| {
-            let a_time = get_timestamp_millis(a, time_partition.as_deref());
-            let b_time = get_timestamp_millis(b, time_partition.as_deref());
-            a_time > b_time
-        })
-        .map(|batch| reverse(&batch))
-        .map(move |batch| adapt_batch(&schema, &batch))
+    ) -> impl Iterator<Item = Result<RecordBatch, ArrowError>> {
+        let adapted_readers = self.readers;
+        kmerge_by(
+            adapted_readers,
+            move |a: &Result<RecordBatch, ArrowError>, b: &Result<RecordBatch, ArrowError>| {
+                match (a, b) {
+                    (Ok(a), Ok(b)) => {
+                        let a_time = get_timestamp_millis(a, time_partition.as_deref());
+                        let b_time = get_timestamp_millis(b, time_partition.as_deref());
+                        a_time > b_time
+                    }
+                    // Surface decoding errors through the iterator instead of silently
+                    // dropping them with Iterator::flatten.
+                    (Err(_), _) => true,
+                    (_, Err(_)) => false,
+                }
+            },
+        )
+        .map(|batch| batch.map(|batch| reverse(&batch)))
+        .map(move |batch| batch.map(|batch| adapt_batch(&schema, &batch)))
     }
 
     pub fn merged_schema(&self) -> Schema {
@@ -214,18 +235,54 @@ impl<R: Read + Seek> Read for OffsetReader<R> {
 pub fn get_reverse_reader<T: Read + Seek>(
     mut reader: T,
 ) -> Result<StreamReader<BufReader<OffsetReader<T>>>, io::Error> {
-    let mut offset = 0;
+    let file_len = reader.seek(SeekFrom::End(0))?;
+    reader.rewind()?;
+
+    let mut offset: usize = 0;
     let mut messages = Vec::new();
 
-    while let Some(res) = find_limit_and_type(&mut reader).transpose() {
-        match res {
-            Ok((header, size)) => {
+    loop {
+        match find_limit_and_type(&mut reader) {
+            Ok(Some((header, size))) => {
+                let next_offset = offset.checked_add(size).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "Arrow message size overflow")
+                })?;
+
+                // Seeking beyond EOF succeeds for regular files. Check the declared
+                // message boundary explicitly so a crash-truncated record batch is
+                // never handed to StreamReader as if it were complete.
+                if next_offset as u64 > file_len {
+                    break;
+                }
                 messages.push((header, offset, size));
-                offset += size;
+                offset = next_offset;
             }
-            Err(err) if err.kind() == io::ErrorKind::UnexpectedEof && !messages.is_empty() => break,
+            Ok(None) => break,
+            Err(err) if err.kind() == io::ErrorKind::UnexpectedEof && !messages.is_empty() => {
+                break;
+            }
             Err(err) => return Err(err),
         }
+    }
+
+    if messages
+        .first()
+        .is_none_or(|(header, _, _)| *header != MessageHeader::Schema)
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Arrow stream has no complete schema message",
+        ));
+    }
+
+    if !messages
+        .iter()
+        .any(|(header, _, _)| *header == MessageHeader::RecordBatch)
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Arrow stream has no complete record batch",
+        ));
     }
 
     // reverse everything leaving the first because it has schema message.
@@ -272,14 +329,27 @@ fn find_limit_and_type(
     reader.read_exact(&mut message)?;
     size += metadata_size;
 
-    let message = unsafe { root_as_message_unchecked(&message) };
+    let message = root_as_message(&message).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Invalid Arrow IPC message: {err}"),
+        )
+    })?;
     let header = message.header_type();
-    let message_size = message.bodyLength();
-    size += message_size as usize;
+    let message_size = usize::try_from(message.bodyLength())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "Invalid Arrow IPC body length"))?;
+    size = size
+        .checked_add(message_size)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "Arrow message size overflow"))?;
 
     let padding = (8 - (size % 8)) % 8;
-    reader.seek(SeekFrom::Current(padding as i64 + message_size))?;
-    size += padding;
+    let seek_by = message_size
+        .checked_add(padding)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "Arrow message size overflow"))?;
+    reader.seek(SeekFrom::Current(seek_by as i64))?;
+    size = size
+        .checked_add(padding)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "Arrow message size overflow"))?;
 
     Ok(Some((header, size)))
 }
@@ -296,9 +366,12 @@ mod tests {
         Array, Float64Array, Int32Array, Int64Array, RecordBatch, StringArray, cast::AsArray,
         types::Int64Type,
     };
-    use arrow_ipc::writer::{
-        DictionaryTracker, IpcDataGenerator, IpcWriteContext, IpcWriteOptions, StreamWriter,
-        write_message,
+    use arrow_ipc::{
+        MessageHeader,
+        writer::{
+            DictionaryTracker, IpcDataGenerator, IpcWriteContext, IpcWriteOptions, StreamWriter,
+            write_message,
+        },
     };
     use arrow_schema::{DataType, Field, Schema};
     use chrono::Utc;
@@ -313,7 +386,7 @@ mod tests {
         utils::time::TimeRange,
     };
 
-    use super::get_reverse_reader;
+    use super::{find_limit_and_type, get_reverse_reader};
 
     fn rb(rows: usize) -> RecordBatch {
         let array1: Arc<dyn Array> = Arc::new(Int64Array::from_iter(0..(rows as i64)));
@@ -339,6 +412,54 @@ mod tests {
         }
 
         writer.into_inner().unwrap()
+    }
+
+    fn truncate_last_record_batch(bytes: &mut Vec<u8>) {
+        let mut cursor = Cursor::new(bytes.as_slice());
+        let mut offset = 0usize;
+        let mut last_record_batch = None;
+        while let Some((header, size)) = find_limit_and_type(&mut cursor).unwrap() {
+            if header == MessageHeader::RecordBatch {
+                last_record_batch = Some((offset, size));
+            }
+            offset += size;
+        }
+
+        let (offset, size) = last_record_batch.expect("record batch message");
+        bytes.truncate(offset + size / 2);
+    }
+
+    #[test]
+    fn reverse_reader_recovers_complete_batches_before_truncated_tail() {
+        let mut bytes = write_mem(&[rb(2), rb(3)]);
+        truncate_last_record_batch(&mut bytes);
+
+        let reader = get_reverse_reader(Cursor::new(bytes)).unwrap();
+        let batches = reader.collect::<Result<Vec<_>, _>>().unwrap();
+
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].num_rows(), 2);
+    }
+
+    #[test]
+    fn reverse_reader_rejects_stream_without_complete_batch() {
+        let mut bytes = write_mem(&[rb(2)]);
+        truncate_last_record_batch(&mut bytes);
+
+        let err = get_reverse_reader(Cursor::new(bytes)).unwrap_err();
+        assert!(err.to_string().contains("no complete record batch"));
+    }
+
+    #[test]
+    fn reverse_reader_accepts_complete_batches_without_eos() {
+        let mut bytes = write_mem(&[rb(2)]);
+        bytes.truncate(bytes.len() - 8);
+
+        let reader = get_reverse_reader(Cursor::new(bytes)).unwrap();
+        let batches = reader.collect::<Result<Vec<_>, _>>().unwrap();
+
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].num_rows(), 2);
     }
 
     #[test]
@@ -524,7 +645,10 @@ mod tests {
         // But first message should be schema, so we'll still read them in order
 
         // Read batch 3
-        let batch = reader.next().expect("Failed to read batch");
+        let batch = reader
+            .next()
+            .expect("Failed to read batch")
+            .expect("Invalid batch");
         assert_eq!(batch.num_rows(), 2);
         let id_array = batch
             .column(0)
@@ -535,7 +659,10 @@ mod tests {
         assert_eq!(id_array.value(1), 30);
 
         // Read batch 2
-        let batch = reader.next().expect("Failed to read batch");
+        let batch = reader
+            .next()
+            .expect("Failed to read batch")
+            .expect("Invalid batch");
         assert_eq!(batch.num_rows(), 2);
         let id_array = batch
             .column(0)
@@ -546,7 +673,10 @@ mod tests {
         assert_eq!(id_array.value(1), 20);
 
         // Read batch 1
-        let batch = reader.next().expect("Failed to read batch");
+        let batch = reader
+            .next()
+            .expect("Failed to read batch")
+            .expect("Invalid batch");
         assert_eq!(batch.num_rows(), 2);
         let id_array = batch
             .column(0)
@@ -623,7 +753,10 @@ mod tests {
             MergedReverseRecordReader::try_new(&[file_path.into()]).merged_iter(schema, None);
 
         // Should get the batch
-        let result_batch = reader.next().expect("Failed to read batch");
+        let result_batch = reader
+            .next()
+            .expect("Failed to read batch")
+            .expect("Invalid batch");
         let id_array = result_batch
             .column(0)
             .as_any()

--- a/src/parseable/staging/reader.rs
+++ b/src/parseable/staging/reader.rs
@@ -38,6 +38,7 @@ use crate::{
 };
 
 #[derive(Debug)]
+/// Merges reverse readers while retaining the source-file validation result.
 pub struct MergedReverseRecordReader {
     pub readers: Vec<StreamReader<BufReader<OffsetReader<File>>>>,
     pub readable_files: Vec<PathBuf>,
@@ -45,6 +46,7 @@ pub struct MergedReverseRecordReader {
 }
 
 impl MergedReverseRecordReader {
+    /// Opens valid Arrow files and separates files that fail structural validation.
     pub fn try_new(file_paths: &[PathBuf]) -> Self {
         let _span = info_span!("open_arrow_files", file_count = file_paths.len()).entered();
         let mut readers = Vec::with_capacity(file_paths.len());
@@ -78,6 +80,7 @@ impl MergedReverseRecordReader {
         }
     }
 
+    /// Merges all readers in reverse timestamp order and adapts each batch to `schema`.
     pub fn merged_iter(
         self,
         schema: Arc<Schema>,
@@ -104,6 +107,7 @@ impl MergedReverseRecordReader {
         .map(move |batch| batch.map(|batch| adapt_batch(&schema, &batch)))
     }
 
+    /// Returns the union of schemas exposed by all readable Arrow streams.
     pub fn merged_schema(&self) -> Schema {
         Schema::try_merge(
             self.readers
@@ -232,6 +236,7 @@ impl<R: Read + Seek> Read for OffsetReader<R> {
     }
 }
 
+/// Builds a reverse Arrow stream reader from complete IPC messages.
 pub fn get_reverse_reader<T: Read + Seek>(
     mut reader: T,
 ) -> Result<StreamReader<BufReader<OffsetReader<T>>>, io::Error> {
@@ -303,7 +308,7 @@ pub fn get_reverse_reader<T: Read + Seek>(
     })
 }
 
-// return limit for
+/// Returns the IPC message type and its padded byte length.
 fn find_limit_and_type(
     reader: &mut (impl Read + Seek),
 ) -> Result<Option<(MessageHeader, usize)>, io::Error> {

--- a/src/parseable/staging/writer.rs
+++ b/src/parseable/staging/writer.rs
@@ -312,6 +312,10 @@ impl DiskWriter {
     pub fn write(&mut self, rb: &RecordBatch) -> Result<usize, StagingError> {
         self.size += rb.size();
         self.inner.write(rb).map_err(StagingError::Arrow)?;
+        // A process crash does not run Drop, so do not leave the tail of an
+        // acknowledged record batch only in BufWriter's userspace buffer.
+        // The EOS marker can be recovered, but missing batch bytes cannot.
+        self.inner.flush().map_err(StagingError::Arrow)?;
         Ok(self.size)
     }
 }
@@ -449,5 +453,44 @@ impl<const N: usize> MutableBuffer<N> {
             self.inner.push(rb.clone());
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs::File, sync::Arc};
+
+    use arrow_array::{Int32Array, RecordBatch};
+    use arrow_ipc::reader::StreamReader;
+    use arrow_schema::{DataType, Field, Schema};
+    use chrono::Utc;
+    use temp_dir::TempDir;
+
+    use crate::{OBJECT_STORE_DATA_GRANULARITY, utils::time::TimeRange};
+
+    use super::DiskWriter;
+
+    #[test]
+    fn disk_writer_flushes_each_complete_batch_before_drop() {
+        let dir = TempDir::new().unwrap();
+        let path = dir
+            .path()
+            .join("schema.date=2026-09-08.hour=11.minute=27.test.data.arrows");
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+        let range = TimeRange::granularity_range(Utc::now(), OBJECT_STORE_DATA_GRANULARITY);
+        let mut writer = DiskWriter::try_new(path, &schema, range).unwrap();
+
+        writer.write(&batch).unwrap();
+
+        // Simulate what another process sees before Drop writes the EOS marker.
+        let file = File::open(&writer.path).unwrap();
+        let mut reader = StreamReader::try_new(file, None).unwrap();
+        let persisted = reader.next().unwrap().unwrap();
+        assert_eq!(persisted.num_rows(), 3);
     }
 }

--- a/src/parseable/staging/writer.rs
+++ b/src/parseable/staging/writer.rs
@@ -146,10 +146,9 @@ impl DiskWriter {
         // a rudimentary way to ensure one parquet per arrow file
         if *ONE_PARQUET_PER_ARROW {
             path.set_extension(Ulid::new().to_string());
-            path.add_extension(PART_FILE_EXTENSION);
-        } else {
-            path.set_extension(PART_FILE_EXTENSION);
+            path.add_extension(ARROW_FILE_EXTENSION);
         }
+        path.add_extension(PART_FILE_EXTENSION);
 
         let file = OpenOptions::new()
             .write(true)
@@ -192,9 +191,8 @@ impl Drop for DiskWriter {
             return;
         }
 
-        let mut arrow_path = self.path.to_owned();
-
-        arrow_path.set_extension(ARROW_FILE_EXTENSION);
+        // `.arrows.part` becomes `.arrows` while preserving a per-file ULID.
+        let mut arrow_path = self.path.with_extension("");
         // If file exists, append a random string before .date to avoid overwriting
         if arrow_path.exists() {
             let file_name = arrow_path.file_name().unwrap().to_string_lossy();
@@ -344,6 +342,7 @@ mod tests {
         .unwrap();
         let range = TimeRange::granularity_range(Utc::now(), OBJECT_STORE_DATA_GRANULARITY);
         let mut writer = DiskWriter::try_new(path, &schema, range).unwrap();
+        assert!(writer.path.to_string_lossy().ends_with(".arrows.part"));
 
         writer.write(&batch).unwrap();
 

--- a/src/parseable/staging/writer.rs
+++ b/src/parseable/staging/writer.rs
@@ -89,6 +89,7 @@ impl Default for Writer {
 }
 
 impl Writer {
+    /// Appends a batch to the writer for its schema/minute file.
     #[cfg_attr(feature = "hotpath", hotpath::measure)]
     pub fn push_disk(
         &mut self,
@@ -111,6 +112,7 @@ impl Writer {
         }
     }
 
+    /// Detaches completed disk writers, or all writers when `forced` is true.
     pub fn take_flushable_disk(&mut self, forced: bool) -> HashMap<String, DiskWriter> {
         let mut flushable_disk = HashMap::new();
         let old_disk = std::mem::take(&mut self.disk);
@@ -165,6 +167,7 @@ impl DiskWriter {
         Ok(Self { inner, path, range })
     }
 
+    /// Returns whether this writer belongs to the current time range.
     pub fn is_current(&self) -> bool {
         self.range.contains(Utc::now())
     }

--- a/src/parseable/staging/writer.rs
+++ b/src/parseable/staging/writer.rs
@@ -32,8 +32,7 @@ use arrow_ipc::{
 };
 use arrow_schema::Schema;
 use arrow_select::concat::concat_batches;
-use chrono::{TimeDelta, Utc};
-use datafusion::physical_plan::buffer::SizedMessage;
+use chrono::Utc;
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use rand::distributions::{Alphanumeric, DistString};
@@ -46,28 +45,6 @@ use crate::{
 };
 
 use super::StagingError;
-
-const DISK_WRITE_BATCH_MAX_AGE_SECS_VAR: &str = "DISK_WRITE_BATCH_MAX_AGE_SECS";
-static DISK_WRITE_BATCH_MAX_AGE_SECS: Lazy<i64> = Lazy::new(|| {
-    if let Ok(var) = std::env::var(DISK_WRITE_BATCH_MAX_AGE_SECS_VAR)
-        && let Ok(var) = var.parse::<i64>()
-    {
-        var
-    } else {
-        1
-    }
-});
-
-const ARROW_FLUSH_SIZE_LIMIT_VAR: &str = "ARROW_FLUSH_SIZE_LIMIT";
-static ARROW_FLUSH_SIZE_LIMIT: Lazy<usize> = Lazy::new(|| {
-    if let Ok(var) = std::env::var(ARROW_FLUSH_SIZE_LIMIT_VAR)
-        && let Ok(var) = var.parse::<usize>()
-    {
-        var
-    } else {
-        1024 * 1024 * 1024 * 10
-    }
-});
 
 const ENABLE_MEMORY_STAGING_VAR: &str = "ENABLE_MEMORY_STAGING";
 pub static ENABLE_MEMORY_STAGING: Lazy<bool> = Lazy::new(|| {
@@ -95,7 +72,6 @@ static ONE_PARQUET_PER_ARROW: Lazy<bool> = Lazy::new(|| {
 pub struct Writer {
     pub mem: Option<MemWriter<4096>>,
     pub disk: HashMap<String, DiskWriter>,
-    disk_pending: HashMap<String, PendingDiskBatch>,
 }
 
 impl Default for Writer {
@@ -108,7 +84,6 @@ impl Default for Writer {
         Self {
             mem,
             disk: HashMap::default(),
-            disk_pending: HashMap::default(),
         }
     }
 }
@@ -121,45 +96,22 @@ impl Writer {
         rb: &RecordBatch,
         file_path: PathBuf,
         range: TimeRange,
-        batch_rows: usize,
     ) -> Result<(), StagingError> {
-        let now = Utc::now();
-        let pending = self.disk_pending.entry(filename.clone()).or_default();
-        pending.rows += rb.num_rows();
-        pending.range.get_or_insert(range);
-        pending.first_seen.get_or_insert(now);
-        pending.batches.push(rb.clone());
-
-        let should_flush = pending.rows >= batch_rows.max(1)
-            || pending.is_older_than(now, TimeDelta::seconds(*DISK_WRITE_BATCH_MAX_AGE_SECS));
-        if should_flush {
-            self.flush_pending_disk(&filename, file_path)?;
+        match self.disk.get_mut(&filename) {
+            Some(writer) => writer.write(rb),
+            None => {
+                if let Some(parent) = file_path.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+                let mut writer = DiskWriter::try_new(file_path, rb.schema().as_ref(), range)?;
+                writer.write(rb)?;
+                self.disk.insert(filename, writer);
+                Ok(())
+            }
         }
-
-        Ok(())
     }
 
-    pub fn flush_pending_disk(
-        &mut self,
-        filename: &str,
-        file_path: PathBuf,
-    ) -> Result<(), StagingError> {
-        let Some(pending) = self.disk_pending.remove(filename) else {
-            return Ok(());
-        };
-        if pending.batches.is_empty() {
-            return Ok(());
-        }
-
-        write_pending_disk_batch(&mut self.disk, filename.to_owned(), pending, file_path)?;
-
-        Ok(())
-    }
-
-    pub fn take_flushable_disk(
-        &mut self,
-        forced: bool,
-    ) -> (HashMap<String, DiskWriter>, PendingDiskWrites) {
+    pub fn take_flushable_disk(&mut self, forced: bool) -> HashMap<String, DiskWriter> {
         let mut flushable_disk = HashMap::new();
         let old_disk = std::mem::take(&mut self.disk);
         for (filename, writer) in old_disk {
@@ -170,89 +122,7 @@ impl Writer {
             }
         }
 
-        let mut flushable_pending = HashMap::new();
-        let old_pending = std::mem::take(&mut self.disk_pending);
-        let now = Utc::now();
-        for (filename, pending) in old_pending {
-            if !forced
-                && pending.is_current()
-                && !pending.is_older_than(now, TimeDelta::seconds(*DISK_WRITE_BATCH_MAX_AGE_SECS))
-            {
-                self.disk_pending.insert(filename, pending);
-            } else {
-                flushable_pending.insert(filename, pending);
-            }
-        }
-
-        (flushable_disk, PendingDiskWrites(flushable_pending))
-    }
-}
-
-pub struct PendingDiskWrites(HashMap<String, PendingDiskBatch>);
-
-impl PendingDiskWrites {
-    pub fn flush_into(
-        self,
-        disk: &mut HashMap<String, DiskWriter>,
-        data_path: &std::path::Path,
-    ) -> Result<(), StagingError> {
-        for (filename, pending) in self.0 {
-            write_pending_disk_batch(disk, filename.clone(), pending, data_path.join(filename))?;
-        }
-        Ok(())
-    }
-}
-
-fn write_pending_disk_batch(
-    disk: &mut HashMap<String, DiskWriter>,
-    filename: String,
-    pending: PendingDiskBatch,
-    file_path: PathBuf,
-) -> Result<(), StagingError> {
-    if pending.batches.is_empty() {
-        return Ok(());
-    }
-
-    let schema = pending.batches[0].schema();
-    let batch = concat_batches(&schema, pending.batches.iter())?;
-    let s = match disk.get_mut(&filename) {
-        Some(writer) => writer.write(&batch)?,
-        None => {
-            let range = pending.range.expect("pending disk batch must have range");
-            if let Some(parent) = file_path.parent() {
-                fs::create_dir_all(parent)?;
-            }
-            let mut writer = DiskWriter::try_new(file_path, &schema, range)?;
-            let s = writer.write(&batch)?;
-            disk.insert(filename.clone(), writer);
-            s
-        }
-    };
-    if s >= *ARROW_FLUSH_SIZE_LIMIT {
-        disk.remove(&filename);
-    }
-
-    Ok(())
-}
-
-#[derive(Default)]
-struct PendingDiskBatch {
-    rows: usize,
-    batches: Vec<RecordBatch>,
-    range: Option<TimeRange>,
-    first_seen: Option<chrono::DateTime<Utc>>,
-}
-
-impl PendingDiskBatch {
-    fn is_current(&self) -> bool {
-        self.range
-            .as_ref()
-            .is_some_and(|range| range.contains(Utc::now()))
-    }
-
-    fn is_older_than(&self, now: chrono::DateTime<Utc>, age: TimeDelta) -> bool {
-        self.first_seen
-            .is_some_and(|first_seen| now.signed_duration_since(first_seen) >= age)
+        flushable_disk
     }
 }
 
@@ -260,7 +130,6 @@ pub struct DiskWriter {
     inner: StreamWriter<BufWriter<File>>,
     path: PathBuf,
     range: TimeRange,
-    size: usize,
 }
 
 impl DiskWriter {
@@ -293,14 +162,7 @@ impl DiskWriter {
                 .unwrap(),
         )?;
 
-        let size = 0;
-
-        Ok(Self {
-            inner,
-            path,
-            range,
-            size,
-        })
+        Ok(Self { inner, path, range })
     }
 
     pub fn is_current(&self) -> bool {
@@ -309,14 +171,13 @@ impl DiskWriter {
 
     /// Write a single recordbatch into file
     #[cfg_attr(feature = "hotpath", hotpath::measure)]
-    pub fn write(&mut self, rb: &RecordBatch) -> Result<usize, StagingError> {
-        self.size += rb.size();
+    pub fn write(&mut self, rb: &RecordBatch) -> Result<(), StagingError> {
         self.inner.write(rb).map_err(StagingError::Arrow)?;
         // A process crash does not run Drop, so do not leave the tail of an
         // acknowledged record batch only in BufWriter's userspace buffer.
         // The EOS marker can be recovered, but missing batch bytes cannot.
         self.inner.flush().map_err(StagingError::Arrow)?;
-        Ok(self.size)
+        Ok(())
     }
 }
 
@@ -345,11 +206,7 @@ impl Drop for DiskWriter {
         if let Err(err) = std::fs::rename(&self.path, &arrow_path) {
             error!("Couldn't rename file {:?}, error = {err}", self.path);
         }
-        tracing::info!(
-            "flushing {:?} due to drop with size {}\n",
-            self.path,
-            self.size
-        );
+        tracing::info!("flushing {:?} due to drop", self.path);
     }
 }
 
@@ -468,7 +325,7 @@ mod tests {
 
     use crate::{OBJECT_STORE_DATA_GRANULARITY, utils::time::TimeRange};
 
-    use super::DiskWriter;
+    use super::{DiskWriter, Writer};
 
     #[test]
     fn disk_writer_flushes_each_complete_batch_before_drop() {
@@ -492,5 +349,36 @@ mod tests {
         let mut reader = StreamReader::try_new(file, None).unwrap();
         let persisted = reader.next().unwrap().unwrap();
         assert_eq!(persisted.num_rows(), 3);
+    }
+
+    #[test]
+    fn writer_appends_batches_directly_to_one_schema_minute_file() {
+        let dir = TempDir::new().unwrap();
+        let filename = "schema.date=2026-09-08.hour=11.minute=27.test.data.arrows";
+        let path = dir.path().join(filename);
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(vec![1, 2, 3]))]).unwrap();
+        let range = TimeRange::granularity_range(Utc::now(), OBJECT_STORE_DATA_GRANULARITY);
+        let mut writer = Writer::default();
+
+        writer
+            .push_disk(filename.to_owned(), &batch, path.clone(), range.clone())
+            .unwrap();
+        writer
+            .push_disk(filename.to_owned(), &batch, path, range)
+            .unwrap();
+        assert_eq!(writer.disk.len(), 1);
+
+        drop(writer.take_flushable_disk(true));
+        let arrow_path = std::fs::read_dir(dir.path())
+            .unwrap()
+            .flatten()
+            .map(|entry| entry.path())
+            .find(|path| path.extension().is_some_and(|ext| ext == "arrows"))
+            .unwrap();
+        let reader = StreamReader::try_new(File::open(arrow_path).unwrap(), None).unwrap();
+        let rows: usize = reader.map(|batch| batch.unwrap().num_rows()).sum();
+        assert_eq!(rows, 6);
     }
 }

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -42,6 +42,7 @@ use std::{
     collections::VecDeque,
     collections::{HashMap, HashSet},
     fs::{self, File, OpenOptions, remove_file, write},
+    io::Read,
     num::NonZeroU32,
     path::{Path, PathBuf},
     sync::{Arc, Mutex, RwLock},
@@ -70,7 +71,8 @@ use crate::{
 };
 
 use super::{
-    ARROW_FILE_EXTENSION, LogStream, PART_FILE_EXTENSION,
+    ARROW_FILE_EXTENSION, ARROW_PART_FILE_SUFFIX, LogStream, PARQUET_PART_FILE_SUFFIX,
+    PART_FILE_EXTENSION,
     staging::{
         StagingError,
         reader::{MergedReverseRecordReader, get_reverse_reader},
@@ -953,7 +955,8 @@ impl Stream {
 
                     let schema = Arc::new(merged_schema.clone());
 
-                    let part_path = parquet_path.with_extension("part");
+                    let mut part_path = parquet_path.clone();
+                    part_path.add_extension(PART_FILE_EXTENSION);
 
                     let write_result = self.write_parquet_part_file(
                         &part_path,
@@ -1507,10 +1510,27 @@ impl Stream {
         None
     }
 
-    /// Recovers orphaned .part files from a previous interrupted run.
-    /// These are incomplete arrow files that weren't finalized before the server crashed.
-    /// Valid .part files are renamed to .arrows for processing; invalid ones
-    /// are logged and removed.
+    /// Returns whether a temporary file contains Parquet output.
+    ///
+    /// The magic-byte fallback recognizes legacy bare `.part` files created
+    /// before Arrow and Parquet temporary suffixes were separated.
+    fn is_parquet_part_file(path: &Path) -> bool {
+        let file_name = path.file_name().and_then(|name| name.to_str());
+        if file_name.is_some_and(|name| name.ends_with(PARQUET_PART_FILE_SUFFIX)) {
+            return true;
+        }
+        if file_name.is_some_and(|name| name.ends_with(ARROW_PART_FILE_SUFFIX)) {
+            return false;
+        }
+
+        let mut magic = [0_u8; 4];
+        File::open(path)
+            .and_then(|mut file| file.read_exact(&mut magic))
+            .is_ok()
+            && magic == *b"PAR1"
+    }
+
+    /// Recovers orphaned Arrow parts and removes rebuildable Parquet parts.
     fn recover_orphan_part_files(&self) {
         let Ok(dir) = self.data_path.read_dir() else {
             return;
@@ -1540,6 +1560,22 @@ impl Stream {
                         continue;
                     }
                     Ok(meta) => {
+                        if Self::is_parquet_part_file(&path) {
+                            warn!(
+                                "Removing orphaned temporary Parquet file {:?} for stream {}, size_bytes={}; source Arrow files will be retried",
+                                path,
+                                self.stream_name,
+                                meta.len()
+                            );
+                            if let Err(delete_err) = remove_file(&path) {
+                                error!(
+                                    "Failed to remove orphaned temporary Parquet file {:?}: {delete_err}",
+                                    path
+                                );
+                            }
+                            continue;
+                        }
+
                         // Validate complete record batches, not only the schema.
                         // A crash can leave a valid schema followed by a
                         // truncated record-batch body.
@@ -1582,8 +1618,16 @@ impl Stream {
                                     }
                                 } else {
                                     // File has at least one fully readable batch.
-                                    let mut arrow_path = path.clone();
-                                    arrow_path.set_extension(ARROW_FILE_EXTENSION);
+                                    let mut arrow_path = if path
+                                        .file_name()
+                                        .and_then(|name| name.to_str())
+                                        .is_some_and(|name| name.ends_with(ARROW_PART_FILE_SUFFIX))
+                                    {
+                                        path.with_extension("")
+                                    } else {
+                                        // Legacy Arrow files used a bare `.part` suffix.
+                                        path.with_extension(ARROW_FILE_EXTENSION)
+                                    };
 
                                     // If arrow file with same name exists, generate a unique name
                                     if arrow_path.exists() {
@@ -2292,7 +2336,8 @@ mod tests {
             .unwrap()
             .set_len(len - 8)
             .unwrap();
-        let part_path = arrow_path.with_extension(PART_FILE_EXTENSION);
+        let mut part_path = arrow_path.clone();
+        part_path.add_extension(PART_FILE_EXTENSION);
         std::fs::rename(&arrow_path, &part_path).unwrap();
 
         staging.recover_orphan_part_files();
@@ -2321,12 +2366,27 @@ mod tests {
             &None,
         );
         fs::create_dir_all(&staging.data_path).unwrap();
-        let part_path = staging.data_path.join("orphan.part");
+        let part_path = staging.data_path.join("orphan.arrows.part");
         fs::write(&part_path, b"not an Arrow stream").unwrap();
 
         staging.recover_orphan_part_files();
 
         assert!(!part_path.exists());
+    }
+
+    #[test]
+    fn arrow_and_parquet_part_files_are_distinguished() {
+        let temp_dir = TempDir::new().unwrap();
+        let arrow_part = temp_dir.path().join("schema.data.arrows.part");
+        let parquet_part = temp_dir.path().join("date=2026-09-09.data.parquet.part");
+        let legacy_parquet_part = temp_dir.path().join("date=2026-09-09.data.part");
+        fs::write(&arrow_part, b"PAR1").unwrap();
+        fs::write(&parquet_part, b"not finalized").unwrap();
+        fs::write(&legacy_parquet_part, b"PAR1").unwrap();
+
+        assert!(!Stream::is_parquet_part_file(&arrow_part));
+        assert!(Stream::is_parquet_part_file(&parquet_part));
+        assert!(Stream::is_parquet_part_file(&legacy_parquet_part));
     }
 
     #[tokio::test]

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -80,17 +80,6 @@ use super::{
 
 static HOSTNAME: OnceCell<String> = OnceCell::new();
 
-const DISK_WRITE_BATCH_ROWS_VAR: &str = "DISK_WRITE_BATCH_ROWS";
-static DISK_WRITE_BATCH_ROWS: Lazy<usize> = Lazy::new(|| {
-    if let Ok(var) = std::env::var(DISK_WRITE_BATCH_ROWS_VAR)
-        && let Ok(var) = var.parse::<usize>()
-    {
-        var
-    } else {
-        1
-    }
-});
-
 const INPROCESS_DIR_PREFIX: &str = "processing_";
 const METRIC_NAME_BLOOM_FILTER_NDV: u64 = 32768;
 const METRIC_ROW_GROUP_PREP_IN_FLIGHT_VAR: &str = "METRIC_ROW_GROUP_PREP_IN_FLIGHT";
@@ -280,7 +269,7 @@ impl Stream {
             );
             let file_path = self.data_path.join(&filename);
 
-            guard.push_disk(filename, record, file_path, range, *DISK_WRITE_BATCH_ROWS)?;
+            guard.push_disk(filename, record, file_path, range)?;
         }
 
         if let Some(mem) = guard.mem.as_mut() {
@@ -686,7 +675,7 @@ impl Stream {
         // Swap out stale writers under the lock, drop them after releasing it.
         // DiskWriter::Drop does I/O (IPC finish + file rename) so dropping
         // outside the lock avoids blocking concurrent push() calls.
-        let (mut stale_writers, pending_writes) = {
+        let stale_writers = {
             let mut writer = self.writer.lock().map_err(|poisoned| {
                 StagingError::PoisonError(PoisonError::new(format!(
                     "Writer lock poisoned while flushing data for stream {} - {}",
@@ -699,7 +688,6 @@ impl Stream {
             }
             writer.take_flushable_disk(forced)
         };
-        pending_writes.flush_into(&mut stale_writers, &self.data_path)?;
         // DiskWriter::Drop I/O happens here, outside the lock
         drop(stale_writers);
         Ok(())

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -45,7 +45,7 @@ use std::{
     num::NonZeroU32,
     path::{Path, PathBuf},
     sync::{Arc, Mutex, RwLock},
-    time::{Instant, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 use tokio::task::JoinSet;
 use tracing::{error, info, info_span, instrument, trace, warn};
@@ -81,6 +81,9 @@ use super::{
 static HOSTNAME: OnceCell<String> = OnceCell::new();
 
 const INPROCESS_DIR_PREFIX: &str = "processing_";
+const QUARANTINE_DIR: &str = "quarantine";
+const QUARANTINE_RETENTION: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+const MAX_QUARANTINE_FILES_PER_STREAM: usize = 1024;
 const METRIC_NAME_BLOOM_FILTER_NDV: u64 = 32768;
 const METRIC_ROW_GROUP_PREP_IN_FLIGHT_VAR: &str = "METRIC_ROW_GROUP_PREP_IN_FLIGHT";
 /// Caps how many arrow files feed a single parquet conversion group. A
@@ -933,6 +936,7 @@ impl Stream {
             self.arrow_files_grouped_exclude_time(now, group_minute, init_signal, shutdown_signal);
         span.record("file_group_count", staging_files.len());
         if staging_files.is_empty() {
+            self.cleanup_quarantine_files();
             self.reset_staging_metrics(tenant_id);
             return Ok(None);
         }
@@ -942,7 +946,7 @@ impl Stream {
         let _schemas: Vec<Result<Option<Schema>, StagingError>> = staging_files.into_par_iter().map(
             |(parquet_path, arrow_files)| -> Result<Option<Schema>, StagingError> {
                 let record_reader = MergedReverseRecordReader::try_new(&arrow_files);
-                self.quarantine_invalid_arrow_files(&record_reader.invalid_files);
+                self.quarantine_invalid_arrow_files(&record_reader.invalid_files, tenant_id);
                 let readable_arrow_files = record_reader.readable_files.clone();
                 if record_reader.readers.is_empty() {
                     Ok(None)
@@ -955,28 +959,58 @@ impl Stream {
 
                     let part_path = parquet_path.with_extension("part");
 
-                    if !self.write_parquet_part_file(
+                    let write_result = self.write_parquet_part_file(
                         &part_path,
                         record_reader,
                         &schema,
                         &props,
                         time_partition,
-                    )? {
-                        return Ok(None)
+                    );
+                    match write_result {
+                        Ok(true) => {}
+                        Ok(false) => {
+                            Self::remove_partial_parquet_file(&part_path);
+                            return Ok(None);
+                        }
+                        Err(err) => {
+                            Self::remove_partial_parquet_file(&part_path);
+                            if matches!(&err, StagingError::Arrow(_)) {
+                                error!(
+                                    "Arrow decode failed while building {}: {err}",
+                                    parquet_path.display()
+                                );
+                                let invalid_files = Self::invalid_arrow_files(
+                                    &readable_arrow_files,
+                                );
+                                if invalid_files.is_empty() {
+                                    warn!(
+                                        "Arrow decode failure could not be attributed to a source file; retaining group for retry"
+                                    );
+                                } else {
+                                    self.quarantine_invalid_arrow_files(&invalid_files, tenant_id);
+                                }
+                                return Ok(None);
+                            }
+                            return Err(err);
+                        }
                     }
 
                     if let Err(e) = std::fs::rename(&part_path, &parquet_path) {
-                    error!(
-                        "Couldn't rename part file: {part_path:?} -> {parquet_path:?}, error = {e}"
-                    );
-                } else {
+                        error!(
+                            "Couldn't rename part file: {part_path:?} -> {parquet_path:?}, error = {e}"
+                        );
+                        Self::remove_partial_parquet_file(&part_path);
+                        return Err(e.into());
+                    }
+
                     self.cleanup_arrow_files_and_dir(&readable_arrow_files, tenant_id);
-                }
-                Ok(Some(merged_schema))
+                    Ok(Some(merged_schema))
                 }
             },
         )
         .collect();
+
+        self.cleanup_quarantine_files();
 
         for res in _schemas {
             {
@@ -994,6 +1028,7 @@ impl Stream {
     }
 
     #[cfg_attr(feature = "hotpath", hotpath::measure)]
+    /// Writes one conversion group to a temporary Parquet file.
     fn write_parquet_part_file(
         &self,
         part_path: &Path,
@@ -1009,7 +1044,8 @@ impl Stream {
         .entered();
         let mut part_file = OpenOptions::new()
             .create(true)
-            .append(true)
+            .write(true)
+            .truncate(true)
             .open(part_path)
             .map_err(|_| StagingError::Create)?;
         let mut writer = ArrowWriter::try_new(&mut part_file, schema.clone(), Some(props.clone()))?;
@@ -1088,16 +1124,44 @@ impl Stream {
             writer.close()?;
         }
 
+        drop(part_file);
+
         if !Self::is_valid_parquet_file(part_path, &self.stream_name) {
             error!(
                 "Invalid parquet file {part_path:?} detected for stream {stream_name}, removing it",
                 stream_name = &self.stream_name
             );
-            remove_file(part_path).expect("File should be removable if it is invalid");
+            Self::remove_partial_parquet_file(part_path);
             return Ok(false);
         }
         trace!("Parquet file successfully constructed");
         Ok(true)
+    }
+
+    /// Removes a temporary Parquet output left by a failed conversion.
+    fn remove_partial_parquet_file(part_path: &Path) {
+        match remove_file(part_path) {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => warn!(
+                "Failed to remove partial parquet file {}: {err}",
+                part_path.display()
+            ),
+        }
+    }
+
+    /// Returns files whose Arrow bodies cannot be decoded completely.
+    fn invalid_arrow_files(arrow_files: &[PathBuf]) -> Vec<PathBuf> {
+        arrow_files
+            .iter()
+            .filter_map(|path| {
+                let invalid = match File::open(path).and_then(get_reverse_reader) {
+                    Ok(mut reader) => reader.any(|batch| batch.is_err()),
+                    Err(_) => true,
+                };
+                invalid.then(|| path.clone())
+            })
+            .collect()
     }
 
     /// function to validate parquet files
@@ -1201,12 +1265,12 @@ impl Stream {
     /// Remove invalid Arrow files from the conversion queue without deleting
     /// them. This prevents an unrecoverable crash artifact from being retried
     /// on every startup while retaining it for inspection.
-    fn quarantine_invalid_arrow_files(&self, arrow_files: &[PathBuf]) {
+    fn quarantine_invalid_arrow_files(&self, arrow_files: &[PathBuf], tenant_id: &Option<String>) {
         if arrow_files.is_empty() {
             return;
         }
 
-        let quarantine_dir = self.data_path.join("quarantine");
+        let quarantine_dir = self.data_path.join(QUARANTINE_DIR);
         if let Err(err) = fs::create_dir_all(&quarantine_dir) {
             error!(
                 "Failed to create Arrow quarantine directory {}: {err}",
@@ -1230,11 +1294,19 @@ impl Stream {
                 quarantine_dir.join(format!("{}.{}", Ulid::new(), file_name.to_string_lossy()));
 
             match fs::rename(file, &target) {
-                Ok(()) => error!(
-                    "Quarantined invalid Arrow file {} as {}",
-                    file.display(),
-                    target.display()
-                ),
+                Ok(()) => {
+                    error!(
+                        "Quarantined invalid Arrow file {} as {}",
+                        file.display(),
+                        target.display()
+                    );
+                    metrics::STAGING_QUARANTINED_FILES
+                        .with_label_values(&[
+                            &self.stream_name,
+                            tenant_id.as_deref().unwrap_or(DEFAULT_TENANT),
+                        ])
+                        .inc();
+                }
                 Err(err) => error!(
                     "Failed to quarantine invalid Arrow file {}: {err}",
                     file.display()
@@ -1255,6 +1327,54 @@ impl Stream {
                 warn!(
                     "Failed to remove empty inprocess directory {}: {err}",
                     parent.display()
+                );
+            }
+        }
+    }
+
+    /// Bounds retained quarantine evidence by age and file count.
+    fn cleanup_quarantine_files(&self) {
+        let quarantine_dir = self.data_path.join(QUARANTINE_DIR);
+        let Ok(entries) = fs::read_dir(&quarantine_dir) else {
+            return;
+        };
+
+        let now = SystemTime::now();
+        let mut retained = Vec::new();
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(metadata) = entry.metadata() else {
+                continue;
+            };
+            if !metadata.is_file() {
+                continue;
+            }
+
+            let modified = metadata.modified().unwrap_or(now);
+            if now
+                .duration_since(modified)
+                .is_ok_and(|age| age > QUARANTINE_RETENTION)
+            {
+                if let Err(err) = remove_file(&path) {
+                    warn!(
+                        "Failed to remove expired quarantine file {}: {err}",
+                        path.display()
+                    );
+                }
+            } else {
+                retained.push((modified, path));
+            }
+        }
+
+        retained.sort_unstable_by_key(|(modified, _)| *modified);
+        let remove_count = retained
+            .len()
+            .saturating_sub(MAX_QUARANTINE_FILES_PER_STREAM);
+        for (_, path) in retained.into_iter().take(remove_count) {
+            if let Err(err) = remove_file(&path) {
+                warn!(
+                    "Failed to enforce quarantine file limit for {}: {err}",
+                    path.display()
                 );
             }
         }
@@ -1493,8 +1613,9 @@ impl Stream {
 
     /// Recovers orphaned .part files from a previous interrupted run.
     /// These are incomplete arrow files that weren't finalized before the server crashed.
-    /// Valid .part files are renamed to .arrows for processing, invalid ones are removed.
-    fn recover_orphan_part_files(&self) {
+    /// Valid .part files are renamed to .arrows for processing; invalid ones
+    /// are quarantined for inspection.
+    fn recover_orphan_part_files(&self, tenant_id: &Option<String>) {
         let Ok(dir) = self.data_path.read_dir() else {
             return;
         };
@@ -1551,17 +1672,14 @@ impl Stream {
                                 });
 
                                 if let Err(e) = validation {
-                                    // File is invalid/corrupted, remove it
                                     warn!(
-                                        "Removing invalid/corrupted .part file: {:?} for stream {}: {e}",
+                                        "Quarantining invalid/corrupted .part file: {:?} for stream {}: {e}",
                                         path, self.stream_name
                                     );
-                                    if let Err(e) = remove_file(&path) {
-                                        error!(
-                                            "Failed to remove invalid .part file {:?}: {e}",
-                                            path
-                                        );
-                                    }
+                                    self.quarantine_invalid_arrow_files(
+                                        std::slice::from_ref(&path),
+                                        tenant_id,
+                                    );
                                 } else {
                                     // File has at least one fully readable batch.
                                     let mut arrow_path = path.clone();
@@ -1623,7 +1741,7 @@ impl Stream {
     ) -> Result<(), StagingError> {
         // On init, recover any orphaned .part files from previous interrupted runs
         if init_signal {
-            self.recover_orphan_part_files();
+            self.recover_orphan_part_files(tenant_id);
         }
 
         let start_flush = Instant::now();
@@ -2041,6 +2159,33 @@ mod tests {
         staging.flush(true).unwrap();
     }
 
+    fn write_compressible_log(staging: &StreamRef, schema: &Schema, mins: i64) {
+        let time: NaiveDateTime = Utc::now()
+            .checked_sub_signed(TimeDelta::minutes(mins))
+            .unwrap()
+            .naive_utc();
+        let rows = 4096;
+        let batch = RecordBatch::try_new(
+            Arc::new(schema.clone()),
+            vec![
+                Arc::new(TimestampMillisecondArray::from_iter_values(0..rows as i64)),
+                Arc::new(Int32Array::from_iter_values(0..rows as i32)),
+                Arc::new(StringArray::from(vec!["compressible-value"; rows])),
+            ],
+        )
+        .unwrap();
+        staging
+            .push(
+                "corrupt",
+                &batch,
+                time,
+                &HashMap::new(),
+                StreamType::UserDefined,
+            )
+            .unwrap();
+        staging.flush(true).unwrap();
+    }
+
     #[test]
     fn different_minutes_multiple_arrow_files_to_parquet() {
         let temp_dir = TempDir::new().unwrap();
@@ -2155,6 +2300,68 @@ mod tests {
     }
 
     #[test]
+    fn corrupt_arrow_body_is_quarantined_without_blocking_other_groups() {
+        let temp_dir = TempDir::new().unwrap();
+        let stream_name = "test_stream";
+        let options = Arc::new(Options {
+            local_staging_path: temp_dir.path().to_path_buf(),
+            row_group_size: 1048576,
+            ..Default::default()
+        });
+        let staging = Stream::new(
+            options,
+            stream_name,
+            LogStreamMetadata::default(),
+            None,
+            &None,
+        );
+        let schema = Schema::new(vec![
+            Field::new(
+                DEFAULT_TIMESTAMP_KEY,
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
+            Field::new("id", DataType::Int32, false),
+            Field::new("value", DataType::Utf8, false),
+        ]);
+
+        write_compressible_log(&staging, &schema, 2);
+        let corrupt_path = staging.arrow_files().pop().unwrap();
+        let mut bytes = fs::read(&corrupt_path).unwrap();
+        let lz4_magic = [0x04, 0x22, 0x4d, 0x18];
+        let magic_offset = bytes
+            .windows(lz4_magic.len())
+            .position(|window| window == lz4_magic)
+            .expect("compressed Arrow body");
+        bytes[magic_offset] ^= 0xff;
+        fs::write(&corrupt_path, bytes).unwrap();
+
+        // A second minute forms an independent conversion group that must
+        // still finish even though the first group contains a corrupt body.
+        write_log(&staging, &schema, 1);
+        let result = staging
+            .convert_disk_files_to_parquet(None, None, false, true, &None)
+            .unwrap();
+
+        assert!(result.is_some());
+        assert_eq!(staging.parquet_files().len(), 1);
+        assert!(staging.inprocess_arrow_files().is_empty());
+        assert_eq!(
+            fs::read_dir(staging.data_path.join(QUARANTINE_DIR))
+                .unwrap()
+                .count(),
+            1
+        );
+        assert!(fs::read_dir(&staging.data_path).unwrap().all(|entry| {
+            entry
+                .unwrap()
+                .path()
+                .extension()
+                .is_none_or(|extension| extension != PART_FILE_EXTENSION)
+        }));
+    }
+
+    #[test]
     fn orphan_arrow_part_with_complete_batch_becomes_valid_parquet() {
         let temp_dir = TempDir::new().unwrap();
         let stream_name = "test_stream";
@@ -2194,7 +2401,7 @@ mod tests {
         let part_path = arrow_path.with_extension(PART_FILE_EXTENSION);
         std::fs::rename(&arrow_path, &part_path).unwrap();
 
-        staging.recover_orphan_part_files();
+        staging.recover_orphan_part_files(&None);
         assert_eq!(staging.arrow_files().len(), 1);
 
         let schema = staging
@@ -2203,6 +2410,35 @@ mod tests {
         assert!(schema.is_some());
         assert_eq!(staging.parquet_files().len(), 1);
         assert!(staging.arrow_files().is_empty());
+    }
+
+    #[test]
+    fn corrupt_orphan_part_is_quarantined() {
+        let temp_dir = TempDir::new().unwrap();
+        let options = Arc::new(Options {
+            local_staging_path: temp_dir.path().to_path_buf(),
+            ..Default::default()
+        });
+        let staging = Stream::new(
+            options,
+            "test_stream",
+            LogStreamMetadata::default(),
+            None,
+            &None,
+        );
+        fs::create_dir_all(&staging.data_path).unwrap();
+        let part_path = staging.data_path.join("orphan.part");
+        fs::write(&part_path, b"not an Arrow stream").unwrap();
+
+        staging.recover_orphan_part_files(&None);
+
+        assert!(!part_path.exists());
+        assert_eq!(
+            fs::read_dir(staging.data_path.join(QUARANTINE_DIR))
+                .unwrap()
+                .count(),
+            1
+        );
     }
 
     #[tokio::test]

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -45,7 +45,7 @@ use std::{
     num::NonZeroU32,
     path::{Path, PathBuf},
     sync::{Arc, Mutex, RwLock},
-    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+    time::{Instant, SystemTime, UNIX_EPOCH},
 };
 use tokio::task::JoinSet;
 use tracing::{error, info, info_span, instrument, trace, warn};
@@ -81,9 +81,6 @@ use super::{
 static HOSTNAME: OnceCell<String> = OnceCell::new();
 
 const INPROCESS_DIR_PREFIX: &str = "processing_";
-const QUARANTINE_DIR: &str = "quarantine";
-const QUARANTINE_RETENTION: Duration = Duration::from_secs(7 * 24 * 60 * 60);
-const MAX_QUARANTINE_FILES_PER_STREAM: usize = 1024;
 const METRIC_NAME_BLOOM_FILTER_NDV: u64 = 32768;
 const METRIC_ROW_GROUP_PREP_IN_FLIGHT_VAR: &str = "METRIC_ROW_GROUP_PREP_IN_FLIGHT";
 /// Caps how many arrow files feed a single parquet conversion group. A
@@ -936,7 +933,6 @@ impl Stream {
             self.arrow_files_grouped_exclude_time(now, group_minute, init_signal, shutdown_signal);
         span.record("file_group_count", staging_files.len());
         if staging_files.is_empty() {
-            self.cleanup_quarantine_files();
             self.reset_staging_metrics(tenant_id);
             return Ok(None);
         }
@@ -946,7 +942,7 @@ impl Stream {
         let _schemas: Vec<Result<Option<Schema>, StagingError>> = staging_files.into_par_iter().map(
             |(parquet_path, arrow_files)| -> Result<Option<Schema>, StagingError> {
                 let record_reader = MergedReverseRecordReader::try_new(&arrow_files);
-                self.quarantine_invalid_arrow_files(&record_reader.invalid_files, tenant_id);
+                self.remove_invalid_arrow_files(&record_reader.invalid_files, tenant_id);
                 let readable_arrow_files = record_reader.readable_files.clone();
                 if record_reader.readers.is_empty() {
                     Ok(None)
@@ -987,7 +983,7 @@ impl Stream {
                                         "Arrow decode failure could not be attributed to a source file; retaining group for retry"
                                     );
                                 } else {
-                                    self.quarantine_invalid_arrow_files(&invalid_files, tenant_id);
+                                    self.remove_invalid_arrow_files(&invalid_files, tenant_id);
                                 }
                                 return Ok(None);
                             }
@@ -1009,8 +1005,6 @@ impl Stream {
             },
         )
         .collect();
-
-        self.cleanup_quarantine_files();
 
         for res in _schemas {
             {
@@ -1262,122 +1256,16 @@ impl Stream {
         }
     }
 
-    /// Remove invalid Arrow files from the conversion queue without deleting
-    /// them. This prevents an unrecoverable crash artifact from being retried
-    /// on every startup while retaining it for inspection.
-    fn quarantine_invalid_arrow_files(&self, arrow_files: &[PathBuf], tenant_id: &Option<String>) {
-        if arrow_files.is_empty() {
-            return;
-        }
-
-        let quarantine_dir = self.data_path.join(QUARANTINE_DIR);
-        if let Err(err) = fs::create_dir_all(&quarantine_dir) {
-            error!(
-                "Failed to create Arrow quarantine directory {}: {err}",
-                quarantine_dir.display()
-            );
-            return;
-        }
-
-        let mut parent_dirs = HashSet::new();
+    /// Logs and deletes invalid Arrow files so they cannot poison later retries.
+    fn remove_invalid_arrow_files(&self, arrow_files: &[PathBuf], tenant_id: &Option<String>) {
         for file in arrow_files {
-            let Some(file_name) = file.file_name() else {
-                continue;
-            };
-            if let Some(parent) = file.parent() {
-                parent_dirs.insert(parent.to_owned());
-            }
-
-            // Always use a unique target. The same filename can be present in
-            // multiple processing directories after an interrupted move.
-            let target =
-                quarantine_dir.join(format!("{}.{}", Ulid::new(), file_name.to_string_lossy()));
-
-            match fs::rename(file, &target) {
-                Ok(()) => {
-                    error!(
-                        "Quarantined invalid Arrow file {} as {}",
-                        file.display(),
-                        target.display()
-                    );
-                    metrics::STAGING_QUARANTINED_FILES
-                        .with_label_values(&[
-                            &self.stream_name,
-                            tenant_id.as_deref().unwrap_or(DEFAULT_TENANT),
-                        ])
-                        .inc();
-                }
-                Err(err) => error!(
-                    "Failed to quarantine invalid Arrow file {}: {err}",
-                    file.display()
-                ),
-            }
+            warn!(
+                "Removing invalid/corrupted Arrow file {} for stream {}",
+                file.display(),
+                self.stream_name
+            );
         }
-
-        for parent in parent_dirs {
-            if parent
-                .file_name()
-                .and_then(|name| name.to_str())
-                .is_some_and(|name| name.starts_with(INPROCESS_DIR_PREFIX))
-                && fs::read_dir(&parent)
-                    .ok()
-                    .is_some_and(|mut entries| entries.next().is_none())
-                && let Err(err) = fs::remove_dir(&parent)
-            {
-                warn!(
-                    "Failed to remove empty inprocess directory {}: {err}",
-                    parent.display()
-                );
-            }
-        }
-    }
-
-    /// Bounds retained quarantine evidence by age and file count.
-    fn cleanup_quarantine_files(&self) {
-        let quarantine_dir = self.data_path.join(QUARANTINE_DIR);
-        let Ok(entries) = fs::read_dir(&quarantine_dir) else {
-            return;
-        };
-
-        let now = SystemTime::now();
-        let mut retained = Vec::new();
-        for entry in entries.flatten() {
-            let path = entry.path();
-            let Ok(metadata) = entry.metadata() else {
-                continue;
-            };
-            if !metadata.is_file() {
-                continue;
-            }
-
-            let modified = metadata.modified().unwrap_or(now);
-            if now
-                .duration_since(modified)
-                .is_ok_and(|age| age > QUARANTINE_RETENTION)
-            {
-                if let Err(err) = remove_file(&path) {
-                    warn!(
-                        "Failed to remove expired quarantine file {}: {err}",
-                        path.display()
-                    );
-                }
-            } else {
-                retained.push((modified, path));
-            }
-        }
-
-        retained.sort_unstable_by_key(|(modified, _)| *modified);
-        let remove_count = retained
-            .len()
-            .saturating_sub(MAX_QUARANTINE_FILES_PER_STREAM);
-        for (_, path) in retained.into_iter().take(remove_count) {
-            if let Err(err) = remove_file(&path) {
-                warn!(
-                    "Failed to enforce quarantine file limit for {}: {err}",
-                    path.display()
-                );
-            }
-        }
+        self.cleanup_arrow_files_and_dir(arrow_files, tenant_id);
     }
 
     pub fn updated_schema(&self, current_schema: Schema) -> Schema {
@@ -1614,8 +1502,8 @@ impl Stream {
     /// Recovers orphaned .part files from a previous interrupted run.
     /// These are incomplete arrow files that weren't finalized before the server crashed.
     /// Valid .part files are renamed to .arrows for processing; invalid ones
-    /// are quarantined for inspection.
-    fn recover_orphan_part_files(&self, tenant_id: &Option<String>) {
+    /// are logged and removed.
+    fn recover_orphan_part_files(&self) {
         let Ok(dir) = self.data_path.read_dir() else {
             return;
         };
@@ -1673,13 +1561,15 @@ impl Stream {
 
                                 if let Err(e) = validation {
                                     warn!(
-                                        "Quarantining invalid/corrupted .part file: {:?} for stream {}: {e}",
+                                        "Removing invalid/corrupted .part file: {:?} for stream {}: {e}",
                                         path, self.stream_name
                                     );
-                                    self.quarantine_invalid_arrow_files(
-                                        std::slice::from_ref(&path),
-                                        tenant_id,
-                                    );
+                                    if let Err(delete_err) = remove_file(&path) {
+                                        error!(
+                                            "Failed to remove invalid/corrupted .part file {:?}: {delete_err}",
+                                            path
+                                        );
+                                    }
                                 } else {
                                     // File has at least one fully readable batch.
                                     let mut arrow_path = path.clone();
@@ -1741,7 +1631,7 @@ impl Stream {
     ) -> Result<(), StagingError> {
         // On init, recover any orphaned .part files from previous interrupted runs
         if init_signal {
-            self.recover_orphan_part_files(tenant_id);
+            self.recover_orphan_part_files();
         }
 
         let start_flush = Instant::now();
@@ -2300,7 +2190,7 @@ mod tests {
     }
 
     #[test]
-    fn corrupt_arrow_body_is_quarantined_without_blocking_other_groups() {
+    fn corrupt_arrow_body_is_removed_without_blocking_other_groups() {
         let temp_dir = TempDir::new().unwrap();
         let stream_name = "test_stream";
         let options = Arc::new(Options {
@@ -2346,12 +2236,6 @@ mod tests {
         assert!(result.is_some());
         assert_eq!(staging.parquet_files().len(), 1);
         assert!(staging.inprocess_arrow_files().is_empty());
-        assert_eq!(
-            fs::read_dir(staging.data_path.join(QUARANTINE_DIR))
-                .unwrap()
-                .count(),
-            1
-        );
         assert!(fs::read_dir(&staging.data_path).unwrap().all(|entry| {
             entry
                 .unwrap()
@@ -2401,7 +2285,7 @@ mod tests {
         let part_path = arrow_path.with_extension(PART_FILE_EXTENSION);
         std::fs::rename(&arrow_path, &part_path).unwrap();
 
-        staging.recover_orphan_part_files(&None);
+        staging.recover_orphan_part_files();
         assert_eq!(staging.arrow_files().len(), 1);
 
         let schema = staging
@@ -2413,7 +2297,7 @@ mod tests {
     }
 
     #[test]
-    fn corrupt_orphan_part_is_quarantined() {
+    fn corrupt_orphan_part_is_removed() {
         let temp_dir = TempDir::new().unwrap();
         let options = Arc::new(Options {
             local_staging_path: temp_dir.path().to_path_buf(),
@@ -2430,15 +2314,9 @@ mod tests {
         let part_path = staging.data_path.join("orphan.part");
         fs::write(&part_path, b"not an Arrow stream").unwrap();
 
-        staging.recover_orphan_part_files(&None);
+        staging.recover_orphan_part_files();
 
         assert!(!part_path.exists());
-        assert_eq!(
-            fs::read_dir(staging.data_path.join(QUARANTINE_DIR))
-                .unwrap()
-                .count(),
-            1
-        );
     }
 
     #[tokio::test]

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -18,7 +18,6 @@
  */
 
 use arrow_array::{ArrayRef, RecordBatch};
-use arrow_ipc::reader::StreamReader;
 use arrow_schema::{Field, Fields, Schema};
 use chrono::{NaiveDateTime, Timelike, Utc};
 use derive_more::derive::{Deref, DerefMut};
@@ -72,7 +71,11 @@ use crate::{
 
 use super::{
     ARROW_FILE_EXTENSION, LogStream, PART_FILE_EXTENSION,
-    staging::{StagingError, reader::MergedReverseRecordReader, writer::Writer},
+    staging::{
+        StagingError,
+        reader::{MergedReverseRecordReader, get_reverse_reader},
+        writer::Writer,
+    },
 };
 
 static HOSTNAME: OnceCell<String> = OnceCell::new();
@@ -951,6 +954,8 @@ impl Stream {
         let _schemas: Vec<Result<Option<Schema>, StagingError>> = staging_files.into_par_iter().map(
             |(parquet_path, arrow_files)| -> Result<Option<Schema>, StagingError> {
                 let record_reader = MergedReverseRecordReader::try_new(&arrow_files);
+                self.quarantine_invalid_arrow_files(&record_reader.invalid_files);
+                let readable_arrow_files = record_reader.readable_files.clone();
                 if record_reader.readers.is_empty() {
                     Ok(None)
                 } else {
@@ -977,7 +982,7 @@ impl Stream {
                         "Couldn't rename part file: {part_path:?} -> {parquet_path:?}, error = {e}"
                     );
                 } else {
-                    self.cleanup_arrow_files_and_dir(&arrow_files, tenant_id);
+                    self.cleanup_arrow_files_and_dir(&readable_arrow_files, tenant_id);
                 }
                 Ok(Some(merged_schema))
                 }
@@ -1046,6 +1051,7 @@ impl Stream {
                 let Some(record) = merged_iter.next() else {
                     break;
                 };
+                let record = record?;
                 let record_rows = record.num_rows();
                 buffered_rows += record_rows;
                 buffer.push(record);
@@ -1088,8 +1094,8 @@ impl Stream {
             }
             writer.close()?;
         } else {
-            for ref record in record_reader.merged_iter(schema.clone(), time_partition.cloned()) {
-                writer.write(record)?;
+            for record in record_reader.merged_iter(schema.clone(), time_partition.cloned()) {
+                writer.write(&record?)?;
             }
             writer.close()?;
         }
@@ -1200,6 +1206,68 @@ impl Stream {
                         );
                     }
                 }
+            }
+        }
+    }
+
+    /// Remove invalid Arrow files from the conversion queue without deleting
+    /// them. This prevents an unrecoverable crash artifact from being retried
+    /// on every startup while retaining it for inspection.
+    fn quarantine_invalid_arrow_files(&self, arrow_files: &[PathBuf]) {
+        if arrow_files.is_empty() {
+            return;
+        }
+
+        let quarantine_dir = self.data_path.join("quarantine");
+        if let Err(err) = fs::create_dir_all(&quarantine_dir) {
+            error!(
+                "Failed to create Arrow quarantine directory {}: {err}",
+                quarantine_dir.display()
+            );
+            return;
+        }
+
+        let mut parent_dirs = HashSet::new();
+        for file in arrow_files {
+            let Some(file_name) = file.file_name() else {
+                continue;
+            };
+            if let Some(parent) = file.parent() {
+                parent_dirs.insert(parent.to_owned());
+            }
+
+            // Always use a unique target. The same filename can be present in
+            // multiple processing directories after an interrupted move.
+            let target =
+                quarantine_dir.join(format!("{}.{}", Ulid::new(), file_name.to_string_lossy()));
+
+            match fs::rename(file, &target) {
+                Ok(()) => error!(
+                    "Quarantined invalid Arrow file {} as {}",
+                    file.display(),
+                    target.display()
+                ),
+                Err(err) => error!(
+                    "Failed to quarantine invalid Arrow file {}: {err}",
+                    file.display()
+                ),
+            }
+        }
+
+        for parent in parent_dirs {
+            if parent
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with(INPROCESS_DIR_PREFIX))
+                && fs::read_dir(&parent)
+                    .ok()
+                    .is_some_and(|mut entries| entries.next().is_none())
+                && let Err(err) = fs::remove_dir(&parent)
+            {
+                warn!(
+                    "Failed to remove empty inprocess directory {}: {err}",
+                    parent.display()
+                );
             }
         }
     }
@@ -1467,10 +1535,34 @@ impl Stream {
                         continue;
                     }
                     Ok(_) => {
-                        // Try to validate the arrow file by reading its schema
+                        // Validate complete record batches, not only the schema.
+                        // A crash can leave a valid schema followed by a
+                        // truncated record-batch body.
                         match File::open(&path) {
                             Ok(file) => {
-                                if let Err(e) = StreamReader::try_new_buffered(file, None) {
+                                let validation = get_reverse_reader(file).and_then(|mut reader| {
+                                    let mut rows = 0usize;
+                                    for batch in &mut reader {
+                                        let batch = batch.map_err(std::io::Error::other)?;
+                                        rows = rows.checked_add(batch.num_rows()).ok_or_else(
+                                            || {
+                                                std::io::Error::new(
+                                                    std::io::ErrorKind::InvalidData,
+                                                    "Arrow row count overflow",
+                                                )
+                                            },
+                                        )?;
+                                    }
+                                    if rows == 0 {
+                                        return Err(std::io::Error::new(
+                                            std::io::ErrorKind::InvalidData,
+                                            "Arrow stream has no recoverable rows",
+                                        ));
+                                    }
+                                    Ok(rows)
+                                });
+
+                                if let Err(e) = validation {
                                     // File is invalid/corrupted, remove it
                                     warn!(
                                         "Removing invalid/corrupted .part file: {:?} for stream {}: {e}",
@@ -1483,7 +1575,7 @@ impl Stream {
                                         );
                                     }
                                 } else {
-                                    // File has valid schema, rename to .arrows
+                                    // File has at least one fully readable batch.
                                     let mut arrow_path = path.clone();
                                     arrow_path.set_extension(ARROW_FILE_EXTENSION);
 
@@ -2072,6 +2164,57 @@ mod tests {
         // Verify parquet files were created and the arrow files deleted
         assert_eq!(staging.parquet_files().len(), 1);
         assert_eq!(staging.arrow_files().len(), 0);
+    }
+
+    #[test]
+    fn orphan_arrow_part_with_complete_batch_becomes_valid_parquet() {
+        let temp_dir = TempDir::new().unwrap();
+        let stream_name = "test_stream";
+        let options = Arc::new(Options {
+            local_staging_path: temp_dir.path().to_path_buf(),
+            row_group_size: 1048576,
+            ..Default::default()
+        });
+        let staging = Stream::new(
+            options,
+            stream_name,
+            LogStreamMetadata::default(),
+            None,
+            &None,
+        );
+        let schema = Schema::new(vec![
+            Field::new(
+                DEFAULT_TIMESTAMP_KEY,
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
+            Field::new("id", DataType::Int32, false),
+            Field::new("value", DataType::Utf8, false),
+        ]);
+        write_log(&staging, &schema, 1);
+
+        // Simulate a crash after a complete batch was flushed but before Drop
+        // wrote the eight-byte EOS marker and renamed the file.
+        let arrow_path = staging.arrow_files().pop().unwrap();
+        let len = arrow_path.metadata().unwrap().len();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&arrow_path)
+            .unwrap()
+            .set_len(len - 8)
+            .unwrap();
+        let part_path = arrow_path.with_extension(PART_FILE_EXTENSION);
+        std::fs::rename(&arrow_path, &part_path).unwrap();
+
+        staging.recover_orphan_part_files();
+        assert_eq!(staging.arrow_files().len(), 1);
+
+        let schema = staging
+            .convert_disk_files_to_parquet(None, None, false, true, &None)
+            .unwrap();
+        assert!(schema.is_some());
+        assert_eq!(staging.parquet_files().len(), 1);
+        assert!(staging.arrow_files().is_empty());
     }
 
     #[tokio::test]

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -1562,7 +1562,7 @@ impl Stream {
                     Ok(meta) => {
                         if Self::is_parquet_part_file(&path) {
                             warn!(
-                                "Removing orphaned temporary Parquet file {:?} for stream {}, size_bytes={}; source Arrow files will be retried",
+                                "Removing orphaned temporary Parquet file {:?} for stream {}, size_bytes={}. Deleting it is safe because its source .arrows files remain in processing_* and will rebuild the Parquet on restart",
                                 path,
                                 self.stream_name,
                                 meta.len()

--- a/src/parseable/streams.rs
+++ b/src/parseable/streams.rs
@@ -1259,11 +1259,19 @@ impl Stream {
     /// Logs and deletes invalid Arrow files so they cannot poison later retries.
     fn remove_invalid_arrow_files(&self, arrow_files: &[PathBuf], tenant_id: &Option<String>) {
         for file in arrow_files {
-            warn!(
-                "Removing invalid/corrupted Arrow file {} for stream {}",
-                file.display(),
-                self.stream_name
-            );
+            match file.metadata() {
+                Ok(meta) => warn!(
+                    "Removing invalid/corrupted Arrow file {} for stream {}, size_bytes={}",
+                    file.display(),
+                    self.stream_name,
+                    meta.len()
+                ),
+                Err(err) => warn!(
+                    "Removing invalid/corrupted Arrow file {} for stream {}, size unavailable: {err}",
+                    file.display(),
+                    self.stream_name
+                ),
+            }
         }
         self.cleanup_arrow_files_and_dir(arrow_files, tenant_id);
     }
@@ -1531,7 +1539,7 @@ impl Stream {
                         }
                         continue;
                     }
-                    Ok(_) => {
+                    Ok(meta) => {
                         // Validate complete record batches, not only the schema.
                         // A crash can leave a valid schema followed by a
                         // truncated record-batch body.
@@ -1561,8 +1569,10 @@ impl Stream {
 
                                 if let Err(e) = validation {
                                     warn!(
-                                        "Removing invalid/corrupted .part file: {:?} for stream {}: {e}",
-                                        path, self.stream_name
+                                        "Removing invalid/corrupted .part file: {:?} for stream {}, size_bytes={}: {e}",
+                                        path,
+                                        self.stream_name,
+                                        meta.len()
                                     );
                                     if let Err(delete_err) = remove_file(&path) {
                                         error!(


### PR DESCRIPTION
- flush complete Arrow batches before disk writes return
- remove pending row/age batching and size-based Arrow rotation
- preserve complete batches before a truncated tail
- propagate Arrow decoding errors instead of silently dropping them
- quarantine unrecoverable files and clean only converted inputs
- refresh schemas from object storage before query planning
- add staging writer and crash-recovery tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete or corrupted Arrow data, with clearer errors and safer processing of truncated streams.
  * Invalid or undecodable Arrow files are now removed automatically instead of quarantined.
  * Stream initialization now works consistently across all runtime modes.
  * Improved recovery and cleanup of incomplete Arrow and Parquet files.

* **Reliability**
  * Record batches are written directly to disk and flushed immediately, improving persistence before shutdown.
  * Temporary Arrow and Parquet files now use consistent extensions during conversion and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->