### PR TITLE
feat: rejection duration after threshold breach

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -510,6 +510,15 @@ pub struct Options {
 
     #[arg(
         long,
+        env = "P_REJECTION_DURATION",
+        default_value = "30",
+        value_parser = validation::validate_seconds,
+        help = "Post threshold breach, reject requests for"
+    )]
+    pub rejection_duration: u64,
+
+    #[arg(
+        long,
         env = "P_MEMORY_THRESHOLD",
         default_value = "100.0",
         value_parser = validation::validate_percentage,

--- a/src/handlers/http/resource_check.rs
+++ b/src/handlers/http/resource_check.rs
@@ -80,6 +80,9 @@ pub fn spawn_resource_monitor(shutdown_rx: tokio::sync::oneshot::Receiver<()>) {
                         info!("Resource utilization back to normal - requests will be accepted");
                     } else {
                         warn!("Resource utilization too high - requests will be rejected");
+
+                        // sleep for rejection duration (+ the check interval)
+                        tokio::time::sleep(Duration::from_secs(PARSEABLE.options.rejection_duration)).await;
                     }
                 },
                 _ = process_metrics_interval.tick() => {

--- a/src/handlers/http/resource_check.rs
+++ b/src/handlers/http/resource_check.rs
@@ -40,6 +40,27 @@ const PROCESS_METRICS_SAMPLE_INTERVAL: Duration = Duration::from_secs(5);
 
 static SERVER_OK: LazyLock<Arc<AtomicBool>> = LazyLock::new(|| Arc::new(AtomicBool::new(true)));
 
+async fn sample_process_metrics() {
+    refresh_sys_info();
+    let process_metrics = tokio::task::spawn_blocking(|| {
+        let sys = SYS_INFO.lock().unwrap();
+        let total_mem = if let Some(cgroup) = sys.cgroup_limits() {
+            cgroup.total_memory
+        } else {
+            sys.total_memory()
+        };
+        sysinfo::get_current_pid()
+            .ok()
+            .and_then(|pid| sys.process(pid))
+            .map(|process| (process.cpu_usage() as f64, process.memory(), total_mem))
+    })
+    .await
+    .unwrap();
+    if let Some((cpu_usage, memory_bytes, total_mem)) = process_metrics {
+        record_process_metrics_sample(cpu_usage, memory_bytes, total_mem);
+    }
+}
+
 /// Spawn a background task to monitor system resources
 pub fn spawn_resource_monitor(shutdown_rx: tokio::sync::oneshot::Receiver<()>) {
     tokio::spawn(async move {
@@ -82,26 +103,27 @@ pub fn spawn_resource_monitor(shutdown_rx: tokio::sync::oneshot::Receiver<()>) {
                         warn!("Resource utilization too high - requests will be rejected");
 
                         // sleep for rejection duration (+ the check interval)
-                        tokio::time::sleep(Duration::from_secs(PARSEABLE.options.rejection_duration)).await;
+                        let rejection_delay = tokio::time::sleep(Duration::from_secs(
+                            PARSEABLE.options.rejection_duration,
+                        ));
+                        tokio::pin!(rejection_delay);
+
+                        loop {
+                            select! {
+                                _ = &mut rejection_delay => break,
+                                _ = process_metrics_interval.tick() => {
+                                    sample_process_metrics().await;
+                                },
+                                _ = &mut shutdown_rx => {
+                                    trace!("Resource monitor shutting down");
+                                    return;
+                                }
+                            }
+                        }
                     }
                 },
                 _ = process_metrics_interval.tick() => {
-                    refresh_sys_info();
-                    let process_metrics = tokio::task::spawn_blocking(|| {
-                        let sys = SYS_INFO.lock().unwrap();
-                        let total_mem = if let Some(cgroup) = sys.cgroup_limits() {
-                            cgroup.total_memory
-                        } else {
-                            sys.total_memory()
-                        };
-                        sysinfo::get_current_pid()
-                            .ok()
-                            .and_then(|pid| sys.process(pid))
-                            .map(|process| (process.cpu_usage() as f64, process.memory(), total_mem))
-                    }).await.unwrap();
-                    if let Some((cpu_usage, memory_bytes, total_mem)) = process_metrics {
-                        record_process_metrics_sample(cpu_usage, memory_bytes, total_mem);
-                    }
+                    sample_process_metrics().await;
                 },
                 _ = &mut shutdown_rx => {
                     trace!("Resource monitor shutting down");


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable rejection duration for resource checks.
  - Configure the delay using `--rejection-duration` or `P_REJECTION_DURATION`; the default is 30 seconds.

- **Behavior Updates**
  - Resource checks now wait for the configured duration after utilization exceeds the threshold before checking again.
  - Process metrics continue to be sampled during rejection delays.
  - Shutdown handling remains responsive while a rejection delay is in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->